### PR TITLE
홈, 마이페이지 스토리북 추가

### DIFF
--- a/frontend/src/app/(main)/_components/storybook/README.md
+++ b/frontend/src/app/(main)/_components/storybook/README.md
@@ -1,0 +1,68 @@
+# 홈 페이지 컴포넌트 Storybook
+
+홈 페이지와 관련된 재사용 가능한 컴포넌트들의 Storybook 스토리입니다.
+
+## 📚 포함된 스토리
+
+### 1. RecordList (기록 목록)
+
+- `Default`: 기본 기록 목록 (3개)
+- `SingleRecord`: 기록 1개
+- `EmptyRecords`: 빈 목록 (추가 버튼 표시)
+- `ManyRecords`: 많은 기록 (9개)
+- `DarkMode`: 다크 모드
+
+### 2. WeekCalendar (주간 캘린더)
+
+- `Default`: 기본 캘린더
+- `DarkMode`: 다크 모드
+- `Interactive`: 인터랙티브 기능 설명
+
+> **참고**: Page 컴포넌트(`page.tsx`)는 스토리북에 포함하지 않습니다. Page는 라우팅, 상태 관리 등 의존성이 많아 E2E 테스트가 더 적합합니다.
+
+## 🚀 실행 방법
+
+```bash
+# Storybook 실행
+pnpm run storybook
+
+# Storybook 빌드
+pnpm run build-storybook
+```
+
+Storybook은 `http://localhost:6006`에서 실행됩니다.
+
+## 🎨 주요 기능
+
+### WeekCalendar
+
+- **날짜 선택**: 클릭으로 날짜 선택 (미래 날짜 비활성화)
+- **스와이프**: 좌우 드래그로 이전/다음 주 이동
+- **연월 클릭**: `/my/month/:month` 페이지로 이동
+- **시각적 표시**:
+  - 오늘: 초록색 배경
+  - 선택된 날짜: 검은색(라이트) / 흰색(다크) 배경
+  - 일요일: 빨간색 텍스트
+  - 토요일: 파란색 텍스트
+
+### RecordList
+
+- **필터링**: 선택된 날짜의 기록만 표시
+- **클릭**: 기록 클릭 시 `/record/:id` 페이지로 이동
+- **빈 상태**: 기록이 없을 때 "기록 추가하기" 버튼 표시
+- **동적 렌더링**: CompactFieldRenderer로 각 필드 타입 렌더링
+
+## 📦 의존성
+
+- `zustand`: WeekCalendar 상태 관리 (useWeekCalendar)
+- `framer-motion`: WeekCalendar 애니메이션
+- `next/navigation`: 라우팅
+- `lucide-react`: 아이콘
+
+## 🔗 관련 파일
+
+- `page.tsx`: 홈 페이지 메인 컴포넌트
+- `RecordList.tsx`: 기록 목록 컴포넌트
+- `WeekCalendar.tsx`: 주간 캘린더 컴포넌트
+- `CompactFieldRenderer.tsx`: 필드 렌더러
+- `useWeekCalendar.ts`: 캘린더 상태 관리 훅

--- a/frontend/src/app/(main)/_components/storybook/RecordList.stories.tsx
+++ b/frontend/src/app/(main)/_components/storybook/RecordList.stories.tsx
@@ -1,0 +1,161 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import RecordList from '../RecordList';
+import { MemoryRecord } from '@/lib/types/record';
+import { formatDateISO } from '@/lib/date';
+
+const mockRecords: MemoryRecord[] = [
+  {
+    id: '1',
+    title: '성수동 팝업 스토어 나들이',
+    createdAt: Date.now(),
+    customFields: [],
+    fieldOrder: ['emotion', 'photos', 'location', 'content', 'rating', 'tags'],
+    data: {
+      date: formatDateISO().replace(/-/g, '.'),
+      time: '오후 2:30',
+      content:
+        '드디어 가보고 싶었던 팝업 스토어 방문! 웨이팅은 길었지만 굿즈들이 너무 귀여웠다.',
+      photos: ['/profile-ex.jpeg'],
+      emotion: { emoji: '🤩', label: '설렘' },
+      tags: ['데이트', '성수', '주말'],
+      location: '성수동 카페거리',
+      rating: { value: 4.5, max: 5 },
+      media: null,
+      table: null,
+    },
+  },
+  {
+    id: '2',
+    title: '동지 팥죽 한 그릇',
+    createdAt: Date.now(),
+    customFields: [],
+    fieldOrder: ['location', 'emotion', 'content', 'table', 'rating'],
+    data: {
+      date: formatDateISO().replace(/-/g, '.'),
+      time: '오후 5:10',
+      content: '어머니가 직접 쑤어주신 팥죽. 달지 않고 담백해서 좋다.',
+      photos: [],
+      emotion: { emoji: '🥣', label: '따뜻해' },
+      tags: ['가족', '겨울'],
+      location: '우리집',
+      rating: { value: 5, max: 5 },
+      media: null,
+      table: [
+        ['재료', '평가'],
+        ['새알심', '쫀득함'],
+        ['팥소', '진함'],
+      ],
+    },
+  },
+  {
+    id: '3',
+    title: '강남 카페 투어',
+    createdAt: Date.now(),
+    customFields: [],
+    fieldOrder: ['photos', 'emotion', 'location', 'content', 'tags'],
+    data: {
+      date: formatDateISO().replace(/-/g, '.'),
+      time: '오후 3:00',
+      content: '강남 핫플 카페 3곳 돌아다니며 디저트 맛보기',
+      photos: ['/profile-ex.jpeg', '/profile-ex.jpeg'],
+      emotion: { emoji: '☕', label: '여유로움' },
+      tags: ['카페', '강남', '디저트'],
+      location: '강남역 일대',
+      rating: { value: 4, max: 5 },
+      media: null,
+      table: null,
+    },
+  },
+];
+
+const meta = {
+  title: 'Record/RecordList',
+  component: RecordList,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    records: {
+      description: '표시할 기록 목록',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-md mx-auto p-5 bg-[#F9F9F9] dark:bg-[#121212]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RecordList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    records: mockRecords,
+  },
+};
+
+export const SingleRecord: Story = {
+  args: {
+    records: [mockRecords[0]],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '기록이 하나만 있는 경우',
+      },
+    },
+  },
+};
+
+export const EmptyRecords: Story = {
+  args: {
+    records: [],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '기록이 없는 경우 - "기록 추가하기" 버튼 표시',
+      },
+    },
+  },
+};
+
+export const ManyRecords: Story = {
+  args: {
+    records: [...mockRecords, ...mockRecords, ...mockRecords],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '많은 기록이 있는 경우',
+      },
+    },
+  },
+};
+
+export const DarkMode: Story = {
+  args: {
+    records: mockRecords,
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        story: '다크 모드',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="dark">
+        <div className="max-w-md mx-auto p-5 bg-[#121212]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};

--- a/frontend/src/app/(main)/_components/storybook/WeekCalendar.stories.tsx
+++ b/frontend/src/app/(main)/_components/storybook/WeekCalendar.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import WeekCalendar from '../WeekCalendar';
+
+const meta = {
+  title: 'Calendar/WeekCalendar',
+  component: WeekCalendar,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="max-w-md mx-auto bg-white dark:bg-[#121212]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof WeekCalendar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '기본 주간 캘린더 - 현재 주를 표시하고 스와이프로 이전/다음 주 이동 가능',
+      },
+    },
+  },
+};
+
+export const DarkMode: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        story: '다크 모드 주간 캘린더',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="dark">
+        <div className="max-w-md mx-auto bg-[#121212]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};
+
+export const Interactive: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+주간 캘린더의 인터랙티브 기능:
+- 날짜 클릭: 해당 날짜 선택 (미래 날짜는 비활성화)
+- 스와이프: 좌우로 스와이프하여 이전/다음 주 이동
+- 연월 클릭: 월별 뷰로 이동
+- 오늘 날짜는 초록색 배경으로 표시
+- 선택된 날짜는 검은색(라이트)/흰색(다크) 배경
+- 일요일은 빨간색, 토요일은 파란색으로 표시
+        `,
+      },
+    },
+  },
+};

--- a/frontend/src/app/(main)/profile/_components/storybook/Profile.stories.tsx
+++ b/frontend/src/app/(main)/profile/_components/storybook/Profile.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import Profile from '../Profile';
+
+const meta = {
+  title: 'Profile/Profile',
+  component: Profile,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="max-w-md mx-auto p-5 bg-[#F9F9F9] dark:bg-[#121212]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Profile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '기본 프로필 카드 - 프로필 이미지, 이름, 이메일, 수정 버튼 포함',
+      },
+    },
+  },
+};
+
+export const DarkMode: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        story: '다크 모드 프로필 카드',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="dark">
+        <div className="max-w-md mx-auto p-5 bg-[#121212]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};
+
+export const Interactive: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+프로필 카드 기능:
+- "프로필 수정" 버튼 클릭 시 /profile/edit 페이지로 이동
+- Active 상태에서 scale 애니메이션
+- 다크 모드 지원
+        `,
+      },
+    },
+  },
+};

