### PR TITLE
스토리지 이미지 요청 로직 포함 에셋 이미지 컴포넌트 추가

### DIFF
--- a/frontend/src/components/AssetImage.tsx
+++ b/frontend/src/components/AssetImage.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import Image, { ImageProps } from 'next/image';
+import { ImageIcon, Loader2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useApiQuery } from '@/hooks/useApi';
+
+interface AssetUrlResponse {
+  url: string;
+}
+
+interface AssetImageProps extends Omit<ImageProps, 'src'> {
+  assetId: string;
+  fallback?: React.ReactNode;
+}
+
+export default function AssetImage({
+  assetId,
+  alt,
+  className,
+  fallback,
+  ...props
+}: AssetImageProps) {
+  const { data, isLoading, isError } = useApiQuery<AssetUrlResponse>(
+    ['asset', assetId],
+    `/api/assets/${assetId}`,
+    {
+      enabled: !!assetId,
+      staleTime: 1000 * 60 * 60, // 1시간 동안 fresh
+      gcTime: 1000 * 60 * 60 * 24, // 24시간 동안 캐시 유지
+    },
+  );
+
+  if (isLoading) {
+    return (
+      <div
+        className={cn(
+          'flex items-center justify-center bg-gray-100 dark:bg-gray-800',
+          className,
+        )}
+      >
+        <Loader2 className="w-6 h-6 text-gray-400 animate-spin" />
+      </div>
+    );
+  }
+
+  if (isError || !data?.url) {
+    if (fallback) {
+      return <>{fallback}</>;
+    }
+
+    return (
+      <div
+        className={cn(
+          'flex items-center justify-center bg-gray-100 dark:bg-gray-800',
+          className,
+        )}
+      >
+        <ImageIcon className="w-6 h-6 text-gray-400" />
+      </div>
+    );
+  }
+
+  return <Image src={data.url} alt={alt} className={className} {...props} />;
+}


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- #115 

Close #115 

## 작업 내용 + 스크린샷

- 에셋 요청 컴포넌트 추가

## 실제 걸린 시간

0.5h

## 작업하며 고민했던 점

에셋을 요청할 때 매번 서버 요청 로직을 작성하기보단, 에셋 이미지 컴포넌트를 만들어 각각의 이미지가 로딩되도록 하는게 좋을 것 같아 컴포넌트로 만들었습니다.

이미지는 자주 바뀌지 않는 값이고, 더는 사용되지 않는다고 해도 해당 assetId를 요청하지 않는다면 캐싱된 데이터는 사용하지 않게 되기에 24시간 동안 캐싱되도록 설정했습니다.
`assetId`가 같은 이미지 요청시 캐시된 이미지 데이터를 내려주기에 네트워크 요청 횟수를 줄일 수 있습니다.

> 사용된 api 요청 url과 응답 타입은 임시로 만든 것입니다.

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [x] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
