### PR TITLE
엑세스 토큰이 메모리에 저장되지 않던 문제 수정

### DIFF
--- a/frontend/src/app/(login)/oauth/callback/page.tsx
+++ b/frontend/src/app/(login)/oauth/callback/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import AuthLoadingScreen from '@/components/AuthLoadingScreen';
 import LoginContent from '../../login/_components/LoginContent';
+import { setAccessToken } from '@/lib/api/auth';
 
 export default function OAuthCallbackPage() {
   const router = useRouter();
@@ -34,6 +35,14 @@ export default function OAuthCallbackPage() {
 
         if (!response.ok) {
           throw new Error('OAuth callback failed');
+        }
+
+        const token = response.headers
+          .get('Authorization')
+          ?.replace('Bearer ', '');
+
+        if (token) {
+          setAccessToken(token);
         }
 
         const data = await response.json();

--- a/frontend/src/lib/api/api.ts
+++ b/frontend/src/lib/api/api.ts
@@ -75,7 +75,7 @@ async function fetchWithRetry<T>(
     // 토큰 만료 에러 처리 (인터셉터 역할)
     if (
       !data.success &&
-      data.error?.code === 'TOKEN_EXPIRED' &&
+      data.error?.code === 'UNAUTHORIZED' &&
       !skipAuth &&
       !url.includes('/auth/reissue') // 재발급 API는 제외
     ) {


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- body에서 header로 accessToken 전달 방식이 바뀌면서 토큰 재발급시의 accessToken 저장 로직을 수정하지 않은 문제
- 로그인 후 accessToken 메모리에 저장
- 서버에 accessToken 재발급 예외 발생시 refreshToken을 쿠키에서 제거하는 로직 추가

## 작업 내용 + 스크린샷

## 실제 걸린 시간

## 작업하며 고민했던 점(선택)

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