--- a/frontend/src/app/(main)/profile/_components/storybook/README.md
+++ b/frontend/src/app/(main)/profile/_components/storybook/README.md
@@ -1,0 +1,123 @@
+# 마이페이지 컴포넌트 Storybook
+
+마이페이지와 관련된 재사용 가능한 컴포넌트들의 Storybook 스토리입니다.
+
+## 📚 포함된 스토리
+
+### 1. Profile (프로필 카드)
+
+- `Default`: 기본 프로필 카드
+- `DarkMode`: 다크 모드
+- `Interactive`: 인터랙티브 기능 설명
+
+### 2. TagDashboard (태그 대시보드)
+
+- `Default`: 기본 태그 대시보드
+- `RecentTab`: 최근 사용 태그 탭
+- `FrequentTab`: 자주 사용 태그 탭
+- `EmptyTags`: 태그가 없는 경우
+- `FewTags`: 태그가 적은 경우 (2개)
+- `DarkMode`: 다크 모드
+- `WithComboSearch`: 조합 검색 기능 포함
+
+### 3. RecordStatistics (기록 통계)
+
+- `Default`: 기본 통계 (접힌 상태)
+- `Collapsed`: 접힌 상태
+- `Expanded`: 펼쳐진 상태 (차트 표시)
+- `DarkMode`: 다크 모드
+- `Interactive`: 인터랙티브 기능 설명
+
+### 4. Setting (설정)
+
+- `Default`: 기본 설정
+- `LightMode`: 라이트 모드 (태양 아이콘)
+- `DarkMode`: 다크 모드 (달 아이콘)
+- `Interactive`: 인터랙티브 기능 설명
+- `WithdrawalDrawer`: 탈퇴 확인 Drawer
+
+> **참고**: Page 컴포넌트(`page.tsx`)는 스토리북에 포함하지 않습니다. Page는 라우팅, 상태 관리 등 의존성이 많아 E2E 테스트가 더 적합합니다.
+
+## 🚀 실행 방법
+
+```bash
+# Storybook 실행
+pnpm run storybook
+
+# Storybook 빌드
+pnpm run build-storybook
+```
+
+Storybook은 `http://localhost:6006`에서 실행됩니다.
+
+## 🎨 주요 기능
+
+### Profile
+
+- **프로필 정보**: 이미지, 이름, 이메일 표시
+- **수정 버튼**: `/profile/edit` 페이지로 이동
+- **반응형**: Active 상태 스케일 애니메이션
+
+### TagDashboard
+
+- **탭 전환**: 최근 사용 / 자주 사용 태그
+- **태그 표시**: 최대 5개까지 표시
+- **조합 검색**: Drawer UI로 여러 태그 선택 후 검색
+  - 태그 선택/해제
+  - 선택된 태그 수 표시
+  - 초기화 버튼
+  - 검색 페이지로 이동 (쿼리 파라미터 전달)
+- **모두 보기**: `/profile/all-tags` 페이지로 이동
+
+### RecordStatistics
+
+- **기본 통계**: WritingRecordStatistics 항상 표시
+- **토글 기능**: "통계 더보기" / "접기" 버튼
+- **확장 통계**:
+  - MonthlyUsageChart: 월별 사용량
+  - PlaceDashboard: 장소별 통계
+  - EmotionDashboard: 감정별 통계
+- **애니메이션**: 부드러운 expand/collapse
+
+## 📦 의존성
+
+- `@radix-ui/react-dialog`: Drawer UI (TagDashboard)
+- `lucide-react`: 아이콘
+- `next/navigation`: 라우팅
+- `next/image`: 이미지 최적화
+
+## 🔗 관련 파일
+
+### 메인 컴포넌트
+
+- `page.tsx`: 마이페이지 메인
+- `Profile.tsx`: 프로필 카드
+- `TagDashboard.tsx`: 태그 대시보드
+- `RecordStatistics.tsx`: 기록 통계 컨테이너
+
+### 하위 컴포넌트
+
+- `WritingRecordStatistics.tsx`: 작성 통계
+- `MonthlyUsageChart.tsx`: 월별 차트
+- `PlaceDashboard.tsx`: 장소 대시보드
+- `EmotionDashboard.tsx`: 감정 대시보드
+- `Setting.tsx`: 설정
+- `ProfileHeaderActions.tsx`: 헤더 액션
+
+## 💡 스토리북 작성 팁
+
+### 재사용 가능한 컴포넌트만 포함
+
+- ✅ Profile, TagDashboard, RecordStatistics
+- ❌ ProfilePage (page.tsx)
+
+### Props를 받는 컴포넌트 우선
+
+- `TagDashboard`: tags prop
+- `RecordList`: records prop
+
+### 다양한 상태 테스트
+
+- Default, Empty, Loading, Error
+- DarkMode, LightMode
+- Collapsed, Expanded

