### PR TITLE
서버 컴포넌트 api 요청시 절대 경로로 추가되도록 수정

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -24,10 +24,6 @@ const nextConfig: NextConfig = {
   async rewrites() {
     return [
       {
-        source: '/api/posts/:path*',
-        destination: `${backendHost}/posts/:path*`,
-      },
-      {
         source: '/api/kopis/:path*',
         destination: 'http://www.kopis.or.kr/openApi/restful/:path*',
       },

--- a/frontend/src/lib/api/api.ts
+++ b/frontend/src/lib/api/api.ts
@@ -1,10 +1,30 @@
 import { ApiResponse } from '../types/response';
 import { getAccessToken, refreshAccessToken, clearTokens } from './auth';
 
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_MOCK === 'true'
-    ? ''
-    : '/api';
+/**
+ * API Base URL 결정
+ * - 클라이언트: '' (빈 문자열, Next.js rewrites가 /api/* 처리)
+ * - 서버: 백엔드 절대 URL (fetch는 상대 경로 불가)
+ */
+function getApiBaseUrl() {
+  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
+    return '';
+  }
+
+  // 클라이언트 환경
+  if (typeof window !== 'undefined') {
+    return '';
+  }
+
+  // 서버 환경 - 백엔드 절대 URL
+  const backendUrl =
+    process.env.NODE_ENV === 'production'
+      ? process.env.NEXT_PUBLIC_PRODUCTION_API_URL
+      : process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/v1';
+  return backendUrl;
+}
+
+const API_BASE_URL = getApiBaseUrl();
 
 interface FetchOptions extends RequestInit {
   params?: Record<string, string | number | boolean>;


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- #66 

## 작업 내용 + 스크린샷

- 서버 컴포넌트에선 next.config의 rewrite가 동작하지 않는 문제로 공통 fetch 쪽에서 환경에 따라 백엔드 주소를 분기처리하도록 수정

## 실제 걸린 시간

- 0.5h

## 작업하며 고민했던 점(선택)

- 

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
