### PR TITLE
LocationPicker 내에 검색 input 다크모드 변경 시 텍스트 색상 흰색에서 검정색으로 수정

### DIFF
--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -182,6 +182,7 @@ export function LocationPicker({
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+                  className="dark:text-itta-black"
                 />
                 <Input.Right>
                   <button onClick={handleSearch} type="button">


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)
- #33 
## 작업 내용 + 스크린샷
LocationPicker 내에 검색 input 다크모드 변경 시 텍스트 색상 흰색에서 검정색으로 수정
## 실제 걸린 시간
3m ..?
## 작업하며 고민했던 점(선택)

## 테스트 실행 여부
- dev 브랜치 잠깐 가져와서 다크모드 적용해봤고 적용되는 거 확인했습니다!
- [x] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
### 검색 페이지
<img width="1609" height="950" alt="image" src="https://github.com/user-attachments/assets/047d1fba-92e2-45a6-be56-22062832578d" />

### 게시글 작성 페이지
<img width="1237" height="951" alt="image" src="https://github.com/user-attachments/assets/dbb9f9c9-e892-4c2c-bb38-00938f4996e7" />