--- a/frontend/src/app/(main)/profile/_components/storybook/RecordStatistics.stories.tsx
+++ b/frontend/src/app/(main)/profile/_components/storybook/RecordStatistics.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import RecordStatistics from '../RecordStatistics';
+import { useEffect } from 'react';
+
+const meta = {
+  title: 'Profile/RecordStatistics',
+  component: RecordStatistics,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="max-w-md mx-auto p-5 bg-[#F9F9F9] dark:bg-[#121212]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof RecordStatistics>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '기본 기록 통계 - 작성 통계와 확장 가능한 상세 통계 포함',
+      },
+    },
+  },
+};
+
+export const Collapsed: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '접힌 상태 (기본) - WritingRecordStatistics만 표시',
+      },
+    },
+  },
+};
+
+// 통계가 자동으로 펼쳐지도록 래퍼 컴포넌트 생성
+function RecordStatisticsExpanded() {
+  useEffect(() => {
+    // DOM이 렌더링된 후 "통계 더보기" 버튼 클릭
+    const timer = setTimeout(() => {
+      const buttons = document.querySelectorAll('button');
+      const expandButton = Array.from(buttons).find((button) =>
+        button.textContent?.includes('통계 더보기'),
+      );
+      if (expandButton) {
+        (expandButton as HTMLButtonElement).click();
+      }
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return <RecordStatistics />;
+}
+
+export const Expanded: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '펼쳐진 상태 - 월별 사용 차트, 장소 대시보드, 감정 대시보드 표시. Docs 모드에서도 자동으로 펼쳐집니다.',
+      },
+    },
+  },
+  render: () => <RecordStatisticsExpanded />,
+};
+
+export const DarkMode: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        story: '다크 모드 기록 통계',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="dark">
+        <div className="max-w-md mx-auto p-5 bg-[#121212]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};
+
+export const Interactive: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+기록 통계 기능:
+- **토글 버튼**: "통계 더보기" / "접기" 버튼으로 상세 통계 표시/숨김
+- **애니메이션**: 부드러운 expand/collapse 애니메이션
+- **포함된 통계**:
+  1. WritingRecordStatistics: 작성 기록 요약
+  2. MonthlyUsageChart: 월별 사용 차트
+  3. PlaceDashboard: 장소별 통계
+  4. EmotionDashboard: 감정별 통계
+        `,
+      },
+    },
+  },
+};

--- a/frontend/src/app/(main)/profile/_components/storybook/Setting.stories.tsx
+++ b/frontend/src/app/(main)/profile/_components/storybook/Setting.stories.tsx
@@ -1,0 +1,207 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import Setting from '../Setting';
+import { ThemeProvider, useTheme } from 'next-themes';
+import { useEffect } from 'react';
+
+// 다크 모드 상태로 렌더링하는 래퍼
+function SettingDarkMode() {
+  const { setTheme } = useTheme();
+
+  useEffect(() => {
+    setTheme('dark');
+  }, [setTheme]);
+
+  return <Setting />;
+}
+
+// 라이트 모드 상태로 렌더링하는 래퍼
+function SettingLightMode() {
+  const { setTheme } = useTheme();
+
+  useEffect(() => {
+    setTheme('light');
+  }, [setTheme]);
+
+  return <Setting />;
+}
+
+const meta = {
+  title: 'Profile/Setting',
+  component: Setting,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Setting>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '기본 설정 컴포넌트 - 다크 모드 토글, 버전 정보, 로그아웃, 탈퇴하기 포함',
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      // 스토리가 렌더링될 때마다 테마 스토리지 초기화
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('storybook-theme-default');
+      }
+      return (
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="light"
+          enableSystem={false}
+          storageKey="storybook-theme-default"
+        >
+          <div className="max-w-md mx-auto p-5 bg-[#F9F9F9]">
+            <Story />
+          </div>
+        </ThemeProvider>
+      );
+    },
+  ],
+};
+
+export const LightMode: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '라이트 모드 설정 - 태양 아이콘과 왼쪽에 있는 회색 토글 표시',
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('storybook-theme-light');
+      }
+      return (
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="light"
+          enableSystem={false}
+          storageKey="storybook-theme-light"
+        >
+          <div className="max-w-md mx-auto p-5 bg-[#F9F9F9]">
+            <Story />
+          </div>
+        </ThemeProvider>
+      );
+    },
+  ],
+  render: () => <SettingLightMode />,
+};
+
+export const DarkMode: Story = {
+  parameters: {
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        story:
+          '다크 모드 설정 - 달 아이콘과 오른쪽으로 이동한 보라색 토글 표시',
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('storybook-theme-dark');
+      }
+      return (
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          enableSystem={false}
+          storageKey="storybook-theme-dark"
+        >
+          <div className="dark">
+            <div className="max-w-md mx-auto p-5 bg-[#121212]">
+              <Story />
+            </div>
+          </div>
+        </ThemeProvider>
+      );
+    },
+  ],
+  render: () => <SettingDarkMode />,
+};
+
+export const Interactive: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+설정 컴포넌트 기능:
+
+**다크 모드 토글**
+- 토글 버튼 클릭으로 라이트/다크 모드 전환
+- 라이트 모드: 태양 ☀️ 아이콘, 회색 토글
+- 다크 모드: 달 🌙 아이콘, 보라색 토글
+- 애니메이션: 부드러운 슬라이드 전환
+
+**기타 기능**
+- 버전 정보: v1.0.0 표시
+- 로그아웃: 로그아웃 처리
+- 탈퇴하기: Drawer로 확인 후 탈퇴
+  - 경고 아이콘과 메시지 표시
+  - 취소 / 탈퇴하기 버튼
+  - 탈퇴하기 버튼은 빨간색 강조
+        `,
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('storybook-theme-interactive');
+      }
+      return (
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="light"
+          enableSystem={false}
+          storageKey="storybook-theme-interactive"
+        >
+          <div className="max-w-md mx-auto p-5 bg-[#F9F9F9] dark:bg-[#121212]">
+            <Story />
+          </div>
+        </ThemeProvider>
+      );
+    },
+  ],
+};
+
+export const WithdrawalDrawer: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '탈퇴하기 Drawer - "탈퇴하기" 버튼 클릭 시 표시되는 확인 창',
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      if (typeof window !== 'undefined') {
+        localStorage.removeItem('storybook-theme-withdrawal');
+      }
+      return (
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="light"
+          enableSystem={false}
+          storageKey="storybook-theme-withdrawal"
+        >
+          <div className="max-w-md mx-auto p-5 bg-[#F9F9F9]">
+            <Story />
+          </div>
+        </ThemeProvider>
+      );
+    },
+  ],
+};

