### PR TITLE
vercel 세션 업데이트시 DDos 공격 감지로 인한 ip 접근 차단

### DIFF
--- a/frontend/src/app/AuthContext.tsx
+++ b/frontend/src/app/AuthContext.tsx
@@ -25,27 +25,19 @@ function SessionGuard({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    if (session?.error || status === 'unauthenticated') {
-      logout();
-      signOut({ redirectTo: '/login' });
-    }
-
+    // 로딩 중에는 아무것도 하지 않음
     if (status === 'loading') return;
 
-    if (status === 'unauthenticated') {
-      // 게스트 유저 타입이 아닐 때만 로그인 페이지로 리다이렉트
-      if (userType !== 'guest') {
-        router.replace('/login');
-      }
-    }
+    // 세션 에러 또는 소셜 유저가 인증 실패한 경우에만 로그아웃 처리
+    const hasSessionError = session?.error;
+    const isUnauthenticated = status === 'unauthenticated';
+    const isSocialUser = userType === 'social';
 
-    // 토큰 에러 또는 인증 만료 시 로그아웃 처리
-    const isUnauthenticated = !session || session.error;
-
-    // 로그인이 필요한 상태인데 세션이 없는 경우 (로그인 유저 타입 체크)
-    if (isUnauthenticated && userType === 'social') {
+    // 소셜 유저가 인증 실패한 경우에만 처리 (게스트는 제외)
+    if ((hasSessionError || isUnauthenticated) && isSocialUser) {
       logout();
       signOut({ redirectTo: '/login' });
+      return; // 조기 종료로 중복 실행 방지
     }
   }, [status, userType, logout, router, pathname, session]);
 

--- a/frontend/src/app/AuthContext.tsx
+++ b/frontend/src/app/AuthContext.tsx
@@ -39,7 +39,7 @@ function SessionGuard({ children }: { children: React.ReactNode }) {
       signOut({ redirectTo: '/login' });
       return; // 조기 종료로 중복 실행 방지
     }
-  }, [status, userType, logout, router, pathname, session]);
+  }, [status, session, pathname]);
 
   return <>{children}</>;
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 
 // 인증 없이 접근 가능한 경로
