### PR TITLE
그룹 권한/permission 및 검증·검색·OAuth 개선

### DIFF
--- a/backend/src/config/typeorm/typeorm.config.ts
+++ b/backend/src/config/typeorm/typeorm.config.ts
@@ -4,15 +4,18 @@ import { join } from 'path';
 
 export const getTypeOrmConfig = (
   configService: ConfigService,
-): TypeOrmModuleOptions => ({
-  type: 'postgres',
-  url: configService.get<string>('DATABASE_URL'),
-  entities: [join(__dirname, '../../**/*.entity.{ts,js}')],
-  migrations: [join(__dirname, '../../../migrations/*.{ts,js}')],
-  synchronize: process.env.NODE_ENV === 'test',
-  migrationsRun: false,
-  logging:
-    configService.get<string>('NODE_ENV') === 'production'
-      ? ['error', 'warn']
-      : ['error', 'warn', 'migration', 'info', 'log'],
-});
+): TypeOrmModuleOptions => {
+  const nodeEnv = configService.get<string>('NODE_ENV');
+  return {
+    type: 'postgres',
+    url: configService.get<string>('DATABASE_URL'),
+    entities: [join(__dirname, '../../**/*.entity.{ts,js}')],
+    migrations: [join(__dirname, '../../../migrations/*.{ts,js}')],
+    synchronize: false,
+    migrationsRun: false,
+    logging:
+      nodeEnv === 'production'
+        ? ['error', 'warn']
+        : ['error', 'warn', 'migration', 'info', 'log'],
+  };
+};

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -27,6 +27,7 @@ import { ApiWrappedOkResponse } from '@/common/swagger/api-wrapped-response.deco
 
 import type { Request, Response } from 'express';
 import type { OAuthUserType } from './auth.type';