--- a/frontend/src/app/(main)/profile/_components/storybook/TagDashboard.stories.tsx
+++ b/frontend/src/app/(main)/profile/_components/storybook/TagDashboard.stories.tsx
@@ -1,0 +1,212 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import TagDashboard from '../TagDashboard';
+import { ProfileTag } from '@/lib/types/profile';
+import { useEffect } from 'react';
+
+const mockTags: ProfileTag = {
+  recent: [
+    { name: '아침', count: 1 },
+    { name: '좋은글', count: 1 },
+    { name: '점심', count: 1 },
+    { name: '커피', count: 1 },
+    { name: '식사', count: 1 },
+  ],
+  frequent: [
+    { name: '산책', count: 12 },
+    { name: '성수동', count: 8 },
+    { name: '맛집', count: 7 },
+    { name: '가족', count: 5 },
+    { name: '주말', count: 4 },
+  ],
+  all: [
+    { name: '산책', count: 12 },
+    { name: '성수동', count: 8 },
+    { name: '맛집', count: 7 },
+    { name: '가족', count: 5 },
+    { name: '아침', count: 1 },
+    { name: '좋은글', count: 1 },
+    { name: '점심', count: 1 },
+    { name: '커피', count: 1 },
+    { name: '식사', count: 1 },
+    { name: '주말', count: 4 },
+    { name: '독서', count: 3 },
+    { name: '영화', count: 6 },
+    { name: '데이트', count: 9 },
+    { name: '운동', count: 2 },
+    { name: '여행', count: 11 },
+  ],
+};
+
+const emptyTags: ProfileTag = {
+  recent: [],
+  frequent: [],
+  all: [],
+};
+
+const fewTags: ProfileTag = {
+  recent: [
+    { name: '산책', count: 3 },
+    { name: '맛집', count: 2 },
+  ],
+  frequent: [
+    { name: '산책', count: 3 },
+    { name: '맛집', count: 2 },
+  ],
+  all: [
+    { name: '산책', count: 3 },
+    { name: '맛집', count: 2 },
+  ],
+};
+
+const meta = {
+  title: 'Profile/TagDashboard',
+  component: TagDashboard,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    tags: {
+      description: '프로필 태그 데이터 (recent, frequent, all)',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-md mx-auto p-5 bg-[#F9F9F9] dark:bg-[#121212]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof TagDashboard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    tags: mockTags,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '기본 태그 대시보드 - 최근 사용 / 자주 사용 탭 전환 가능',
+      },
+    },
+  },
+};
+
+export const RecentTab: Story = {
+  args: {
+    tags: mockTags,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '최근 사용 태그 탭 (기본 선택)',
+      },
+    },
+  },
+};
+
+// 자주 사용 탭이 자동으로 클릭되도록 래퍼 컴포넌트 생성
+function TagDashboardWithFrequentTab({ tags }: { tags: ProfileTag }) {
+  useEffect(() => {
+    // DOM이 렌더링된 후 자주 사용 버튼 클릭
+    const timer = setTimeout(() => {
+      const buttons = document.querySelectorAll('button');
+      const frequentButton = Array.from(buttons).find(
+        (button) => button.textContent === '자주 사용',
+      );
+      if (frequentButton) {
+        (frequentButton as HTMLButtonElement).click();
+      }
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return <TagDashboard tags={tags} />;
+}
+
+export const FrequentTab: Story = {
+  args: {
+    tags: mockTags,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '자주 사용 태그 탭 - 사용 횟수가 많은 순으로 정렬. Docs 모드에서도 자동으로 탭이 전환됩니다.',
+      },
+    },
+  },
+  render: (args) => <TagDashboardWithFrequentTab {...args} />,
+};
+
+export const EmptyTags: Story = {
+  args: {
+    tags: emptyTags,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '태그가 없는 경우 - "사용된 태그가 없습니다" 메시지 표시',
+      },
+    },
+  },
+};
+
+export const FewTags: Story = {
+  args: {
+    tags: fewTags,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '태그가 적은 경우 (2개)',
+      },
+    },
+  },
+};
+
+export const DarkMode: Story = {
+  args: {
+    tags: mockTags,
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        story: '다크 모드 태그 대시보드',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="dark">
+        <div className="max-w-md mx-auto p-5 bg-[#121212]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};
+
+export const WithComboSearch: Story = {
+  args: {
+    tags: mockTags,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+태그 대시보드 기능:
+- **탭 전환**: 최근 사용 / 자주 사용 태그 전환
+- **조합 검색**: Drawer로 여러 태그 선택 후 검색
+- **모두 보기**: /profile/all-tags 페이지로 이동
+- **태그 표시**: 최대 5개까지 표시, 각 태그의 사용 횟수 표시
+        `,
+      },
+    },
+  },
+};

--- a/frontend/src/app/(main)/profile/all-emotions/_components/EmotionList.tsx
+++ b/frontend/src/app/(main)/profile/all-emotions/_components/EmotionList.tsx
@@ -7,10 +7,11 @@ import { useState } from 'react';
 
 interface EmotionListProps {
   emotions: ProfileEmotion;
+  defaultTab?: 'recent' | 'frequent';
 }
 
-export default function EmotionList({ emotions }: EmotionListProps) {
-  const [emotionTab, setEmotionTab] = useState<'recent' | 'frequent'>('recent');
+export default function EmotionList({ emotions, defaultTab = 'recent' }: EmotionListProps) {
+  const [emotionTab, setEmotionTab] = useState<'recent' | 'frequent'>(defaultTab);
   const router = useRouter();
 
   const handleSingleTagSearch = (tagName: string) => {
@@ -41,26 +42,34 @@ export default function EmotionList({ emotions }: EmotionListProps) {
       </div>
 
       <div className="flex-1 overflow-y-auto hide-scrollbar">
-        {emotions[emotionTab].map((emotion) => (
-          <button
-            key={emotion.name}
-            onClick={() => handleSingleTagSearch(emotion.name)}
-            className="cursor-pointer w-full flex items-center justify-between px-6 py-5 border-b transition-colors active:bg-gray-50 dark:active:bg-white/5 dark:border-white/5 border-gray-50"
-          >
-            <div className="flex items-center gap-1.5">
-              <span className="text-[15px]">{emotion.emoji}</span>
-              <span className="text-[15px] font-medium dark:text-gray-200 text-itta-black">
-                {emotion.name}
-              </span>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="text-[14px] font-medium dark:text-gray-400 text-gray-600">
-                {emotion.count}
-              </span>
-              <ChevronRight className="w-4 h-4 text-gray-300" />
-            </div>
-          </button>
-        ))}
+        {emotions[emotionTab].length === 0 ? (
+          <div className="flex px-3 py-10 items-center justify-center h-full">
+            <p className="text-sm font-medium text-gray-400">
+              사용된 감정이 없습니다.
+            </p>
+          </div>
+        ) : (
+          emotions[emotionTab].map((emotion) => (
+            <button
+              key={emotion.name}
+              onClick={() => handleSingleTagSearch(emotion.name)}
+              className="cursor-pointer w-full flex items-center justify-between px-6 py-5 border-b transition-colors active:bg-gray-50 dark:active:bg-white/5 dark:border-white/5 border-gray-50"
+            >
+              <div className="flex items-center gap-1.5">
+                <span className="text-[15px]">{emotion.emoji}</span>
+                <span className="text-[15px] font-medium dark:text-gray-200 text-itta-black">
+                  {emotion.name}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-[14px] font-medium dark:text-gray-400 text-gray-600">
+                  {emotion.count}
+                </span>
+                <ChevronRight className="w-4 h-4 text-gray-300" />
+              </div>
+            </button>
+          ))
+        )}
       </div>
     </>
   );

--- a/frontend/src/app/(main)/profile/all-emotions/_components/storybook/EmotionList.stories.tsx
+++ b/frontend/src/app/(main)/profile/all-emotions/_components/storybook/EmotionList.stories.tsx
@@ -1,0 +1,175 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import EmotionList from '../EmotionList';
+import { ProfileEmotion } from '@/lib/types/profile';
+
+const meta = {
+  title: 'Profile/AllEmotions/EmotionList',
+  component: EmotionList,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof EmotionList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockEmotions: ProfileEmotion = {
+  recent: [
+    { name: '행복', emoji: '😊', count: 15 },
+    { name: '설렘', emoji: '🥰', count: 12 },
+    { name: '평온', emoji: '😌', count: 10 },
+    { name: '뿌듯', emoji: '😎', count: 8 },
+    { name: '감사', emoji: '🙏', count: 7 },
+    { name: '기쁨', emoji: '😄', count: 5 },
+    { name: '만족', emoji: '😁', count: 4 },
+    { name: '즐거움', emoji: '😆', count: 3 },
+  ],
+  frequent: [
+    { name: '평온', emoji: '😌', count: 45 },
+    { name: '행복', emoji: '😊', count: 38 },
+    { name: '감사', emoji: '🙏', count: 32 },
+    { name: '기쁨', emoji: '😄', count: 28 },
+    { name: '뿌듯', emoji: '😎', count: 25 },
+    { name: '설렘', emoji: '🥰', count: 22 },
+    { name: '만족', emoji: '😁', count: 18 },
+    { name: '즐거움', emoji: '😆', count: 15 },
+  ],
+  all: [],
+};
+
+const fewEmotions: ProfileEmotion = {
+  recent: [
+    { name: '행복', emoji: '😊', count: 3 },
+    { name: '설렘', emoji: '🥰', count: 2 },
+  ],
+  frequent: [
+    { name: '평온', emoji: '😌', count: 5 },
+    { name: '감사', emoji: '🙏', count: 4 },
+  ],
+  all: [],
+};
+
+const emptyEmotions: ProfileEmotion = {
+  recent: [],
+  frequent: [],
+  all: [],
+};
+
+export const Default: Story = {
+  args: {
+    emotions: mockEmotions,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '기본 감정 목록 - 최근 사용한 탭이 기본으로 선택됨',
+      },
+    },
+  },
+};
+
+export const RecentTab: Story = {
+  args: {
+    emotions: mockEmotions,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '최근 사용한 감정 탭 - 시간순으로 정렬된 감정 표시',
+      },
+    },
+  },
+};
+
+export const FrequentTab: Story = {
+  args: {
+    emotions: mockEmotions,
+    defaultTab: 'frequent',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '자주 사용한 감정 탭 - 사용 횟수가 많은 감정 표시',
+      },
+    },
+  },
+};
+
+export const FewEmotions: Story = {
+  args: {
+    emotions: fewEmotions,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '감정이 적은 경우 - 각 탭에 2개씩만 표시',
+      },
+    },
+  },
+};
+
+export const EmptyEmotions: Story = {
+  args: {
+    emotions: emptyEmotions,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '감정이 없는 경우 - 빈 목록 표시',
+      },
+    },
+  },
+};
+
+export const DarkMode: Story = {
+  args: {
+    emotions: mockEmotions,
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        story: '다크 모드 - 어두운 배경의 감정 목록',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="dark">
+        <div className="min-h-screen bg-[#121212]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};
+
+export const Interactive: Story = {
+  args: {
+    emotions: mockEmotions,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+감정 목록 컴포넌트 기능:
+
+**탭 전환**
+- 최근 사용한: 시간순으로 정렬된 감정
+- 자주 사용한: 사용 횟수가 많은 순서로 정렬
+
+**감정 아이템**
+- 이모지와 감정명 표시
+- 우측에 사용 횟수 표시
+- 클릭 시 해당 감정으로 검색 페이지 이동
+- Active 상태: 회색 배경 표시
+
+**스크롤**
+- 긴 목록은 스크롤 가능
+- 스크롤바 숨김 처리
+        `,
+      },
+    },
+  },
+};

