### PR TITLE
초대 코드 페이지 -> 로그인 후 자동 그룹 가입되는 로직 추가

### DIFF
--- a/frontend/src/app/(invite)/_utils/handleInviteError.ts
+++ b/frontend/src/app/(invite)/_utils/handleInviteError.ts
@@ -1,0 +1,39 @@
+//import { toast } from 'sonner';
+
+export const INVITE_ERROR_POLICY = {
+  INVITE_CODE_EXPIRED: {
+    message: '만료된 초대 코드입니다. 다시 요청해주세요.',
+    path: '/',
+    action: 'replace',
+  },
+  BAD_REQUEST: {
+    message: '이미 이 그룹의 멤버입니다.',
+    path: '/shared',
+  },
+  GROUP_FULL: {
+    message: '그룹 인원이 가득 차서 참여할 수 없습니다.',
+    path: null,
+  },
+} as const;
+
+export const handleInviteError = (error: unknown) => {
+  const apiError = error as {
+    code?: string;
+    data?: { code?: string; message?: string };
+    message?: string;
+  };
+
+  const errorCode = apiError.code ?? apiError.data?.code;
+  const policy =
+    errorCode && errorCode in INVITE_ERROR_POLICY
+      ? INVITE_ERROR_POLICY[errorCode as keyof typeof INVITE_ERROR_POLICY]
+      : null;
+
+  if (policy) {
+    //toast.error(policy.message);
+
+    if (policy.path) {
+      return policy.path;
+    }
+  }
+};

--- a/frontend/src/hooks/useGroupInvite.ts
+++ b/frontend/src/hooks/useGroupInvite.ts
@@ -1,13 +1,8 @@
-import { GroupRoleType } from '@/lib/types/group';
 import { useApiPost } from './useApi';
 import { useQuery } from '@tanstack/react-query';
 import { post } from '@/lib/api/api';
 import { createApiError } from '@/lib/utils/errorHandler';
-
-export interface InviteRequest {
-  permission: GroupRoleType;
-  expiresInSeconds: number;
-}
+import { InviteJoinResponse } from '@/lib/types/groupResponse';
 
 export interface InviteResponse {
   inviteId: string;
@@ -56,5 +51,5 @@ export const useCreateInviteCode = (
  */
 export const useJoinGroup = (code: string) => {
   //TODO: 임시 Response 이후 확정나면 수정
-  return useApiPost<InviteResponse>(`/api/groups/invites/${code}/join`);
+  return useApiPost<InviteJoinResponse>(`/api/groups/invites/${code}/join`);
 };

--- a/frontend/src/lib/types/groupResponse.ts
+++ b/frontend/src/lib/types/groupResponse.ts
@@ -48,3 +48,45 @@ export interface GroupEditResponse {
   me: GroupMember;
   members: GroupMember[];
 }
+
+/**
+ * -------- 아래 3개는 초대코드를 통한 유저 가입 후 반환되는 응답 객체들 중 일부 -------
+ */
+//그룹 정보
+export interface GroupInfo {
+  id: string;
+  name: string;
+  coverMediaId: string | null;
+  coverSourcePostId: string | null;
+  lastActivityAt: string | null;
+  createdAt: string;
+}
+
+// 유저 상세 정보
+export interface UserInfo {
+  id: string;
+  email: string | null;
+  nickname: string;
+  provider: string; // 'kakao' | 'google'
+  providerId: string;
+  profileImageId: string | null;
+  settings: Record<string, unknown>;
+  createdAt: string;
+  deletedAt: string | null;
+}
+
+/**
+ * 초대 코드로 가입 시 반환되는 데이터
+ **/
+export interface InviteJoinResponse {
+  id: string;
+  groupId: string;
+  userId: string;
+  group: GroupInfo;
+  user: UserInfo;
+  role: GroupRoleType;
+  nicknameInGroup: string;
+  profileMediaId: string | null;
+  lastReadAt: string | null;
+  joinedAt: string;
+}


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)
- #84 

## 작업 내용 + 스크린샷
- 게스트 가입/Oauth 콜백 후 쿠키 조회 -> 그룹 가입 로직 추가
- 에러별 간단한 route 처리를 위해 전역 에러 핸들러 추가

지금 내부적인 구조가 기존에 로그인 한 유저 판별을 useAuthStore 에서 정보를 가져온 후에 판별하고 있습니다.
따라서 마이페이지 관련 유저 조회 api 가 연결되면 로그인된 상태에서 바로 그룹 가입을 진행할 수 있는지 알 수 있을 것 같아요!

### 그래서 현재 검증한 것은(가능한 것은)
> 로그인한적없는 유저가 invitecode 가 있는 URL 을 통해 들어오게 되었을 때
> `invite 페이지 -> 로그인 -> 자동 가입`

위 흐름이 제대로 흘러가는지 검증했습니다! (Oauth 유저로 로그인 후 가입되는 거 확인 완료한 상태!)

## 실제 걸린 시간
2h

## 작업하며 고민했던 점(선택)

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [x] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