-const PUBLIC_PATHS = ['/login', '/oauth/callback'];
+const PUBLIC_PATHS = ['/login', '/oauth/callback', '/invite'];
 
 export default auth((req) => {
   const { nextUrl, auth: session, cookies } = req;
@@ -17,21 +17,21 @@ export default auth((req) => {
   // 초대 코드는 URL 파라미터에서 직접 확인
   const hasInviteCode = !!nextUrl.searchParams.get('inviteCode');
 
+  // 로그인 페이지 처리 (로그인된 유저는 홈으로, 아니면 접근 허용)
   if (nextUrl.pathname === '/login') {
+    if (isSocialLoggedIn) {
+      return NextResponse.redirect(new URL('/', nextUrl));
+    }
     return NextResponse.next();
   }
 
-  // 로그인된 유저가 로그인 페이지 접근 시 홈으로
-  if (nextUrl.pathname === '/login' && isSocialLoggedIn) {
-    return NextResponse.redirect(new URL('/', nextUrl));
-  }
-
+  // 초대 링크 처리
   if (nextUrl.pathname.startsWith('/invite') && hasInviteCode) {
     return NextResponse.next();
   }
 
-  //  로그인 안 했고, 공개 경로도 아니고, 초대 코드도 없으면 로그인으로
-  if (!isLoggedIn && !isPublicPath && !hasInviteCode && !isGuestLoggedIn) {
+  // 로그인 안 했고, 공개 경로도 아니고, 초대 코드도 없으면 로그인으로
+  if (!isLoggedIn && !isPublicPath && !hasInviteCode) {
     const loginUrl = new URL('/login', nextUrl);
     // 원래 가려던 주소를 저장해두면 로그인 후 되돌려보낼 때 유용
     loginUrl.searchParams.set('callbackUrl', nextUrl.pathname);


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)
- #197 

<br />

- 로그아웃/탈퇴 요청 후 3개의 세션 중복 체크를 1개로 통합
- early return 추가로 중복 실행 방지
- 세션 로딩 중에는 세션 체크하지 않도록 수정

Close #197

## 작업 내용 + 스크린샷

vercel dashboard를 통해서 확인해본 결과, 엄청나 수의 요청이 vercel로 들어왔고,
이를 vercel이 DDos 공격으로 판단해 해당 캠퍼의 ip를 차단한 문제.

인증과 관련된 파일 중 가장 유력한 후보인 middleware와 sessionProvider 부분을 살펴봤습니다.
각각을 봤을 때는 큰 문제는 없어보였는데, 두 파일을 함께 처리 흐름을 생각하며 따라갔더니 문제가 발생함을 파악했습니다.

### 문제점

로그아웃/탈퇴 후 무한 요청이 발생한 원인은 AuthContext와 middleware 간의 타이밍 경쟁 조건이었습니다.
먼저, `AuthContext` 의 중복된 세션 체크로 인해 총 3번의 리다이렉트를 시도합니다.
```typescript
// AuthContext.tsx
// 첫 번째 체크
if (session?.error || status === 'unauthenticated') {
  logout();
  signOut({ redirectTo: '/login' });
}

// 두 번째 체크
if (status === 'unauthenticated') {
  if (userType !== 'guest') {
    router.replace('/login');
  }
}

// 세 번째 체크
const isUnauthenticated = !session || session.error;
if (isUnauthenticated && userType === 'social') {
  logout();
  signOut({ redirectTo: '/login' });
}
```
- `status === 'unauthenticated'` 일 때 3가지 블록이 모두 실행
- `signOut({ redirectTo: '/login' })` 2번 + `router.replace('/login')` 1번 = 총 3번의 리다이렉트를 시도
- early return이 없어서 한 번의 useEffect 실행에 모든 로직이 순차적으로 실행됨

signOut의 redirectTo가 있으니 알아서 return 되겠다 싶었어요.
그래서 굳이 early return을 추가해주지 않았던 건데, 이 부분이 문제가 된 것 같습니다.

### 문제 시나리오
```
1. 사용자가 로그아웃 버튼 클릭
   ↓
2. 세션이 삭제됨 → status = 'unauthenticated'
   ↓
3. AuthContext useEffect 트리거
   ↓
4. 첫 번째 체크: logout() + signOut({ redirectTo: '/login' }) 실행
   ↓ (early return 없음)
   ↓
5. 두 번째 체크: router.replace('/login') 실행
   ↓ (early return 없음)
   ↓
6. 세 번째 체크: logout() + signOut({ redirectTo: '/login' }) 또 실행
   ↓
7. 총 3번의 리다이렉트 시도 → /login으로 이동
   ↓
8. middleware가 /login 요청을 받음
   ↓
9. middleware가 session 체크 → unauthenticated
   ↓
10. middleware가 NextResponse.next() 반환
   ↓
11. 페이지 로드 시 AuthContext가 다시 마운트됨
   ↓
12. useEffect가 다시 실행됨
   ↓
13. status가 여전히 'unauthenticated'
   ↓
14. 다시 3번부터 반복...
```

### 개선 및 해결법

위의 문제점을 

- 3개의 중복 체크 로직을 1개로 통합
- early return을 추가해 중복 실행 방지

으로 개선했습니다.

### 이 문제가 가끔 발생하던 이유

저는 잘 돌아갔는데, 앤프와 다른 캠퍼에게서 발생하는 문제였죠.
이건 타이밍과 관련이 있는 문제이기 때문인데, 브라우저의 상태와 네트워크 속도, React 렌더링 타이밍에 따라 달라지기 때문이에요.

- 빠른 네트워크 환경에선 `/login` 리다이렉트가 빠르게 완료되어서 루프가 짧게 끝남
- 느린 네트워크 환경에선 리다이렉트 중에 `useEffect` 가 여러 번 실행되면서 요청이 누적됨

네트워크 환경만을 본다면 위의 경우로 나뉘어요.
네트워크 문제만은 아닐테고, 여러 복합적인 요인이 섞여서 타이밍 이슈가 발생한 것 같아요.

추가로 기존 코드 + useEffect 의존성 배열로 세션, zustand 상태 등을 넣었는데, 
로그아웃 시:
- session 변경 → useEffect 실행 → logout() 호출
- logout()이 userType 변경 → useEffect 다시 실행
- signOut()이 status 변경 → useEffect 또 실행
- 의존성이 계속 변경되면서 연쇄 실행 발생

이런 연쇄 반응으로 인해서도 무한 요청이 발생할 수 있을 것 같았어요.
세션 상태랑 전역 상태 값을 의존성 배열에 넣어야 하긴 하는데, 기존 문제가 되는 코드와 함께 동작하면서 더 문제가 됐던 것 같아요.

### 수정 후 동작 시나리오
```
1. 사용자가 로그아웃 버튼 클릭
   ↓
2. 세션이 삭제됨 → status = 'unauthenticated'
   ↓
3. AuthContext useEffect 트리거
   ↓
4. status === 'loading' 체크 → false, 통과
   ↓
5. isSocialUser === true && isUnauthenticated === true
   ↓
6. logout() + signOut({ redirectTo: '/login' }) 한 번만 실행
   ↓
7. return으로 즉시 종료 (추가 로직 실행 안 됨)
   ↓
8. /login으로 리다이렉트 (1번만)
   ↓
9. middleware가 /login 요청 받음 → NextResponse.next() 반환
   ↓
10. /login 페이지 로드
   ↓
11. 공개 경로이므로 AuthContext가 가드하지 않음
   ↓
12. 정상 종료
```

## 실제 걸린 시간

2h

## 작업하며 고민했던 점

저는 몇 번을 시도해도 무한 요청이 발생하지 않아서.. 
저의 추측을 토대로 문제가 발생할 가능성이 있는게 맞는지 AI에게 물어보면서 작업했습니다.

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