--- a/frontend/src/app/(main)/profile/all-emotions/_components/storybook/README.md
+++ b/frontend/src/app/(main)/profile/all-emotions/_components/storybook/README.md
@@ -1,0 +1,66 @@
+# 전체 감정 목록 컴포넌트 Storybook
+
+전체 감정 페이지(`/profile/all-emotions`)의 재사용 가능한 컴포넌트 스토리입니다.
+
+## 📚 포함된 스토리
+
+### EmotionList (감정 목록)
+
+- `Default`: 기본 감정 목록 (최근 사용한 탭)
+- `RecentTab`: 최근 사용한 감정 탭
+- `FrequentTab`: 자주 사용한 감정 탭
+- `FewEmotions`: 감정이 적은 경우 (2개)
+- `EmptyEmotions`: 감정이 없는 경우
+- `DarkMode`: 다크 모드
+- `Interactive`: 인터랙티브 기능 설명
+
+> **참고**: Page 컴포넌트(`page.tsx`)는 스토리북에 포함하지 않습니다. Page는 라우팅, 상태 관리 등 의존성이 많아 E2E 테스트가 더 적합합니다.
+
+## 🚀 실행 방법
+
+```bash
+# Storybook 실행
+pnpm run storybook
+
+# Storybook 빌드
+pnpm run build-storybook
+```
+
+Storybook은 `http://localhost:6006`에서 실행됩니다.
+
+## 🎨 주요 기능
+
+### EmotionList
+
+- **탭 전환**: 최근 사용한 / 자주 사용한 감정
+- **감정 표시**: 이모지와 감정명, 사용 횟수
+- **검색 이동**: 감정 클릭 시 검색 페이지로 이동 (`/search?emotion=감정명`)
+- **스크롤**: 긴 목록 스크롤 가능 (스크롤바 숨김)
+- **반응형**: Active 상태 배경색 변경
+
+## 📦 의존성
+
+- `lucide-react`: 아이콘 (ChevronRight)
+- `next/navigation`: 라우팅
+- `@/lib/types/profile`: ProfileEmotion 타입
+
+## 🔗 관련 파일
+
+### 메인 컴포넌트
+
+- `page.tsx`: 전체 감정 페이지
+- `EmotionList.tsx`: 감정 목록 컴포넌트
+- `ProfileAllEmotionsHeaderActions.tsx`: 헤더 액션
+
+## 💡 스토리북 작성 팁
+
+### 재사용 가능한 컴포넌트만 포함
+
+- ✅ EmotionList (props를 받는 컴포넌트)
+- ❌ AllEmotionsPage (page.tsx)
+
+### 다양한 상태 테스트
+
+- Default, Empty, FewEmotions
+- DarkMode, LightMode
+- RecentTab, FrequentTab