+import { KakaoAuthGuard } from './guards/kakao-auth.guard';
 import { DevTokenRequestDto } from './dto/dev-token.dto';
 
 interface AuthenticatedRequest extends Request {
@@ -88,7 +89,7 @@ export class AuthController {
   }
 
   @Get('kakao')
-  @UseGuards(AuthGuard('kakao'))
+  @UseGuards(KakaoAuthGuard)
   @ApiOperation({
     summary: 'Kakao 로그인',
     description: 'Kakao OAuth2 로그인 페이지로 리다이렉트합니다.',
@@ -96,7 +97,7 @@ export class AuthController {
   async kakaoLogin() {}
 
   @Get('kakao/callback')
-  @UseGuards(AuthGuard('kakao'))
+  @UseGuards(KakaoAuthGuard)
   @ApiOperation({
     summary: 'Kakao 로그인 콜백',
     description: 'Kakao 인증 완료 후 호출되며, FE로 리다이렉트합니다.',

--- a/backend/src/modules/auth/guards/kakao-auth.guard.ts
+++ b/backend/src/modules/auth/guards/kakao-auth.guard.ts
@@ -5,7 +5,7 @@ import { AuthGuard } from '@nestjs/passport';
 export class KakaoAuthGuard extends AuthGuard('kakao') {
   getAuthenticateOptions() {
     return {
-      scope: ['profile_nickname'],
+      scope: ['profile_nickname', 'account_email'],
     };
   }
 }

--- a/backend/src/modules/auth/guards/kakao-auth.guard.ts
+++ b/backend/src/modules/auth/guards/kakao-auth.guard.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class KakaoAuthGuard extends AuthGuard('kakao') {
+  getAuthenticateOptions() {
+    return {
+      scope: ['profile_nickname'],
+    };
+  }
+}

--- a/backend/src/modules/feed/dto/feed-card.response.dto.ts
+++ b/backend/src/modules/feed/dto/feed-card.response.dto.ts
@@ -98,6 +98,11 @@ export class FeedCardResponseDto {
   blocks: FeedBlockDto[];
   @ApiProperty({ type: () => [FeedContributorDto] })
   contributors: FeedContributorDto[];
+  @ApiProperty({
+    description: '요청자 기준 권한 정보',
+    example: 'EDITOR',
+  })
+  permission: 'ADMIN' | 'EDITOR' | 'VIEWER' | 'OWNER' | null;
   constructor(init: FeedCardResponseDto) {
     Object.assign(this, init);
   }

--- a/backend/src/modules/feed/feed.controller.ts
+++ b/backend/src/modules/feed/feed.controller.ts
@@ -93,14 +93,20 @@ export class FeedController {
   @ApiParam({ name: 'groupId', description: '그룹 ID' })
   @ApiFeedOkResponse()
   async getGroupFeed(
+    @User() user: MyJwtPayload,
     @Param('groupId') groupId: string,
     @Query() query: GetFeedQueryDto,
   ): Promise<{
     data: FeedCardResponseDto[];
     meta: { warnings: unknown[]; feedLength: number };
   }> {
+    const userId = user?.sub;
+    if (!userId) {
+      throw new UnauthorizedException('Access token is required.');
+    }
     const { cards, warnings } = await this.feedGroupQuery.getGroupFeed(
       groupId,
+      userId,
       query,
     );
     return { data: cards, meta: { warnings, feedLength: cards.length } };

--- a/backend/src/modules/feed/feed.group.query.service.ts
+++ b/backend/src/modules/feed/feed.group.query.service.ts
@@ -26,7 +26,7 @@ export class FeedGroupQueryService {
     private readonly groupMemberRepo: Repository<GroupMember>,
   ) {}
 
-  async getGroupFeed(groupId: string, query: GetFeedQueryDto) {
+  async getGroupFeed(groupId: string, userId: string, query: GetFeedQueryDto) {
     const { from, to } = dayRange(query.date, query.tz ?? 'Asia/Seoul');
 
     const postsQb = this.postRepo.createQueryBuilder('p');
@@ -38,6 +38,7 @@ export class FeedGroupQueryService {
     postsQb.select([
       'p.id',
       'p.groupId',
+      'p.ownerUserId',
       'p.eventAt',
       'p.createdAt',
       'p.updatedAt',
@@ -54,6 +55,7 @@ export class FeedGroupQueryService {
       this.postContributorRepo,
       this.groupMemberRepo,
       this.logger,
+      userId,
     );
   }
 }

--- a/backend/src/modules/feed/feed.personal.query.service.ts
+++ b/backend/src/modules/feed/feed.personal.query.service.ts
@@ -38,6 +38,7 @@ export class FeedPersonalQueryService {
     postsQb.select([
       'p.id',
       'p.groupId',
+      'p.ownerUserId',
       'p.eventAt',
       'p.createdAt',
       'p.updatedAt',
@@ -54,6 +55,7 @@ export class FeedPersonalQueryService {
       this.postContributorRepo,
       this.groupMemberRepo,
       this.logger,
+      userId,
     );
   }
 }

--- a/backend/src/modules/feed/feed.query.service.ts
+++ b/backend/src/modules/feed/feed.query.service.ts
@@ -65,6 +65,7 @@ export class FeedQueryService {
     postsQb.select([
       'p.id',
       'p.groupId',
+      'p.ownerUserId',
       'p.eventAt',
       'p.createdAt',
       'p.updatedAt',
@@ -83,6 +84,7 @@ export class FeedQueryService {
       this.postContributorRepo,
       this.groupMemberRepo,
       this.logger,
+      userId,
     );
   }
 }

--- a/backend/src/modules/group/controller/group-management.controller.ts
+++ b/backend/src/modules/group/controller/group-management.controller.ts
@@ -75,8 +75,8 @@ export class GroupManagementController {
       properties: {
         role: {
           type: 'string',
-          enum: [GroupRoleEnum.ADMIN, GroupRoleEnum.EDITOR],
-          example: GroupRoleEnum.EDITOR,
+          enum: GroupRoleEnum,
+          example: GroupRoleEnum.VIEWER,
         },
       },
     },

--- a/backend/src/modules/group/controller/group-management.controller.ts
+++ b/backend/src/modules/group/controller/group-management.controller.ts
@@ -22,6 +22,7 @@ import { GetGroupSettingsResponseDto } from '../dto/get-group-settings.dto';
 import { GetGroupMembersResponseDto } from '../dto/get-group-members.dto';
 import { GetGroupMemberMeResponseDto } from '../dto/get-group-member-me.dto';
 import { UpdateGroupMemberMeDto } from '../dto/update-group-member-me.dto';
+import { GetGroupPermissionResponseDto } from '../dto/get-group-permission.dto';
 import { User } from '@/common/decorators/user.decorator';
 import type { MyJwtPayload } from '../../auth/auth.type';
 import { GroupRoleEnum } from '@/enums/group-role.enum';
@@ -151,6 +152,20 @@ export class GroupManagementController {
     @Param('groupId') groupId: string,
   ): Promise<GetGroupMemberMeResponseDto> {
     return this.groupManagementService.getGroupMemberMe(user.sub, groupId);
+  }
+
+  @Get(':groupId/members/me/role')
+  @ApiOperation({
+    summary: '그룹 내 내 권한(role) 조회',
+    description: '특정 그룹에서의 내 권한(role)만 조회합니다.',
+  })
+  @ApiParam({ name: 'groupId', description: '그룹 ID' })
+  @ApiWrappedOkResponse({ type: GetGroupPermissionResponseDto })
+  async getGroupPermission(
+    @User() user: MyJwtPayload,
+    @Param('groupId') groupId: string,
+  ): Promise<GetGroupPermissionResponseDto> {
+    return this.groupManagementService.getGroupPermission(user.sub, groupId);
   }
 
   @UseGuards(GroupRoleGuard)

--- a/backend/src/modules/group/controller/group-management.controller.ts
+++ b/backend/src/modules/group/controller/group-management.controller.ts
@@ -75,7 +75,7 @@ export class GroupManagementController {
       properties: {
         role: {
           type: 'string',
-          enum: GroupRoleEnum,
+          enum: Object.values(GroupRoleEnum),
           example: GroupRoleEnum.VIEWER,
         },
       },

--- a/backend/src/modules/group/dto/get-group-permission.dto.ts
+++ b/backend/src/modules/group/dto/get-group-permission.dto.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { GroupRoleEnum } from '@/enums/group-role.enum';
+
+export class GetGroupPermissionResponseDto {
+  @ApiProperty({ enum: GroupRoleEnum })
+  role: GroupRoleEnum;
+}

--- a/backend/src/modules/group/dto/get-groups.dto.ts
+++ b/backend/src/modules/group/dto/get-groups.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { GroupRoleEnum } from '@/enums/group-role.enum';
 
 export class GroupCoverDto {
   @ApiProperty({ description: '커버 이미지 Asset ID' })
@@ -60,6 +61,9 @@ export class GroupItemDto {
     nullable: true,
   })
   latestPost: GroupLatestPostDto | null;
+
+  @ApiProperty({ description: '내 권한', enum: GroupRoleEnum, nullable: true })
+  permission: GroupRoleEnum | null;
 }
 
 export class GetGroupsResponseDto {

--- a/backend/src/modules/group/service/group-management.service.ts
+++ b/backend/src/modules/group/service/group-management.service.ts
@@ -22,6 +22,7 @@ import { UpdateGroupCoverResponseDto } from '../dto/update-group-cover.dto';
 import { GetGroupSettingsResponseDto } from '../dto/get-group-settings.dto';
 import { GetGroupMemberMeResponseDto } from '../dto/get-group-member-me.dto';
 import { UpdateGroupMemberMeDto } from '../dto/update-group-member-me.dto';
+import { GetGroupPermissionResponseDto } from '../dto/get-group-permission.dto';
 import {
   GetGroupCoverCandidatesQueryDto,
   GetGroupCoverCandidatesResponseDto,
@@ -393,6 +394,27 @@ export class GroupManagementService {
       role: member.role,
       updatedAt: member.updatedAt,
     };
+  }
+
+  /** 그룹 내 내 권한(role)만 조회 */
+  async getGroupPermission(
+    userId: string,
+    groupId: string,
+  ): Promise<GetGroupPermissionResponseDto> {
+    const member = await this.groupMemberRepo.findOne({
+      where: { groupId, userId },
+      select: { role: true },
+    });
+    if (!member) {
+      const groupExists = await this.groupRepo.exists({
+        where: { id: groupId },
+      });
+      if (!groupExists) {
+        throw new NotFoundException('존재하지 않는 그룹입니다.');
+      }
+      throw new ForbiddenException('그룹 멤버가 아닙니다.');
+    }
+    return { role: member.role };
   }
 
   /** 그룹 내 내 설정 정보 수정 */

--- a/backend/src/modules/group/service/group.service.ts
+++ b/backend/src/modules/group/service/group.service.ts
@@ -120,7 +120,7 @@ export class GroupService {
   async getGroups(userId: string): Promise<GetGroupsResponseDto> {
     const members = await this.groupMemberRepo.find({
       where: { userId },
-      select: ['groupId'],
+      select: ['groupId', 'role'],
     });
 
     if (members.length === 0) {
@@ -128,6 +128,7 @@ export class GroupService {
     }
 
     const groupIds = members.map((m) => m.groupId);
+    const roleByGroupId = new Map(members.map((m) => [m.groupId, m.role]));
 
     // 1. Batch: 그룹 정보 조회
     const groups = await this.groupRepo
@@ -145,9 +146,11 @@ export class GroupService {
     // 2. Batch: 그룹별 멤버 수 집계
     const memberCounts = await this.groupMemberRepo
       .createQueryBuilder('gm')
+      .innerJoin('gm.user', 'u')
       .select('gm.groupId', 'groupId')
       .addSelect('COUNT(gm.id)', 'count')
       .where('gm.groupId IN (:...groupIds)', { groupIds })
+      .andWhere('u.deletedAt IS NULL')
       .groupBy('gm.groupId')
       .getRawMany<{ groupId: string; count: string }>();
 
@@ -224,6 +227,7 @@ export class GroupService {
               placeName: null,
             }
           : null,
+        permission: roleByGroupId.get(groupId) ?? null,
       });
     }
 

--- a/backend/src/modules/group/service/group.service.ts
+++ b/backend/src/modules/group/service/group.service.ts
@@ -118,10 +118,13 @@ export class GroupService {
 
   /** 그룹 목록 조회 (최신 활동 순) - N+1 최적화 */
   async getGroups(userId: string): Promise<GetGroupsResponseDto> {
-    const members = await this.groupMemberRepo.find({
-      where: { userId },
-      select: ['groupId', 'role'],
-    });
+    const members = await this.groupMemberRepo
+      .createQueryBuilder('gm')
+      .innerJoin('gm.user', 'u')
+      .select(['gm.groupId', 'gm.role'])
+      .where('gm.userId = :userId', { userId })
+      .andWhere('u.deletedAt IS NULL')
+      .getMany();
 
     if (members.length === 0) {
       return { items: [] };

--- a/backend/src/modules/post/collab/patch-stream.service.ts
+++ b/backend/src/modules/post/collab/patch-stream.service.ts
@@ -49,7 +49,13 @@ export class PatchStreamService {
     payload: PatchApplyPayload,
   ) {
     this.ensureNotPublishing(draftId);
-    if (!payload?.draftId || payload.draftId !== draftId) {
+    if (!payload) {
+      throw new WsException('payload is required.');
+    }
+    if (payload.draftId === undefined || payload.draftId === null) {
+      throw new WsException('draftId is required.');
+    }
+    if (payload.draftId !== draftId) {
       throw new WsException('draftId mismatch.');
     }
     if (typeof payload.baseVersion !== 'number') {

--- a/backend/src/modules/post/dto/create-post.dto.ts
+++ b/backend/src/modules/post/dto/create-post.dto.ts
@@ -3,6 +3,7 @@ import {
   IsOptional,
   IsString,
   MaxLength,
+  MinLength,
   ValidateNested,
   IsUUID,
   IsArray,
@@ -24,6 +25,7 @@ export class CreatePostDto {
 
   @ApiProperty({ example: 'string' })
   @IsString()
+  @MinLength(1)
   @MaxLength(200)
   title: string;
 

--- a/backend/src/modules/post/dto/edit-post.dto.ts
+++ b/backend/src/modules/post/dto/edit-post.dto.ts
@@ -2,6 +2,7 @@ import {
   IsArray,
   IsString,
   MaxLength,
+  MinLength,
   ValidateNested,
   IsOptional,
   IsUUID,
@@ -13,6 +14,7 @@ import { PostBlockDto } from './post-block.dto';
 export class EditPostDto {
   @ApiProperty({ example: 'string' })
   @IsString()
+  @MinLength(1)
   @MaxLength(200)
   title: string;
 

--- a/backend/src/modules/post/dto/post-detail.dto.ts
+++ b/backend/src/modules/post/dto/post-detail.dto.ts
@@ -46,4 +46,9 @@ export class PostDetailDto {
   blocks: PostBlockDto[];
   @ApiProperty({ type: () => [PostContributorDto] })
   contributors: PostContributorDto[];
+  @ApiProperty({
+    description: '요청자 기준 권한 정보',
+    example: 'EDITOR',
+  })
+  permission: 'ADMIN' | 'EDITOR' | 'VIEWER' | 'OWNER' | null;
 }

--- a/backend/src/modules/post/post-draft.controller.ts
+++ b/backend/src/modules/post/post-draft.controller.ts
@@ -147,7 +147,7 @@ export class PostDraftController {
       groupId,
       dto,
     );
-    return this.postService.findOne(postId);
+    return this.postService.findOne(postId, requesterId);
   }
 
   @Post('posts/:postId/edit/publish')
@@ -174,6 +174,6 @@ export class PostDraftController {
       postId,
       dto,
     );
-    return this.postService.findOne(updatedPostId);
+    return this.postService.findOne(updatedPostId, requesterId);
   }
 }

--- a/backend/src/modules/post/post-draft.gateway.ts
+++ b/backend/src/modules/post/post-draft.gateway.ts
@@ -275,7 +275,13 @@ export class PostDraftGateway
     @ConnectedSocket() socket: Socket,
   ) {
     const socketData = this.getSocketData(socket);
-    if (payload?.draftId && payload.draftId !== socketData.draftId) {
+    if (!payload) {
+      throw new WsException('payload is required.');
+    }
+    if (payload.draftId === undefined || payload.draftId === null) {
+      throw new WsException('draftId is required.');
+    }
+    if (payload.draftId !== socketData.draftId) {
       throw new WsException('draftId mismatch.');
     }
     this.leaveCurrentDraft(socket);
@@ -287,7 +293,13 @@ export class PostDraftGateway
     @ConnectedSocket() socket: Socket,
   ) {
     const socketData = this.getSocketData(socket);
-    if (payload?.draftId && payload.draftId !== socketData.draftId) {
+    if (!payload) {
+      throw new WsException('payload is required.');
+    }
+    if (payload.draftId === undefined || payload.draftId === null) {
+      throw new WsException('draftId is required.');
+    }
+    if (payload.draftId !== socketData.draftId) {
       throw new WsException('draftId mismatch.');
     }
     if (!socketData.draftId || !socketData.sessionId) {

--- a/backend/src/modules/post/post-draft.service.ts
+++ b/backend/src/modules/post/post-draft.service.ts
@@ -428,6 +428,28 @@ export class PostDraftService {
   }
 
   private ensureBlockValueValid(block: PostBlockDto) {
+    if (block.type === PostBlockType.MOOD) {
+      const mood = (block.value as { mood?: unknown } | undefined)?.mood;
+      if (mood === undefined || mood === null || mood === '') {
+        return;
+      }
+    }
+    if (block.type === PostBlockType.MEDIA) {
+      const media = block.value as
+        | { title?: unknown; type?: unknown; externalId?: unknown }
+        | undefined;
+      if (
+        !media ||
+        typeof media.title !== 'string' ||
+        media.title.trim().length === 0 ||
+        typeof media.type !== 'string' ||
+        media.type.trim().length === 0 ||
+        typeof media.externalId !== 'string' ||
+        media.externalId.trim().length === 0
+      ) {
+        return;
+      }
+    }
     const candidate = plainToInstance(PostBlockDto, block); // 일반 객체를 DTO 인스턴스로 변환하는 함수
     const errors = validateSync(candidate, { forbidUnknownValues: false }); // class-validator로 즉시(동기) 검증하는 함수
     if (errors.length === 0) return;

--- a/backend/src/modules/post/post-publish.service.ts
+++ b/backend/src/modules/post/post-publish.service.ts
@@ -29,6 +29,8 @@ import { PostContributorRole } from '@/enums/post-contributor-role.enum';
 import { PostBlockType } from '@/enums/post-block-type.enum';
 import { CreatePostDto } from './dto/create-post.dto';
 import { validateBlocks } from './validator/blocks.validator';
+import { validateBlockValues } from './validator/block-values.validator';
+import { validatePostTitle } from './validator/post-title.validator';
 import { BlockValueMap } from './types/post-block.types';
 import { extractMetaFromBlocks } from './validator/meta.extractor';
 import { resolveEventAtFromBlocks } from './validator/event-at.resolver';
@@ -104,7 +106,9 @@ export class PostPublishService {
           );
 
           const snapshotBlocks = snapshot.blocks;
+          validatePostTitle(snapshot.title);
           validateBlocks(snapshotBlocks);
+          validateBlockValues(snapshotBlocks);
           this.ensureBlockIds(snapshotBlocks);
           this.ensureNoDuplicateBlockIds(snapshotBlocks);
 
@@ -269,8 +273,10 @@ export class PostPublishService {
 
         const snapshot = this.parseGroupDraftSnapshot(draft.snapshot, groupId);
 
+        validatePostTitle(snapshot.title);
         const blocks = snapshot.blocks;
         validateBlocks(blocks);
+        validateBlockValues(blocks);
         this.ensureBlockIds(blocks);
         this.ensureNoDuplicateBlockIds(blocks);
 

--- a/backend/src/modules/post/post-publish.service.ts
+++ b/backend/src/modules/post/post-publish.service.ts
@@ -107,7 +107,9 @@ export class PostPublishService {
 
           const snapshotBlocks = snapshot.blocks;
           validatePostTitle(snapshot.title);
-          validateBlocks(snapshotBlocks);
+          validateBlocks(snapshotBlocks, {
+            layoutErrorMessage: 'Layout is invalid.',
+          });
           validateBlockValues(snapshotBlocks);
           this.ensureBlockIds(snapshotBlocks);
           this.ensureNoDuplicateBlockIds(snapshotBlocks);
@@ -275,7 +277,9 @@ export class PostPublishService {
 
         validatePostTitle(snapshot.title);
         const blocks = snapshot.blocks;
-        validateBlocks(blocks);
+        validateBlocks(blocks, {
+          layoutErrorMessage: 'Layout is invalid.',
+        });
         validateBlockValues(blocks);
         this.ensureBlockIds(blocks);
         this.ensureNoDuplicateBlockIds(blocks);

--- a/backend/src/modules/post/post.controller.ts
+++ b/backend/src/modules/post/post.controller.ts
@@ -63,7 +63,7 @@ export class PostController {
       throw new UnauthorizedException('Access token is required.');
     }
     await this.postService.ensureCanViewPost(id, requesterId);
-    return this.postService.findOne(id);
+    return this.postService.findOne(id, requesterId);
   }
 
   @Get(':postId/edit')

--- a/backend/src/modules/post/post.service.ts
+++ b/backend/src/modules/post/post.service.ts
@@ -26,6 +26,8 @@ import { PostBlockType } from '@/enums/post-block-type.enum';
 import { GroupRoleEnum } from '@/enums/group-role.enum';
 import { PostContributorRole } from '@/enums/post-contributor-role.enum';
 import { validateBlocks } from './validator/blocks.validator';
+import { validateBlockValues } from './validator/block-values.validator';
+import { validatePostTitle } from './validator/post-title.validator';
 import { BlockValueMap } from './types/post-block.types';
 import { extractMetaFromBlocks } from './validator/meta.extractor';
 import { resolveEventAtFromBlocks } from './validator/event-at.resolver';
@@ -57,7 +59,9 @@ export class PostService {
    */
   async createPost(ownerUserId: string, dto: CreatePostDto) {
     // 블록 검증 → 메타 추출 → eventAt 생성 순서로 선행 처리
+    validatePostTitle(dto.title);
     validateBlocks(dto.blocks);
+    validateBlockValues(dto.blocks);
 
     const owner = await this.userRepository.findOne({
       where: { id: ownerUserId },
@@ -388,7 +392,9 @@ export class PostService {
       }
     }
 
+    validatePostTitle(dto.title);
     validateBlocks(dto.blocks);
+    validateBlockValues(dto.blocks);
     this.ensureNoDuplicateBlockIds(dto.blocks);
 
     const meta = extractMetaFromBlocks(dto.blocks);

--- a/backend/src/modules/post/post.service.ts
+++ b/backend/src/modules/post/post.service.ts
@@ -500,8 +500,14 @@ export class PostService {
       if (member.role === GroupRoleEnum.VIEWER) {
         throw new ForbiddenException('Insufficient permission.');
       }
-    }
-    if (post.ownerUserId !== requesterId) {
+      const isAdmin = member.role === GroupRoleEnum.ADMIN;
+      const isOwner = post.ownerUserId === requesterId;
+      if (!isAdmin && !isOwner) {
+        throw new ForbiddenException(
+          'Only the owner or admin can delete this post',
+        );
+      }
+    } else if (post.ownerUserId !== requesterId) {
       throw new ForbiddenException('Only the owner can delete this post');
     }
     await this.postRepository.softDelete(postId);

--- a/backend/src/modules/post/validator/block-values.validator.ts
+++ b/backend/src/modules/post/validator/block-values.validator.ts
@@ -1,0 +1,105 @@
+import { BadRequestException } from '@nestjs/common';
+import { validateSync } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { PostBlockDto } from '../dto/post-block.dto';
+import { PostBlockType } from '@/enums/post-block-type.enum';
+
+export function validateBlockValues(blocks: PostBlockDto[]) {
+  for (const block of blocks) {
+    switch (block.type) {
+      case PostBlockType.DATE: {
+        const date = (block.value as { date?: unknown } | undefined)?.date;
+        if (typeof date !== 'string' || date.trim().length === 0) {
+          throw new BadRequestException('DATE.value.date is required.');
+        }
+        break;
+      }
+      case PostBlockType.TIME: {
+        const time = (block.value as { time?: unknown } | undefined)?.time;
+        if (typeof time !== 'string' || time.trim().length === 0) {
+          throw new BadRequestException('TIME.value.time is required.');
+        }
+        break;
+      }
+      case PostBlockType.TEXT: {
+        const text = (block.value as { text?: unknown } | undefined)?.text;
+        if (typeof text !== 'string' || text.trim().length === 0) {
+          throw new BadRequestException('TEXT.value.text is required.');
+        }
+        break;
+      }
+      case PostBlockType.TAG: {
+        const tags = (block.value as { tags?: unknown } | undefined)?.tags;
+        if (!Array.isArray(tags)) {
+          throw new BadRequestException('TAG.value.tags must be an array.');
+        }
+        const cleaned = tags
+          .filter((t) => typeof t === 'string')
+          .map((t) => t.trim())
+          .filter((t) => t.length > 0);
+        if (cleaned.length === 0) {
+          throw new BadRequestException('TAG.value.tags must not be empty.');
+        }
+        break;
+      }
+      case PostBlockType.IMAGE: {
+        const mediaIds = (block.value as { mediaIds?: unknown } | undefined)
+          ?.mediaIds;
+        if (!Array.isArray(mediaIds) || mediaIds.length === 0) {
+          throw new BadRequestException('IMAGE.mediaIds must not be empty.');
+        }
+        break;
+      }
+      case PostBlockType.TABLE: {
+        const value = block.value as
+          | { rows?: unknown; cols?: unknown; cells?: unknown }
+          | undefined;
+        const rows = value?.rows;
+        const cols = value?.cols;
+        if (
+          typeof rows !== 'number' ||
+          typeof cols !== 'number' ||
+          rows < 1 ||
+          cols < 1
+        ) {
+          throw new BadRequestException('TABLE.rows/cols must be >= 1.');
+        }
+        if (!Array.isArray(value?.cells)) {
+          throw new BadRequestException('TABLE.cells must be a 2D array.');
+        }
+        const cells = value?.cells as unknown[];
+        if (cells.length !== rows) {
+          throw new BadRequestException('TABLE.cells row count mismatch.');
+        }
+        let hasNonEmptyCell = false;
+        for (const row of cells) {
+          if (!Array.isArray(row) || row.length !== cols) {
+            throw new BadRequestException('TABLE.cells col count mismatch.');
+          }
+          for (const cell of row) {
+            if (typeof cell !== 'string') {
+              throw new BadRequestException('TABLE.cells must be strings.');
+            }
+            if (cell.trim().length > 0) {
+              hasNonEmptyCell = true;
+            }
+          }
+        }
+        if (!hasNonEmptyCell) {
+          throw new BadRequestException('TABLE.cells must not be empty.');
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    const candidate = plainToInstance(PostBlockDto, block);
+    const errors = validateSync(candidate, { forbidUnknownValues: false });
+    if (errors.length === 0) continue;
+    const message =
+      errors
+        .flatMap((error) => Object.values(error.constraints ?? {}))
+        .find((value) => value.length > 0) ?? 'block value is invalid.';
+    throw new BadRequestException(message);
+  }
+}

--- a/backend/src/modules/post/validator/post-title.validator.ts
+++ b/backend/src/modules/post/validator/post-title.validator.ts
@@ -1,0 +1,7 @@
+import { BadRequestException } from '@nestjs/common';
+
+export function validatePostTitle(title: unknown) {
+  if (typeof title !== 'string' || title.trim().length === 0) {
+    throw new BadRequestException('title must not be empty.');
+  }
+}

--- a/backend/src/modules/search/dto/search.dto.ts
+++ b/backend/src/modules/search/dto/search.dto.ts
@@ -69,8 +69,8 @@ export class SearchResultItemDto {
   @ApiProperty({ description: '게시글 ID' })
   id: string;
 
-  @ApiPropertyOptional({ description: '썸네일 URL' })
-  thumbnailUrl?: string;
+  @ApiPropertyOptional({ description: '썸네일 미디어 ID' })
+  thumbnailMediaId?: string;
 
   @ApiProperty({ description: '제목' })
   title: string;

--- a/backend/src/modules/stats/stats.service.ts
+++ b/backend/src/modules/stats/stats.service.ts
@@ -103,7 +103,7 @@ export class StatsService {
 
   private async getRecentEmotions(userId: string): Promise<EmotionCount[]> {
     const res = await this.postRepo.find({
-      where: { ownerUserId: userId },
+      where: { ownerUserId: userId, deletedAt: IsNull() },
       order: { createdAt: 'DESC' },
       select: ['emotion'],
     });
@@ -124,7 +124,7 @@ export class StatsService {
     userId: string,
     limit?: number,
   ): Promise<{ items: EmotionCount[]; totalCount: number }> {
-    const items = await this.getEmotions(userId, 'frequent');
+    const items = await this.getEmotions(userId, 'recent');
     const totalCount = items.reduce((sum, item) => sum + item.count, 0);
     const limited = limit !== undefined ? items.slice(0, limit) : items;
     return { items: limited, totalCount };

--- a/backend/src/modules/user/user.service.ts
+++ b/backend/src/modules/user/user.service.ts
@@ -37,13 +37,20 @@ export class UserService {
 
     let user = await this.userRepo.findOne({
       where: { provider, providerId },
+      withDeleted: true,
     });
 
-    if (!user) {
-      user = this.userRepo.create(params);
-
-      await this.userRepo.save(user);
+    if (user) {
+      if (user.deletedAt) {
+        await this.userRepo.recover(user);
+      }
+      user.email = params.email ?? user.email;
+      user.nickname = params.nickname ?? user.nickname;
+      return this.userRepo.save(user);
     }
+
+    user = this.userRepo.create(params);
+    await this.userRepo.save(user);
 
     return user;
   }

--- a/backend/test/search.e2e-spec.ts
+++ b/backend/test/search.e2e-spec.ts
@@ -1,0 +1,152 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import type { Repository } from 'typeorm';
+
+import { AppModule } from '../src/app.module';
+import { User } from '../src/modules/user/entity/user.entity';
+import { Post } from '../src/modules/post/entity/post.entity';
+import { PostBlock } from '../src/modules/post/entity/post-block.entity';
+import { PostScope } from '../src/enums/post-scope.enum';
+import { PostBlockType } from '../src/enums/post-block-type.enum';
+import { GoogleStrategy } from '../src/modules/auth/strategies/google.strategy';
+import { KakaoStrategy } from '../src/modules/auth/strategies/kakao.strategy';
+
+describe('SearchController (e2e)', () => {
+  let app: INestApplication<App>;
+  let userRepository: Repository<User>;
+  let postRepository: Repository<Post>;
+  let postBlockRepository: Repository<PostBlock>;
+  let accessToken: string;
+  let user: User;
+  let titlePost: Post;
+  let textPost: Post;
+
+  type SearchItemsResponse = {
+    items: Array<{ id: string }>;
+  };
+
+  const isSearchItemsResponse = (
+    value: unknown,
+  ): value is SearchItemsResponse => {
+    if (!value || typeof value !== 'object') return false;
+    if (!('items' in value)) return false;
+    const items = (value as { items?: unknown }).items;
+    return (
+      Array.isArray(items) &&
+      items.every(
+        (item) =>
+          typeof item === 'object' &&
+          item !== null &&
+          'id' in item &&
+          typeof (item as { id?: unknown }).id === 'string',
+      )
+    );
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(GoogleStrategy)
+      .useValue({})
+      .overrideProvider(KakaoStrategy)
+      .useValue({})
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+
+    userRepository = app.get(getRepositoryToken(User));
+    postRepository = app.get(getRepositoryToken(Post));
+    postBlockRepository = app.get(getRepositoryToken(PostBlock));
+    const jwtService = app.get(JwtService);
+
+    user = await userRepository.save(
+      userRepository.create({
+        email: 'search-owner@example.com',
+        nickname: 'search-owner',
+        provider: 'kakao',
+        providerId: `search-owner-${Date.now()}`,
+      }),
+    );
+    accessToken = jwtService.sign({ sub: user.id });
+
+    const eventAtToday = new Date('2026-02-03T09:30:00+09:00');
+    const eventAtYesterday = new Date('2026-02-02T09:30:00+09:00');
+
+    titlePost = await postRepository.save(
+      postRepository.create({
+        scope: PostScope.PERSONAL,
+        ownerUserId: user.id,
+        title: '오늘의 기록',
+        eventAt: eventAtToday,
+      }),
+    );
+
+    textPost = await postRepository.save(
+      postRepository.create({
+        scope: PostScope.PERSONAL,
+        ownerUserId: user.id,
+        title: '다른 제목',
+        eventAt: eventAtYesterday,
+      }),
+    );
+
+    await postBlockRepository.save(
+      postBlockRepository.create({
+        postId: textPost.id,
+        type: PostBlockType.TEXT,
+        value: { text: '오늘 기록은 텍스트에만 있습니다.' },
+        layoutRow: 1,
+        layoutCol: 1,
+        layoutSpan: 1,
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('키워드가 제목 또는 텍스트 블록에 포함된 글을 반환한다', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/search')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ keyword: '기록' })
+      .expect(201);
+
+    const body = res.body as unknown;
+    expect(isSearchItemsResponse(body)).toBe(true);
+    const ids = (body as SearchItemsResponse).items.map((item) => item.id);
+    expect(ids).toContain(titlePost.id);
+    expect(ids).toContain(textPost.id);
+  });
+
+  it('기간 필터로 해당 날짜 범위의 글만 반환한다', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/search')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({
+        startDate: '2026-02-03T00:00:00+09:00',
+        endDate: '2026-02-03T23:59:59+09:00',
+      })
+      .expect(201);
+
+    const body = res.body as unknown;
+    expect(isSearchItemsResponse(body)).toBe(true);
+    const ids = (body as SearchItemsResponse).items.map((item) => item.id);
+    expect(ids).toContain(titlePost.id);
+    expect(ids).not.toContain(textPost.id);
+  });
+});


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- 권한 정책 정리 및 permission 노출 규칙 적용
- 드래프트/발행 검증 분리와 레이아웃 오류 메시지/로그 개선
- 검색/통계/OAuth/테스트 보강 포함

## 작업 내용 + 스크린샷

- 그룹 글 VIEWER 차단, ADMIN 삭제 허용
- 피드/상세 및 `/v1/groups` permission 반환
  - **FE : 참고하여 공유/수정/삭제 안 뜨도록 해야함**
- 그룹 내 내 권한 경량 조회 API `/v1/groups/:groupId/members/me/role` 추가
  - 그룹함 +  버튼이 달려있는 모든 페이지에서 권한 조회가 일어날 수 있다 생각해서 추가함
- 그룹 멤버 권한 변경 시 VIEWER도 가능하도록 추가
  - **FE : 참고하여 VIEWER도 추가**
- 드래프트 MOOD/MEDIA 완화 + publish/POST 필수값 검증 강화 (@Yeong-si )
  - 드래프트에서는 완화하고, publish/POST에서는 빈값 허용하지 않음
- WS draftId 오류 메시지 분리
  - payload 누락 / draftId 누락 / draftId 불일치 메시지 구분
- 감정 통계 최근 사용순으로 적용 및 삭제 글 제외 (@H-sooyeon )
- OAuth 재가입 복구 및 Kakao scope 정리
  - 재가입시 기존 데이터를 임시 복구 처리함
  - 닉네임은 필수 필드로 받게함
  - scope에 email을 추가하여 선택적으로 받을 수 있도록 함
  - deleted_at IS NULL 조건의 partial unique index로 해결하는 방법이 있음
    - 해당 방법은 deleted_at으로 삭제된 user는 무시하고 unique index를 적용하도록 할 수 있음
- 테스트 sync 비활성화 + e2e 수정
- 검색 썸네일/날짜 필터 보정
  - 검색 결과 thumbnailUrl이 아니라 Id로 반환하도록 수정함
  - 날짜의 경우 start-date만 넣었을 때 end-date를 자동으로 넣도록 수정하여 오늘 날짜가 뜨도록 해봄..
  - **FE: 작업 필요**
- 레이아웃 로그 보강 (@Yeong-si )
  - 드래프트 내에서 레이아웃 오류는 `Layout is invalid.`가 공통으로 날라오도록 수정함

## 실제 걸린 시간
약 7시간

## 작업하며 고민했던 점(선택)

1. 권한/permission 규칙을 그룹 역할과 개인 owner 판단으로 일관화
2. 드래프트와 발행 검증을 분리해 UX/안정성 균형
3. Kakao 권한 제약 내에서 최소 동의로 흐름 유지

## 테스트 실행 여부

- [x] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

- 권한/permission 규칙(그룹/개인/권한 없음) 케이스 확인 부탁
- 드래프트/발행 검증과 레이아웃 오류 메시지 확인 부탁
- 검색 썸네일/날짜 범위 보정 동작 확인 부탁

## 시각 자료(이미지/영상, 있다면)(선택)