--- a/frontend/src/app/(main)/profile/all-tags/_components/TagList.tsx
+++ b/frontend/src/app/(main)/profile/all-tags/_components/TagList.tsx
@@ -7,10 +7,11 @@ import { useState } from 'react';
 
 interface TagListProps {
   tags: ProfileTag;
+  defaultTab?: 'recent' | 'frequent';
 }
 
-export default function TagList({ tags }: TagListProps) {
-  const [tagTab, setTagTab] = useState<'recent' | 'frequent'>('recent');
+export default function TagList({ tags, defaultTab = 'recent' }: TagListProps) {
+  const [tagTab, setTagTab] = useState<'recent' | 'frequent'>(defaultTab);
   const router = useRouter();
 
   const handleSingleTagSearch = (tagName: string) => {
@@ -41,26 +42,36 @@ export default function TagList({ tags }: TagListProps) {
       </div>
 
       <div className="flex-1 overflow-y-auto hide-scrollbar">
-        {tags[tagTab].map((tag) => (
-          <button
-            key={tag.name}
-            onClick={() => handleSingleTagSearch(tag.name)}
-            className="cursor-pointer w-full flex items-center justify-between px-6 py-5 border-b transition-colors active:bg-gray-50 dark:active:bg-white/5 dark:border-white/5 border-gray-50"
-          >
-            <div className="flex items-center gap-0.5">
-              <span className="text-[#10B981] font-medium text-[15px]">#</span>
-              <span className="text-[15px] font-medium dark:text-gray-200 text-itta-black">
-                {tag.name}
-              </span>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="text-[14px] font-medium dark:text-gray-400 text-gray-600">
-                {tag.count}
-              </span>
-              <ChevronRight className="w-4 h-4 text-gray-300" />
-            </div>
-          </button>
-        ))}
+        {tags[tagTab].length === 0 ? (
+          <div className="flex px-3 py-10 items-center justify-center h-full">
+            <p className="text-sm font-medium text-gray-400">
+              사용된 태그가 없습니다.
+            </p>
+          </div>
+        ) : (
+          tags[tagTab].map((tag) => (
+            <button
+              key={tag.name}
+              onClick={() => handleSingleTagSearch(tag.name)}
+              className="cursor-pointer w-full flex items-center justify-between px-6 py-5 border-b transition-colors active:bg-gray-50 dark:active:bg-white/5 dark:border-white/5 border-gray-50"
+            >
+              <div className="flex items-center gap-0.5">
+                <span className="text-[#10B981] font-medium text-[15px]">
+                  #
+                </span>
+                <span className="text-[15px] font-medium dark:text-gray-200 text-itta-black">
+                  {tag.name}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-[14px] font-medium dark:text-gray-400 text-gray-600">
+                  {tag.count}
+                </span>
+                <ChevronRight className="w-4 h-4 text-gray-300" />
+              </div>
+            </button>
+          ))
+        )}
       </div>
     </>
   );

--- a/frontend/src/app/(main)/profile/all-tags/_components/storybook/README.md
+++ b/frontend/src/app/(main)/profile/all-tags/_components/storybook/README.md
@@ -1,0 +1,66 @@
+# 전체 태그 목록 컴포넌트 Storybook
+
+전체 태그 페이지(`/profile/all-tags`)의 재사용 가능한 컴포넌트 스토리입니다.
+
+## 📚 포함된 스토리
+
+### TagList (태그 목록)
+
+- `Default`: 기본 태그 목록 (최근 사용한 탭)
+- `RecentTab`: 최근 사용한 태그 탭
+- `FrequentTab`: 자주 사용한 태그 탭
+- `FewTags`: 태그가 적은 경우 (2개)
+- `EmptyTags`: 태그가 없는 경우
+- `DarkMode`: 다크 모드
+- `Interactive`: 인터랙티브 기능 설명
+
+> **참고**: Page 컴포넌트(`page.tsx`)는 스토리북에 포함하지 않습니다. Page는 라우팅, 상태 관리 등 의존성이 많아 E2E 테스트가 더 적합합니다.
+
+## 🚀 실행 방법
+
+```bash
+# Storybook 실행
+pnpm run storybook
+
+# Storybook 빌드
+pnpm run build-storybook
+```
+
+Storybook은 `http://localhost:6006`에서 실행됩니다.
+
+## 🎨 주요 기능
+
+### TagList
+
+- **탭 전환**: 최근 사용한 / 자주 사용한 태그
+- **태그 표시**: # 기호와 태그명, 사용 횟수
+- **검색 이동**: 태그 클릭 시 검색 페이지로 이동 (`/search?tag=태그명`)
+- **스크롤**: 긴 목록 스크롤 가능 (스크롤바 숨김)
+- **반응형**: Active 상태 배경색 변경
+
+## 📦 의존성
+
+- `lucide-react`: 아이콘 (ChevronRight)
+- `next/navigation`: 라우팅
+- `@/lib/types/profile`: ProfileTag 타입
+
+## 🔗 관련 파일
+
+### 메인 컴포넌트
+
+- `page.tsx`: 전체 태그 페이지
+- `TagList.tsx`: 태그 목록 컴포넌트
+- `ProfileAllTagsHeaderActions.tsx`: 헤더 액션
+
+## 💡 스토리북 작성 팁
+
+### 재사용 가능한 컴포넌트만 포함
+
+- ✅ TagList (props를 받는 컴포넌트)
+- ❌ AllTagsPage (page.tsx)
+
+### 다양한 상태 테스트
+
+- Default, Empty, FewTags
+- DarkMode, LightMode
+- RecentTab, FrequentTab

--- a/frontend/src/app/(main)/profile/all-tags/_components/storybook/TagList.stories.tsx
+++ b/frontend/src/app/(main)/profile/all-tags/_components/storybook/TagList.stories.tsx
@@ -1,0 +1,175 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import TagList from '../TagList';
+import { ProfileTag } from '@/lib/types/profile';
+
+const meta = {
+  title: 'Profile/AllTags/TagList',
+  component: TagList,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof TagList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockTags: ProfileTag = {
+  recent: [
+    { name: '여행', count: 15 },
+    { name: '맛집', count: 12 },
+    { name: '카페', count: 10 },
+    { name: '친구', count: 8 },
+    { name: '운동', count: 7 },
+    { name: '독서', count: 5 },
+    { name: '영화', count: 4 },
+    { name: '공부', count: 3 },
+  ],
+  frequent: [
+    { name: '일상', count: 45 },
+    { name: '기록', count: 38 },
+    { name: '추억', count: 32 },
+    { name: '감사', count: 28 },
+    { name: '성장', count: 25 },
+    { name: '행복', count: 22 },
+    { name: '도전', count: 18 },
+    { name: '배움', count: 15 },
+  ],
+  all: [],
+};
+
+const fewTags: ProfileTag = {
+  recent: [
+    { name: '여행', count: 3 },
+    { name: '맛집', count: 2 },
+  ],
+  frequent: [
+    { name: '일상', count: 5 },
+    { name: '기록', count: 4 },
+  ],
+  all: [],
+};
+
+const emptyTags: ProfileTag = {
+  recent: [],
+  frequent: [],
+  all: [],
+};
+
+export const Default: Story = {
+  args: {
+    tags: mockTags,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '기본 태그 목록 - 최근 사용한 탭이 기본으로 선택됨',
+      },
+    },
+  },
+};
+
+export const RecentTab: Story = {
+  args: {
+    tags: mockTags,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '최근 사용한 태그 탭 - 시간순으로 정렬된 태그 표시',
+      },
+    },
+  },
+};
+
+export const FrequentTab: Story = {
+  args: {
+    tags: mockTags,
+    defaultTab: 'frequent',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '자주 사용한 태그 탭 - 사용 횟수가 많은 태그 표시',
+      },
+    },
+  },
+};
+
+export const FewTags: Story = {
+  args: {
+    tags: fewTags,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '태그가 적은 경우 - 각 탭에 2개씩만 표시',
+      },
+    },
+  },
+};
+
+export const EmptyTags: Story = {
+  args: {
+    tags: emptyTags,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '태그가 없는 경우 - 빈 목록 표시',
+      },
+    },
+  },
+};
+
+export const DarkMode: Story = {
+  args: {
+    tags: mockTags,
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        story: '다크 모드 - 어두운 배경의 태그 목록',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="dark">
+        <div className="min-h-screen bg-[#121212]">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};
+
+export const Interactive: Story = {
+  args: {
+    tags: mockTags,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+태그 목록 컴포넌트 기능:
+
+**탭 전환**
+- 최근 사용한: 시간순으로 정렬된 태그
+- 자주 사용한: 사용 횟수가 많은 순서로 정렬
+
+**태그 아이템**
+- # 기호와 태그명 표시
+- 우측에 사용 횟수 표시
+- 클릭 시 해당 태그로 검색 페이지 이동
+- Active 상태: 회색 배경 표시
+
+**스크롤**
+- 긴 목록은 스크롤 가능
+- 스크롤바 숨김 처리
+        `,
+      },
+    },
+  },
+};

--- a/frontend/src/app/(main)/profile/edit/_components/storybook/ProfileInfo.stories.tsx
+++ b/frontend/src/app/(main)/profile/edit/_components/storybook/ProfileInfo.stories.tsx
@@ -1,0 +1,213 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import ProfileInfo from '../../../../../../components/ProfileInfo';
+import ProfileEditProvider from '@/app/(main)/profile/edit/_components/ProfileEditContext';
+
+// Context Provider에 전달할 커스텀 args 타입
+type CustomArgs = {
+  profileImage: string;
+  showEmail?: boolean;
+  initialNickname?: string;
+  email?: string;
+};
+
+const meta: Meta<CustomArgs> = {
+  title: 'Profile/Edit/ProfileInfo',
+  component: ProfileInfo,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    profileImage: {
+      control: 'text',
+      description: '프로필 이미지 URL',
+    },
+    showEmail: {
+      control: 'boolean',
+      description: '이메일 표시 여부',
+    },
+    initialNickname: {
+      control: 'text',
+      description: 'Context에 전달되는 초기 닉네임',
+    },
+    email: {
+      control: 'text',
+      description: 'Context에 전달되는 이메일',
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      const customArgs = context.args as CustomArgs;
+      return (
+        <ProfileEditProvider
+          initialNickname={customArgs.initialNickname || '사용자'}
+          initialImage={customArgs.profileImage}
+          email={customArgs.email}
+        >
+          <div className="max-w-md mx-auto">
+            <Story />
+          </div>
+        </ProfileEditProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+type Story = StoryObj<CustomArgs>;
+
+export const Default: Story = {
+  args: {
+    profileImage: 'https://avatar.vercel.sh/user1',
+    showEmail: false,
+    initialNickname: '김이따',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '기본 프로필 수정 - 이미지와 닉네임 편집',
+      },
+    },
+  },
+};
+
+export const WithEmail: Story = {
+  args: {
+    profileImage: 'https://avatar.vercel.sh/user1',
+    showEmail: true,
+    initialNickname: '김이따',
+    email: 'user@example.com',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '이메일 표시 포함 - 이메일 필드는 수정 불가',
+      },
+    },
+  },
+};
+
+export const EmptyNickname: Story = {
+  args: {
+    profileImage: 'https://avatar.vercel.sh/user1',
+    showEmail: true,
+    initialNickname: '',
+    email: 'user@example.com',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '닉네임 미입력 상태 - 플레이스홀더 표시',
+      },
+    },
+  },
+};
+
+export const ShortNickname: Story = {
+  args: {
+    profileImage: 'https://avatar.vercel.sh/user1',
+    showEmail: true,
+    initialNickname: '김',
+    email: 'user@example.com',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '짧은 닉네임 (1자) - 에러 메시지 "닉네임은 최소 2자 이상이어야 합니다." 표시',
+      },
+    },
+  },
+};
+
+export const LongNickname: Story = {
+  args: {
+    profileImage: 'https://avatar.vercel.sh/user1',
+    showEmail: true,
+    initialNickname: '아주아주아주긴닉네임을가진사용자',
+    email: 'very.long.email.address@example.com',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '긴 닉네임 (10자 초과) - 에러 메시지 "닉네임은 최대 10자까지 입력 가능합니다." 표시',
+      },
+    },
+  },
+};
+
+export const DarkMode: Story = {
+  args: {
+    profileImage: 'https://avatar.vercel.sh/user1',
+    showEmail: true,
+    initialNickname: '김이따',
+    email: 'user@example.com',
+  },
+  parameters: {
+    backgrounds: { default: 'dark' },
+    docs: {
+      description: {
+        story: '다크 모드 - 어두운 배경의 프로필 편집',
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      const customArgs = context.args as CustomArgs;
+      return (
+        <ProfileEditProvider
+          initialNickname={customArgs.initialNickname || '사용자'}
+          initialImage={customArgs.profileImage}
+          email={customArgs.email}
+        >
+          <div className="dark">
+            <div className="max-w-md mx-auto p-5 bg-[#121212]">
+              <Story />
+            </div>
+          </div>
+        </ProfileEditProvider>
+      );
+    },
+  ],
+};
+
+export const Interactive: Story = {
+  args: {
+    profileImage: 'https://avatar.vercel.sh/user1',
+    showEmail: true,
+    initialNickname: '김이따',
+    email: 'user@example.com',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `
+프로필 편집 컴포넌트 기능:
+
+**프로필 이미지**
+- 카메라 아이콘 클릭으로 이미지 변경
+- 이미지 파일 선택 시 즉시 미리보기
+- Active 상태: 스케일 애니메이션
+
+**닉네임 편집**
+- 실시간 입력 가능
+- 입력 중 X 버튼으로 전체 삭제
+- 포커스 시 초록색 하단 보더 (정상), 빨간색 하단 보더 (에러)
+- 플레이스홀더: "사용할 닉네임을 입력해 주세요"
+- 안내 텍스트: "기억하고 싶은 이름으로 나를 표현해 보세요."
+
+**닉네임 유효성 검사**
+- 최소 2자 이상 (1자 이하: 에러)
+- 최대 10자 이하 (10자 초과: 에러)
+- 에러 시 빨간색 하단 보더 + 에러 메시지 표시
+
+**이메일 (선택적)**
+- showEmail prop으로 표시 여부 제어
+- 읽기 전용 (수정 불가)
+- 회색 배경으로 비활성 상태 표시
+        `,
+      },
+    },
+  },
+};

--- a/frontend/src/app/(main)/profile/edit/_components/storybook/README.md
+++ b/frontend/src/app/(main)/profile/edit/_components/storybook/README.md
@@ -1,0 +1,101 @@
+# 프로필 편집 컴포넌트 Storybook
+
+프로필 편집 페이지(`/profile/edit`)의 재사용 가능한 컴포넌트 스토리입니다.
+
+## 📚 포함된 스토리
+
+### ProfileInfo (프로필 정보 편집)
+
+- `Default`: 기본 프로필 편집 (이미지 + 닉네임)
+- `WithEmail`: 이메일 표시 포함
+- `EmptyNickname`: 닉네임 미입력 상태
+- `LongNickname`: 긴 닉네임과 이메일
+- `DarkMode`: 다크 모드
+- `Interactive`: 인터랙티브 기능 설명
+
+> **참고**: Page 컴포넌트(`page.tsx`)는 스토리북에 포함하지 않습니다. Page는 라우팅, 상태 관리 등 의존성이 많아 E2E 테스트가 더 적합합니다.
+
+## 🚀 실행 방법
+
+```bash
+# Storybook 실행
+pnpm run storybook
+
+# Storybook 빌드
+pnpm run build-storybook
+```
+
+Storybook은 `http://localhost:6006`에서 실행됩니다.
+
+## 🎨 주요 기능
+
+### ProfileInfo
+
+- **프로필 이미지 변경**:
+  - 카메라 아이콘 버튼
+  - 파일 선택 시 즉시 미리보기
+  - Active 상태 스케일 애니메이션
+- **닉네임 편집**:
+  - 실시간 입력
+  - X 버튼으로 전체 삭제
+  - 포커스 시 초록색 보더
+  - 플레이스홀더와 안내 텍스트
+- **이메일 표시 (선택적)**:
+  - `showEmail` prop으로 제어
+  - 읽기 전용
+  - 회색 배경 비활성 스타일
+
+## 📦 의존성
+
+- `lucide-react`: 아이콘 (Camera, X)
+- `next/image`: 이미지 최적화
+- `ProfileEditContext`: 프로필 편집 상태 관리
+  - `nickname`, `setNickname`
+  - `image`, `setImage`
+  - `email` (읽기 전용)
+
+## 🔗 관련 파일
+
+### 메인 컴포넌트
+
+- `ProfileInfo.tsx`: 프로필 정보 편집 컴포넌트
+- `ProfileEditContext.tsx`: 프로필 편집 Context Provider
+- `ProfileEditHeaderActions.tsx`: 헤더 액션 (취소/완료)
+
+### Page
+
+- `page.tsx`: 프로필 편집 페이지
+- `ProfileEditClient.tsx`: 클라이언트 컴포넌트
+
+## 💡 스토리북 작성 팁
+
+### Context Provider 사용
+
+ProfileInfo는 ProfileEditContext를 필요로 하므로, 모든 스토리에 decorator로 ProfileEditProvider를 감싸야 합니다.
+
+```tsx
+decorators: [
+  (Story, context) => (
+    <ProfileEditProvider
+      initialNickname={context.args.initialNickname || '사용자'}
+      initialImage={context.args.profileImage}
+      email={context.args.email}
+    >
+      <Story />
+    </ProfileEditProvider>
+  ),
+],
+```
+
+### 다양한 상태 테스트
+
+- Default, WithEmail, EmptyNickname
+- LongNickname (오버플로우 테스트)
+- DarkMode, LightMode
+
+### Props 전달
+
+- `profileImage`: 초기 프로필 이미지 URL
+- `showEmail`: 이메일 필드 표시 여부
+- `initialNickname`: 초기 닉네임 (Context에 전달)
+- `email`: 이메일 주소 (Context에 전달)

--- a/frontend/src/components/ProfileInfo.tsx
+++ b/frontend/src/components/ProfileInfo.tsx
@@ -28,6 +28,16 @@ export default function ProfileInfo({
     }
   };
 
+  // 닉네임 유효성 검사
+  const getNicknameError = () => {
+    if (nickname.length === 0) return null;
+    if (nickname.length < 2) return '닉네임은 최소 2자 이상이어야 합니다.';
+    if (nickname.length > 10) return '닉네임은 최대 10자까지 입력 가능합니다.';
+    return null;
+  };
+
+  const nicknameError = getNicknameError();
+
   return (
     <>
       <div className="py-8 flex flex-col gap-10">
@@ -68,7 +78,11 @@ export default function ProfileInfo({
                 type="text"
                 value={nickname}
                 onChange={(e) => setNickname(e.target.value)}
-                className="w-full border-b-2 bg-transparent px-1 py-4 text-sm font-semibold transition-all outline-none dark:border-white/5 dark:focus:border-[#10B981] dark:text-white dark:placeholder-gray-700 border-gray-100 focus:border-[#10B981] text-itta-black placeholder-gray-300"
+                className={`w-full border-b-2 bg-transparent px-1 py-4 text-sm font-semibold transition-all outline-none dark:text-white dark:placeholder-gray-700 text-itta-black placeholder-gray-300 ${
+                  nicknameError
+                    ? 'border-red-500 dark:border-red-500 focus:border-red-500 dark:focus:border-red-500'
+                    : 'dark:border-white/5 dark:focus:border-[#10B981] border-gray-100 focus:border-[#10B981]'
+                }`}
                 placeholder="사용할 닉네임을 입력해 주세요"
               />
               {nickname && (
@@ -80,9 +94,15 @@ export default function ProfileInfo({
                 </button>
               )}
             </div>
-            <p className="text-[10px] text-gray-400 px-1">
-              기억하고 싶은 이름으로 나를 표현해 보세요.
-            </p>
+            {nicknameError ? (
+              <p className="text-[10px] text-red-500 px-1 font-medium">
+                {nicknameError}
+              </p>
+            ) : (
+              <p className="text-[10px] text-gray-400 px-1">
+                기억하고 싶은 이름으로 나를 표현해 보세요.
+              </p>
+            )}
           </div>
 
           {showEmail && email && (


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- #81 

close #81 

## 작업 내용 + 스크린샷

- 홈 페이지, 마이페이지 스토리북으로 컴포넌트 테스트 추가
- 마이페이지 내부 태그 전체 보기 페이지, 감정 전체 보기 페이지도 적용되어 있습니다.

## 실제 걸린 시간

- 2h

## 작업하며 고민했던 점(선택)

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

`pnpm run storybook` 명령어 입력시 스토리북 브라우저가 열립니다.
스토리북은 `6006` 포트로 열립니다.

## 시각 자료(이미지/영상, 있다면)(선택)

<img width="1432" height="831" alt="image" src="https://github.com/user-attachments/assets/ffdb1d2d-b2df-4af7-a33c-71749edc044e" />

