### PR TITLE
공동작성 안정화 + 그룹함 드래프트 목록/제한 적용

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,6 +16,13 @@ GOOGLE_CLIENT_SECRET=<your_oauth_google_client_secret> # 구글 OAuth앱이 발�
 KAKAO_CLIENT_ID=<your_oauth_kakao_client_id> # 카카오 REST API 키
 KAKAO_CLIENT_SECRET=<your_oauth_kakao_client_secret> # 카카오 로그인 On인경우만 필수
 
+
+# =========
+# WS/Collab Stream 설정
+# =========
+STREAM_DROP_BUFFER_LIMIT=50 # 소켓 writeBuffer 길이 임계값(초과 시 STREAM 드롭)
+STREAM_ROOM_BYPASS_LIMIT=30 # 룸 인원 기준(이 이상이면 세션별 검사 생략)
+
 # =========
 # Database
 # =========

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,6 +22,8 @@ KAKAO_CLIENT_SECRET=<your_oauth_kakao_client_secret> # 카카오 로그인 On인
 # =========
 STREAM_DROP_BUFFER_LIMIT=50 # 소켓 writeBuffer 길이 임계값(초과 시 STREAM 드롭)
 STREAM_ROOM_BYPASS_LIMIT=30 # 룸 인원 기준(이 이상이면 세션별 검사 생략)
+DRAFT_JOIN_LIMIT=10 # 드래프트 동시 접속 제한(초과 시 JOIN 거부)
+DRAFT_LIST_REFRESH_MS=3000 # 그룹 드래프트 목록 소켓 갱신 주기(ms)
 
 # =========
 # Database

--- a/backend/migrations/1770288931741-add-post-draft-create-slot.ts
+++ b/backend/migrations/1770288931741-add-post-draft-create-slot.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddPostDraftCreateSlot1770288931741 implements MigrationInterface {
+  name = 'AddPostDraftCreateSlot1770288931741';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "post_drafts" ADD "create_slot" integer`,
+    );
+    await queryRunner.query(
+      `UPDATE "post_drafts" SET "create_slot" = 1 WHERE "kind" = 'CREATE' AND "is_active" = true AND "create_slot" IS NULL`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "uq_post_drafts_active_group_create"`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_post_drafts_active_group_create_slot" ON "post_drafts" ("group_id", "create_slot") WHERE is_active = true AND kind = 'CREATE'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "uq_post_drafts_active_group_create_slot"`,
+    );
+    await queryRunner.query(
+      `WITH ranked AS (
+        SELECT
+          id,
+          ROW_NUMBER() OVER (
+            PARTITION BY group_id
+            ORDER BY updated_at DESC, created_at DESC
+          ) AS rn
+        FROM post_drafts
+        WHERE is_active = true AND kind = 'CREATE'
+      )
+      UPDATE post_drafts d
+      SET is_active = false
+      FROM ranked r
+      WHERE d.id = r.id AND r.rn > 1`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "uq_post_drafts_active_group_create" ON "post_drafts" ("group_id") WHERE is_active = true AND kind = 'CREATE'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "post_drafts" DROP COLUMN "create_slot"`,
+    );
+  }
+}

--- a/backend/src/modules/feed/dto/feed-card.response.dto.ts
+++ b/backend/src/modules/feed/dto/feed-card.response.dto.ts
@@ -109,6 +109,10 @@ export class FeedCardResponseDto {
     example: 'EDITOR',
   })
   permission: 'ADMIN' | 'EDITOR' | 'VIEWER' | 'OWNER' | null;
+  @ApiPropertyOptional({
+    description: '해당 게시글의 공동 수정 드래프트가 열려있는지 여부',
+  })
+  hasActiveEditDraft?: boolean;
   constructor(init: FeedCardResponseDto) {
     Object.assign(this, init);
   }

--- a/backend/src/modules/feed/feed.group.query.service.ts
+++ b/backend/src/modules/feed/feed.group.query.service.ts
@@ -8,6 +8,7 @@ import { PostBlock } from '../post/entity/post-block.entity';
 import { PostContributor } from '../post/entity/post-contributor.entity';
 import { GroupMember } from '../group/entity/group_member.entity';
 import { PostScope } from '@/enums/post-scope.enum';
+import { PostDraft } from '../post/entity/post-draft.entity';
 import { GetFeedQueryDto } from './dto/get-feed.query.dto';
 import { buildFeedCards, dayRange } from './feed.helpers';
 
@@ -24,6 +25,8 @@ export class FeedGroupQueryService {
     private readonly postContributorRepo: Repository<PostContributor>,
     @InjectRepository(GroupMember)
     private readonly groupMemberRepo: Repository<GroupMember>,
+    @InjectRepository(PostDraft)
+    private readonly postDraftRepo: Repository<PostDraft>,
   ) {}
 
   async getGroupFeed(groupId: string, userId: string, query: GetFeedQueryDto) {
@@ -56,6 +59,7 @@ export class FeedGroupQueryService {
       this.groupMemberRepo,
       this.logger,
       userId,
+      { draftRepo: this.postDraftRepo },
     );
   }
 }

--- a/backend/src/modules/feed/feed.module.ts
+++ b/backend/src/modules/feed/feed.module.ts
@@ -10,6 +10,7 @@ import { FeedGroupQueryService } from './feed.group.query.service';
 import { Post } from '../post/entity/post.entity';
 import { PostBlock } from '../post/entity/post-block.entity';
 import { PostContributor } from '../post/entity/post-contributor.entity';
+import { PostDraft } from '../post/entity/post-draft.entity';
 import { GroupMember } from '../group/entity/group_member.entity';
 import { Group } from '../group/entity/group.entity';
 import { GroupModule } from '../group/group.module';
@@ -20,6 +21,7 @@ import { GroupModule } from '../group/group.module';
       Post,
       PostBlock,
       PostContributor,
+      PostDraft,
       GroupMember,
       Group,
     ]),

--- a/backend/src/modules/feed/feed.query.service.ts
+++ b/backend/src/modules/feed/feed.query.service.ts
@@ -9,6 +9,7 @@ import { PostContributor } from '../post/entity/post-contributor.entity';
 import { PostBlock } from '../post/entity/post-block.entity';
 import { GroupMember } from '../group/entity/group_member.entity';
 import { Group } from '../group/entity/group.entity';
+import { PostDraft } from '../post/entity/post-draft.entity';
 import { buildFeedCards, dayRange } from './feed.helpers';
 
 @Injectable()
@@ -26,6 +27,8 @@ export class FeedQueryService {
     private readonly groupMemberRepo: Repository<GroupMember>,
     @InjectRepository(Group)
     private readonly groupRepo: Repository<Group>,
+    @InjectRepository(PostDraft)
+    private readonly postDraftRepo: Repository<PostDraft>,
   ) {}
 
   async getFeedForUser(userId: string, query: GetFeedQueryDto) {
@@ -88,7 +91,11 @@ export class FeedQueryService {
       this.groupMemberRepo,
       this.logger,
       userId,
-      { includeGroupName: true, groupRepo: this.groupRepo },
+      {
+        includeGroupName: true,
+        groupRepo: this.groupRepo,
+        draftRepo: this.postDraftRepo,
+      },
     );
   }
 }

--- a/backend/src/modules/group/service/group-invite.service.ts
+++ b/backend/src/modules/group/service/group-invite.service.ts
@@ -12,9 +12,8 @@ import { GroupRoleEnum } from '@/enums/group-role.enum';
 import { GroupActivityType } from '@/enums/group-activity-type.enum';
 import { User } from '../../user/entity/user.entity';
 import { GroupActivityService } from './group-activity.service';
+import { resolveGroupNickname } from '../utils/group-nickname';
 import * as crypto from 'crypto';
-
-const GROUP_NICKNAME_REGEX = /^[a-zA-Z0-9가-힣 ]+$/;
 
 @Injectable()
 export class GroupInviteService {
@@ -106,7 +105,7 @@ export class GroupInviteService {
       group: { id: invite.groupId },
       user,
       role: invite.permission,
-      nicknameInGroup: this.validateGroupNickname(user.nickname),
+      nicknameInGroup: resolveGroupNickname(user.nickname),
     });
 
     const saved = await this.groupMemberRepo.save(member);
@@ -122,20 +121,5 @@ export class GroupInviteService {
   /** 초대 링크 삭제 */
   async deleteInvite(inviteId: string) {
     await this.inviteRepo.delete(inviteId);
-  }
-
-  private validateGroupNickname(nickname: string): string {
-    const trimmed = nickname.trim();
-    if (trimmed.length < 2 || trimmed.length > 50) {
-      throw new BadRequestException(
-        '닉네임은 2자 이상 50자 이하이어야 합니다.',
-      );
-    }
-    if (!GROUP_NICKNAME_REGEX.test(trimmed)) {
-      throw new BadRequestException(
-        '닉네임은 한글, 영문, 숫자, 공백만 허용됩니다.',
-      );
-    }
-    return trimmed;
   }
 }

--- a/backend/src/modules/group/service/group-management.service.ts
+++ b/backend/src/modules/group/service/group-management.service.ts
@@ -32,7 +32,10 @@ import {
 } from '../dto/get-group-cover-candidates.dto';
 import { GroupActivityService } from './group-activity.service';
 
-const GROUP_NICKNAME_REGEX = /^[a-zA-Z0-9가-힣 ]+$/;
+import {
+  resolveGroupNickname,
+  validateGroupNickname,
+} from '../utils/group-nickname';
 
 @Injectable()
 export class GroupManagementService {
@@ -73,7 +76,7 @@ export class GroupManagementService {
         group,
         user,
         role,
-        nicknameInGroup: this.validateGroupNickname(user.nickname),
+        nicknameInGroup: resolveGroupNickname(user.nickname),
       });
 
       return this.groupMemberRepo.save(member);
@@ -497,7 +500,7 @@ export class GroupManagementService {
       if (nicknameInGroup === member.nicknameInGroup) {
         // 이미 동일한 닉네임이면 무시하거나 처리 (여기서는 전체 변경 없음을 체크했으므로 진행)
       } else {
-        member.nicknameInGroup = this.validateGroupNickname(nicknameInGroup);
+        member.nicknameInGroup = validateGroupNickname(nicknameInGroup);
       }
     }
 
@@ -712,20 +715,5 @@ export class GroupManagementService {
           `Failed to cleanup stale group cover (groupId=${groupId}): ${message}`,
         );
       });
-  }
-
-  private validateGroupNickname(nickname: string): string {
-    const trimmed = nickname.trim();
-    if (trimmed.length < 2 || trimmed.length > 50) {
-      throw new BadRequestException(
-        '닉네임은 2자 이상 50자 이하이어야 합니다.',
-      );
-    }
-    if (!GROUP_NICKNAME_REGEX.test(trimmed)) {
-      throw new BadRequestException(
-        '닉네임은 한글, 영문, 숫자, 공백만 허용됩니다.',
-      );
-    }
-    return trimmed;
   }
 }

--- a/backend/src/modules/group/service/group.service.ts
+++ b/backend/src/modules/group/service/group.service.ts
@@ -23,7 +23,7 @@ import { PostScope } from '@/enums/post-scope.enum';
 import { GetGroupsResponseDto, GroupItemDto } from '../dto/get-groups.dto';
 import { GroupActivityService } from './group-activity.service';
 
-const GROUP_NICKNAME_REGEX = /^[a-zA-Z0-9가-힣 ]+$/;
+import { resolveGroupNickname } from '../utils/group-nickname';
 
 @Injectable()
 export class GroupService {
@@ -67,7 +67,7 @@ export class GroupService {
           group: savedGroup,
           user: { id: ownerId } as User,
           role: GroupRoleEnum.ADMIN,
-          nicknameInGroup: this.validateGroupNickname(owner.nickname),
+          nicknameInGroup: resolveGroupNickname(owner.nickname),
         });
         await manager.save(ownerMember);
 
@@ -321,21 +321,6 @@ export class GroupService {
       height: latestMedia.media.height,
       mimeType: latestMedia.media.mimeType,
     };
-  }
-
-  private validateGroupNickname(nickname: string): string {
-    const trimmed = nickname.trim();
-    if (trimmed.length < 2 || trimmed.length > 50) {
-      throw new BadRequestException(
-        '닉네임은 2자 이상 50자 이하이어야 합니다.',
-      );
-    }
-    if (!GROUP_NICKNAME_REGEX.test(trimmed)) {
-      throw new BadRequestException(
-        '닉네임은 한글, 영문, 숫자, 공백만 허용됩니다.',
-      );
-    }
-    return trimmed;
   }
 
   private cleanupStaleGroupCovers(groupIds: string[]) {

--- a/backend/src/modules/group/service/group.service.ts
+++ b/backend/src/modules/group/service/group.service.ts
@@ -72,8 +72,20 @@ export class GroupService {
         await manager.save(ownerMember);
 
         return savedGroup;
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
       } catch (error) {
+        if (
+          error instanceof BadRequestException ||
+          error instanceof ForbiddenException ||
+          error instanceof NotFoundException
+        ) {
+          throw error;
+        }
+        const message =
+          error instanceof Error ? error.message : 'unknown error';
+        this.logger.error(
+          `Failed to create group (ownerId=${ownerId}): ${message}`,
+          error instanceof Error ? error.stack : undefined,
+        );
         throw new InternalServerErrorException(
           '그룹 생성 중 오류가 발생했습니다.',
         );

--- a/backend/src/modules/group/utils/group-nickname.ts
+++ b/backend/src/modules/group/utils/group-nickname.ts
@@ -1,0 +1,26 @@
+import { BadRequestException } from '@nestjs/common';
+
+const GROUP_NICKNAME_REGEX = /^[a-zA-Z0-9가-힣 ]+$/;
+const DEFAULT_GROUP_NICKNAME = '유저';
+
+export function validateGroupNickname(nickname: string): string {
+  const trimmed = nickname.trim();
+  if (trimmed.length < 2 || trimmed.length > 50) {
+    throw new BadRequestException('닉네임은 2자 이상 50자 이하이어야 합니다.');
+  }
+  if (!GROUP_NICKNAME_REGEX.test(trimmed)) {
+    throw new BadRequestException(
+      '닉네임은 한글, 영문, 숫자, 공백만 허용됩니다.',
+    );
+  }
+  return trimmed;
+}
+
+export function resolveGroupNickname(nickname?: string | null): string {
+  if (!nickname) return DEFAULT_GROUP_NICKNAME;
+  try {
+    return validateGroupNickname(nickname);
+  } catch {
+    return DEFAULT_GROUP_NICKNAME;
+  }
+}

--- a/backend/src/modules/post/COLLAB_WS.md
+++ b/backend/src/modules/post/COLLAB_WS.md
@@ -21,12 +21,15 @@
 
 - `JOIN_DRAFT { draftId }`
 - `LEAVE_DRAFT { draftId? }`
+- `JOIN_GROUP_DRAFTS { groupId }`
+- `LEAVE_GROUP_DRAFTS { groupId? }`
 - `PRESENCE_SNAPSHOT { sessionId, members, locks, version }`
 - `PRESENCE_JOINED { member }`
 - `PRESENCE_LEFT { sessionId }`
 - `PRESENCE_HEARTBEAT { draftId? }`
 - `PRESENCE_REPLACED { previousSessionId, sessionId, displayName }`
 - `SESSION_REPLACED {}` (기존 세션에만 전송)
+- `GROUP_DRAFTS_SNAPSHOT { groupId, drafts }`
 
 Lock
 
@@ -56,6 +59,24 @@ Stream/Patch/Publish
 - 클라이언트 → 서버 입장 요청 이벤트
 - 서버는 세션 정보 생성 후 `PRESENCE_SNAPSHOT`으로 응답
 - 정상 흐름에서는 이 이벤트 이후에만 LOCK 이벤트를 보내는 것을 권장
+
+### JOIN_GROUP_DRAFTS
+
+- 클라이언트 → 서버 그룹 드래프트 목록 구독 요청
+- 서버는 `GROUP_DRAFTS_SNAPSHOT`을 즉시 응답하고 이후 주기적으로 갱신
+- 그룹 멤버만 구독 가능 (VIEWER 포함)
+
+### LEAVE_GROUP_DRAFTS
+
+- 클라이언트 → 서버 그룹 드래프트 목록 구독 해제
+- 그룹함을 떠날 때 호출
+
+### GROUP_DRAFTS_SNAPSHOT
+
+- 서버 → 클라이언트, 그룹 드래프트 목록 스냅샷
+- payload 예시: `{ groupId, drafts: [{ draftId, kind, title, createdAt, updatedAt, participantCount, isPublishing, targetPostId }] }`
+- 갱신 주기 기본값: 3초(`DRAFT_LIST_REFRESH_MS`)
+- `kind`는 `CREATE`/`EDIT`, `targetPostId`는 EDIT에만 존재
 
 ### PRESENCE_SNAPSHOT
 

--- a/backend/src/modules/post/COLLAB_WS.md
+++ b/backend/src/modules/post/COLLAB_WS.md
@@ -51,6 +51,7 @@ Stream/Patch/Publish
 - `DRAFT_PUBLISH_STARTED { draftId }`
 - `DRAFT_PUBLISH_ENDED { draftId, currentVersion? }`
 - `DRAFT_PUBLISHED { postId }`
+- `DRAFT_INVALIDATED { draftId, reason }`
 
 ## 이벤트 상세 설명
 
@@ -201,6 +202,12 @@ Stream/Patch/Publish
 - publish 완료 시 룸 전체 브로드캐스트
 - payload: `{ postId }`
 - 클라이언트는 편집 화면 종료/상세 페이지 이동
+
+### DRAFT_INVALIDATED
+
+- 게시글 삭제 등으로 드래프트가 더 이상 유효하지 않을 때 브로드캐스트
+- payload: `{ draftId, reason }`
+- 클라이언트는 드래프트 종료 및 목록 이동 처리
 
 ### DRAFT_PUBLISH_STARTED
 

--- a/backend/src/modules/post/COLLAB_WS.md
+++ b/backend/src/modules/post/COLLAB_WS.md
@@ -46,7 +46,7 @@ Stream/Patch/Publish
 - `PATCH_COMMITTED { version, patch, authorSessionId }`
 - `PATCH_REJECTED_STALE { currentVersion }`
 - `DRAFT_PUBLISH_STARTED { draftId }`
-- `DRAFT_PUBLISH_FAILED { draftId, message }`
+- `DRAFT_PUBLISH_ENDED { draftId, currentVersion? }`
 - `DRAFT_PUBLISHED { postId }`
 
 ## 이벤트 상세 설명
@@ -184,14 +184,14 @@ Stream/Patch/Publish
 ### DRAFT_PUBLISH_STARTED
 
 - publish 시작 시 룸 전체 브로드캐스트
-- payload: `{ draftId }`
+- payload: `{ draftId, currentVersion? }`
 - 클라이언트는 로딩 UI 표시
 
-### DRAFT_PUBLISH_FAILED
+### DRAFT_PUBLISH_ENDED
 
-- publish 실패 시 룸 전체 브로드캐스트
-- payload: `{ draftId, message }`
-- 클라이언트는 로딩 UI 해제 및 에러 메시지 표시
+- publish 실패/중단 시 룸 전체 브로드캐스트
+- payload: `{ draftId }`
+- 클라이언트는 로딩 UI 해제
 
 ## Payload 요약
 

--- a/backend/src/modules/post/collab/patch-stream.service.ts
+++ b/backend/src/modules/post/collab/patch-stream.service.ts
@@ -16,8 +16,10 @@ import { acquireLockWithEmit } from './lock-events';
 
 @Injectable()
 export class PatchStreamService implements OnModuleDestroy {
-  private static readonly STREAM_DROP_BUFFER_LIMIT = 50;
-  private static readonly STREAM_ROOM_BYPASS_LIMIT = 30;
+  private static readonly STREAM_DROP_BUFFER_LIMIT =
+    PatchStreamService.readEnvInt('STREAM_DROP_BUFFER_LIMIT', 50);
+  private static readonly STREAM_ROOM_BYPASS_LIMIT =
+    PatchStreamService.readEnvInt('STREAM_ROOM_BYPASS_LIMIT', 30);
   private static readonly STREAM_FLUSH_INTERVAL_MS = 250;
   private readonly streamBuffer = new Map<string, BufferedStream>();
   private readonly logger = new Logger(PatchStreamService.name);
@@ -302,6 +304,14 @@ export class PatchStreamService implements OnModuleDestroy {
       return;
     }
     throw new WsException('Lock owner only.');
+  }
+
+  private static readEnvInt(key: string, fallback: number) {
+    const raw = process.env[key];
+    if (!raw) return fallback;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+    return Math.floor(parsed);
   }
 }
 

--- a/backend/src/modules/post/collab/patch-stream.service.ts
+++ b/backend/src/modules/post/collab/patch-stream.service.ts
@@ -200,11 +200,7 @@ export class PatchStreamService implements OnModuleDestroy {
       if (!this.isStreamOwner(entry.draftId, entry.blockId, entry.sessionId)) {
         return;
       }
-      entry.server.to(entry.room).emit('BLOCK_VALUE_STREAM', {
-        blockId: entry.blockId,
-        partialValue: entry.partialValue,
-        sessionId: entry.sessionId,
-      });
+      this.emitStream(entry);
     });
 
     if (this.streamBuffer.size > 0) {
@@ -237,6 +233,14 @@ export class PatchStreamService implements OnModuleDestroy {
       `table:${blockId}`,
     );
     return blockOwner === sessionId || tableOwner === sessionId;
+  }
+
+  private emitStream(entry: BufferedStream) {
+    entry.server.to(entry.room).volatile.emit('BLOCK_VALUE_STREAM', {
+      blockId: entry.blockId,
+      partialValue: entry.partialValue,
+      sessionId: entry.sessionId,
+    });
   }
 
   private ensureTitleLockOwner(draftId: string, sessionId: string) {

--- a/backend/src/modules/post/collab/types.ts
+++ b/backend/src/modules/post/collab/types.ts
@@ -25,6 +25,14 @@ export type LeaveDraftPayload = {
   draftId?: string;
 };
 
+export type JoinGroupDraftsPayload = {
+  groupId: string;
+};
+
+export type LeaveGroupDraftsPayload = {
+  groupId?: string;
+};
+
 export type PresenceHeartbeatPayload = {
   draftId?: string;
 };
@@ -78,4 +86,5 @@ export type DraftSocketData = {
   displayName?: string;
   role?: string;
   draftId?: string;
+  groupDraftGroupId?: string;
 };

--- a/backend/src/modules/post/dto/post-detail.dto.ts
+++ b/backend/src/modules/post/dto/post-detail.dto.ts
@@ -51,4 +51,8 @@ export class PostDetailDto {
     example: 'EDITOR',
   })
   permission: 'ADMIN' | 'EDITOR' | 'VIEWER' | 'OWNER' | null;
+  @ApiPropertyOptional({
+    description: '해당 게시글의 공동 수정 드래프트가 열려있는지 여부',
+  })
+  hasActiveEditDraft?: boolean;
 }

--- a/backend/src/modules/post/entity/post-draft.entity.ts
+++ b/backend/src/modules/post/entity/post-draft.entity.ts
@@ -41,6 +41,9 @@ export class PostDraft {
   @Column({ name: 'target_post_id', type: 'uuid', nullable: true })
   targetPostId: string | null;
 
+  @Column({ name: 'create_slot', type: 'int', nullable: true })
+  createSlot: number | null;
+
   @Column({ type: 'jsonb', default: () => "'{}'::jsonb" })
   snapshot: Record<string, unknown>;
 

--- a/backend/src/modules/post/post-draft.gateway.ts
+++ b/backend/src/modules/post/post-draft.gateway.ts
@@ -407,6 +407,13 @@ export class PostDraftGateway
       .emit('DRAFT_PUBLISH_ENDED', payload);
   }
 
+  broadcastDraftInvalidated(draftId: string, reason: string) {
+    this.server.to(this.getDraftRoom(draftId)).emit('DRAFT_INVALIDATED', {
+      draftId,
+      reason,
+    });
+  }
+
   private getDraftRoom(draftId: string) {
     return `draft:${draftId}`;
   }

--- a/backend/src/modules/post/post-draft.gateway.ts
+++ b/backend/src/modules/post/post-draft.gateway.ts
@@ -331,11 +331,14 @@ export class PostDraftGateway
     });
   }
 
-  broadcastDraftPublishFailed(draftId: string, message: string) {
-    this.server.to(this.getDraftRoom(draftId)).emit('DRAFT_PUBLISH_FAILED', {
-      draftId,
-      message,
-    });
+  broadcastDraftPublishEnded(draftId: string, currentVersion?: number) {
+    const payload: { draftId: string; currentVersion?: number } = { draftId };
+    if (typeof currentVersion === 'number') {
+      payload.currentVersion = currentVersion;
+    }
+    this.server
+      .to(this.getDraftRoom(draftId))
+      .emit('DRAFT_PUBLISH_ENDED', payload);
   }
 
   private getDraftRoom(draftId: string) {

--- a/backend/src/modules/post/post-draft.gateway.ts
+++ b/backend/src/modules/post/post-draft.gateway.ts
@@ -30,6 +30,8 @@ import type {
   DraftSocketData,
   JoinDraftPayload,
   LeaveDraftPayload,
+  JoinGroupDraftsPayload,
+  LeaveGroupDraftsPayload,
   LockPayload,
   PresenceMember,
   PresenceHeartbeatPayload,
@@ -50,7 +52,17 @@ export class PostDraftGateway
   private readonly logger = new Logger(PostDraftGateway.name);
   private static readonly PRESENCE_TTL_MS = 60_000;
   private static readonly PRESENCE_SWEEP_MS = 10_000;
+  private static readonly DRAFT_JOIN_LIMIT = PostDraftGateway.readEnvInt(
+    'DRAFT_JOIN_LIMIT',
+    10,
+  );
+  private static readonly GROUP_DRAFT_REFRESH_MS = PostDraftGateway.readEnvInt(
+    'DRAFT_LIST_REFRESH_MS',
+    3000,
+  );
   private presenceSweepTimer?: NodeJS.Timeout;
+  private groupDraftRefreshTimer?: NodeJS.Timeout;
+  private readonly groupDraftSubscribers = new Map<string, Set<string>>();
 
   constructor(
     @InjectRepository(PostDraft)
@@ -75,6 +87,13 @@ export class PostDraftGateway
     this.presenceSweepTimer = setInterval(() => {
       this.sweepStalePresence();
     }, PostDraftGateway.PRESENCE_SWEEP_MS);
+
+    if (this.groupDraftRefreshTimer) {
+      clearInterval(this.groupDraftRefreshTimer);
+    }
+    this.groupDraftRefreshTimer = setInterval(() => {
+      void this.broadcastGroupDraftSnapshots();
+    }, PostDraftGateway.GROUP_DRAFT_REFRESH_MS);
   }
 
   @SubscribeMessage('JOIN_DRAFT')
@@ -92,6 +111,14 @@ export class PostDraftGateway
 
     const sessionId = randomUUID();
     const actorId = this.resolveActorId(socket);
+    const existingMember = this.presenceService.getMemberByActor(
+      draftId,
+      actorId,
+    );
+    const memberCount = this.presenceService.getMembersArray(draftId).length;
+    if (!existingMember && memberCount >= PostDraftGateway.DRAFT_JOIN_LIMIT) {
+      throw new WsException('Draft is full.');
+    }
     const { displayName, role, profileImageId } = await this.resolveMemberInfo(
       actorId,
       draftId,
@@ -140,6 +167,44 @@ export class PostDraftGateway
     });
 
     socket.to(room).emit('PRESENCE_JOINED', { member });
+  }
+
+  @SubscribeMessage('JOIN_GROUP_DRAFTS')
+  async handleJoinGroupDrafts(
+    @MessageBody() payload: JoinGroupDraftsPayload,
+    @ConnectedSocket() socket: Socket,
+  ) {
+    const groupId = payload?.groupId;
+    if (!groupId || !isUUID(groupId)) {
+      throw new WsException('groupId must be a UUID.');
+    }
+
+    const actorId = this.resolveActorId(socket);
+    await this.ensureGroupMember(groupId, actorId, false);
+
+    this.leaveGroupDrafts(socket);
+
+    const socketData = this.getSocketData(socket);
+    socketData.groupDraftGroupId = groupId;
+
+    const room = this.getGroupDraftRoom(groupId);
+    void socket.join(room);
+    this.addGroupDraftSubscriber(groupId, socket.id);
+
+    await this.emitGroupDraftSnapshot(groupId, socket);
+  }
+
+  @SubscribeMessage('LEAVE_GROUP_DRAFTS')
+  handleLeaveGroupDrafts(
+    @MessageBody() payload: LeaveGroupDraftsPayload,
+    @ConnectedSocket() socket: Socket,
+  ) {
+    const socketData = this.getSocketData(socket);
+    const groupId = payload?.groupId;
+    if (groupId && socketData.groupDraftGroupId !== groupId) {
+      throw new WsException('groupId mismatch.');
+    }
+    this.leaveGroupDrafts(socket);
   }
 
   @SubscribeMessage('LOCK_ACQUIRE')
@@ -313,6 +378,7 @@ export class PostDraftGateway
 
   handleDisconnect(socket: Socket) {
     this.leaveCurrentDraft(socket);
+    this.leaveGroupDrafts(socket);
   }
 
   handleConnection(socket: Socket) {
@@ -345,6 +411,10 @@ export class PostDraftGateway
     return `draft:${draftId}`;
   }
 
+  private getGroupDraftRoom(groupId: string) {
+    return `group-drafts:${groupId}`;
+  }
+
   private leaveCurrentDraft(socket: Socket) {
     const socketData = this.getSocketData(socket);
     const draftId = socketData.draftId;
@@ -370,6 +440,81 @@ export class PostDraftGateway
     if (socketData.actorId) {
       this.presenceService.clearSocketIdIfMatch(socketData.actorId, socket.id);
     }
+  }
+
+  private leaveGroupDrafts(socket: Socket) {
+    const socketData = this.getSocketData(socket);
+    const groupId = socketData.groupDraftGroupId;
+    if (!groupId) return;
+
+    void socket.leave(this.getGroupDraftRoom(groupId));
+    const subscribers = this.groupDraftSubscribers.get(groupId);
+    if (subscribers) {
+      subscribers.delete(socket.id);
+      if (subscribers.size === 0) {
+        this.groupDraftSubscribers.delete(groupId);
+      }
+    }
+    socketData.groupDraftGroupId = undefined;
+  }
+
+  private addGroupDraftSubscriber(groupId: string, socketId: string) {
+    const subscribers = this.groupDraftSubscribers.get(groupId);
+    if (subscribers) {
+      subscribers.add(socketId);
+      return;
+    }
+    this.groupDraftSubscribers.set(groupId, new Set([socketId]));
+  }
+
+  private async broadcastGroupDraftSnapshots() {
+    const groupIds = Array.from(this.groupDraftSubscribers.keys());
+    await Promise.all(
+      groupIds.map((groupId) => this.emitGroupDraftSnapshot(groupId)),
+    );
+  }
+
+  private async emitGroupDraftSnapshot(groupId: string, socket?: Socket) {
+    const drafts = await this.buildGroupDraftSnapshot(groupId);
+    const payload = { groupId, drafts };
+    if (socket) {
+      socket.emit('GROUP_DRAFTS_SNAPSHOT', payload);
+      return;
+    }
+    this.server
+      .to(this.getGroupDraftRoom(groupId))
+      .emit('GROUP_DRAFTS_SNAPSHOT', payload);
+  }
+
+  private async buildGroupDraftSnapshot(groupId: string) {
+    const drafts = await this.postDraftRepository.find({
+      where: { groupId, isActive: true },
+      order: { updatedAt: 'DESC' },
+      select: {
+        id: true,
+        kind: true,
+        targetPostId: true,
+        snapshot: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    return drafts.map((draft) => ({
+      draftId: draft.id,
+      kind: draft.kind,
+      targetPostId: draft.targetPostId,
+      title: this.resolveDraftTitle(draft.snapshot),
+      createdAt: draft.createdAt.toISOString(),
+      updatedAt: draft.updatedAt.toISOString(),
+      participantCount: this.presenceService.getMembersArray(draft.id).length,
+      isPublishing: this.draftStateService.isPublishing(draft.id),
+    }));
+  }
+
+  private resolveDraftTitle(snapshot: Record<string, unknown>) {
+    const title = (snapshot as { title?: unknown }).title;
+    return typeof title === 'string' ? title : '';
   }
 
   private sweepStalePresence() {
@@ -419,6 +564,24 @@ export class PostDraftGateway
       throw new WsException('actorId is invalid.');
     }
     return actorId;
+  }
+
+  private async ensureGroupMember(
+    groupId: string,
+    actorId: string,
+    requireEditor: boolean,
+  ) {
+    const member = await this.groupMemberRepository.findOne({
+      where: { groupId, userId: actorId },
+      select: { role: true },
+    });
+    if (!member) {
+      throw new WsException('Group membership is required.');
+    }
+    if (requireEditor && member.role === GroupRoleEnum.VIEWER) {
+      throw new WsException('Insufficient permission.');
+    }
+    return member;
   }
 
   private async resolveMemberInfo(actorId: string, draftId: string) {
@@ -517,6 +680,14 @@ export class PostDraftGateway
     const previousSocket = this.server.sockets.sockets.get(previousSocketId);
     // TODO: Include device info (user agent / deviceId) in SESSION_REPLACED payload.
     previousSocket?.emit('SESSION_REPLACED', {});
+  }
+
+  private static readEnvInt(key: string, fallback: number) {
+    const raw = process.env[key];
+    if (!raw) return fallback;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+    return Math.floor(parsed);
   }
 
   private ensureNotPublishing(draftId: string) {

--- a/backend/src/modules/post/post-draft.service.ts
+++ b/backend/src/modules/post/post-draft.service.ts
@@ -30,6 +30,8 @@ import { GroupActivityType } from '@/enums/group-activity-type.enum';
 
 @Injectable()
 export class PostDraftService {
+  private static readonly CREATE_DRAFT_LIMIT = 5;
+
   constructor(
     @InjectRepository(PostDraft)
     private readonly postDraftRepository: Repository<PostDraft>,
@@ -48,50 +50,71 @@ export class PostDraftService {
     groupId: string,
     actorId: string,
   ): Promise<PostDraft> {
-    const group = await this.groupRepository.findOne({
-      where: { id: groupId },
-      select: { id: true },
-    });
-    if (!group) throw new NotFoundException('Group not found');
     await this.ensureGroupEditor(groupId, actorId);
 
-    const existing = await this.postDraftRepository.findOne({
-      where: { groupId, isActive: true, kind: 'CREATE' },
-    });
-    if (existing) return existing;
+    return this.postDraftRepository.manager.transaction(async (manager) => {
+      const groupRepo = manager.getRepository(Group);
+      const draftRepo = manager.getRepository(PostDraft);
 
-    const draft = this.postDraftRepository.create({
-      groupId,
-      ownerActorId: actorId,
-      kind: 'CREATE',
-      snapshot: this.buildDefaultDraftSnapshot(groupId),
-    });
-
-    try {
-      const saved = await this.postDraftRepository.save(draft);
-      await this.groupActivityService.recordActivity({
-        groupId,
-        type: GroupActivityType.POST_COLLAB_START,
-        actorIds: [actorId],
-        refId: saved.id,
+      const group = await groupRepo.findOne({
+        where: { id: groupId },
+        select: { id: true },
+        lock: { mode: 'pessimistic_write' },
       });
-      return saved;
-    } catch (error) {
-      const dbError = error as { code?: string };
-      if (error instanceof QueryFailedError && dbError.code === '23505') {
-        const concurrent = await this.postDraftRepository.findOne({
-          where: { groupId, isActive: true, kind: 'CREATE' },
-        });
-        if (concurrent) return concurrent;
-        throw new ConflictException(
-          'Active draft already exists for this group.',
-        );
+      if (!group) throw new NotFoundException('Group not found');
+
+      const activeDrafts = await draftRepo
+        .createQueryBuilder('draft')
+        .setLock('pessimistic_write')
+        .where('draft.groupId = :groupId', { groupId })
+        .andWhere('draft.isActive = true')
+        .andWhere("draft.kind = 'CREATE'")
+        .getMany();
+
+      const usedSlots = new Set<number>();
+      activeDrafts.forEach((draft) => {
+        if (typeof draft.createSlot === 'number') {
+          usedSlots.add(draft.createSlot);
+        }
+      });
+
+      let availableSlot: number | null = null;
+      for (
+        let slot = 1;
+        slot <= PostDraftService.CREATE_DRAFT_LIMIT;
+        slot += 1
+      ) {
+        if (!usedSlots.has(slot)) {
+          availableSlot = slot;
+          break;
+        }
       }
-      if (error instanceof QueryFailedError) {
-        throw new InternalServerErrorException('Failed to create draft.');
+
+      if (!availableSlot) {
+        throw new ConflictException('Active create draft limit reached.');
       }
-      throw error;
-    }
+
+      const draft = draftRepo.create({
+        groupId,
+        ownerActorId: actorId,
+        kind: 'CREATE',
+        createSlot: availableSlot,
+        snapshot: this.buildDefaultDraftSnapshot(groupId),
+      });
+
+      try {
+        return await draftRepo.save(draft);
+      } catch (error) {
+        const dbError = error as { code?: string };
+        if (error instanceof QueryFailedError && dbError.code === '23505') {
+          throw new ConflictException('Active create draft limit reached.');
+        }
+        if (error instanceof QueryFailedError) {
+          throw new InternalServerErrorException('Failed to create draft.');
+        }
+        throw error;
+      }
+    });
   }
 
   async getGroupDraft(

--- a/backend/src/modules/post/post-publish.service.ts
+++ b/backend/src/modules/post/post-publish.service.ts
@@ -214,9 +214,10 @@ export class PostPublishService {
       });
       return postId;
     } catch (error) {
-      this.postDraftGateway.broadcastDraftPublishFailed(
+      const currentVersion = await this.getDraftCurrentVersion(draftId);
+      this.postDraftGateway.broadcastDraftPublishEnded(
         draftId,
-        this.resolvePublishFailureMessage(error),
+        currentVersion ?? undefined,
       );
       if (error instanceof QueryFailedError) {
         const dbError = error as { code?: string };
@@ -403,9 +404,10 @@ export class PostPublishService {
       });
       return postId;
     } catch (error) {
-      this.postDraftGateway.broadcastDraftPublishFailed(
+      const currentVersion = await this.getDraftCurrentVersion(draftId);
+      this.postDraftGateway.broadcastDraftPublishEnded(
         draftId,
-        this.resolvePublishFailureMessage(error),
+        currentVersion ?? undefined,
       );
       if (error instanceof QueryFailedError) {
         const dbError = error as { code?: string };
@@ -417,19 +419,6 @@ export class PostPublishService {
     } finally {
       this.draftStateService.finishPublishing(draftId);
     }
-  }
-
-  private resolvePublishFailureMessage(error: unknown): string {
-    if (
-      error instanceof BadRequestException ||
-      error instanceof ConflictException ||
-      error instanceof ForbiddenException ||
-      error instanceof NotFoundException ||
-      error instanceof UnauthorizedException
-    ) {
-      return error.message;
-    }
-    return '발행에 실패했습니다.';
   }
 
   private updateGroupLastActivity(groupId: string, postId: string) {
@@ -450,6 +439,24 @@ export class PostPublishService {
           `Failed to update group lastActivityAt (groupId=${groupId}, postId=${postId}): ${message}`,
         );
       });
+  }
+
+  private async getDraftCurrentVersion(draftId: string) {
+    try {
+      const draft = await this.postRepository.manager
+        .getRepository(PostDraft)
+        .findOne({
+          where: { id: draftId },
+          select: { version: true },
+        });
+      return draft?.version ?? null;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown error';
+      this.logger.warn(
+        `Failed to load draft version (draftId=${draftId}): ${message}`,
+      );
+      return null;
+    }
   }
 
   private ensureBlockIds(blocks: CreatePostDto['blocks']) {

--- a/backend/src/modules/post/post.service.ts
+++ b/backend/src/modules/post/post.service.ts
@@ -311,6 +311,20 @@ export class PostService {
       permission = isOwner ? 'OWNER' : null;
     }
 
+    let hasActiveEditDraft: boolean | undefined;
+    if (post.scope === PostScope.GROUP && post.groupId) {
+      const activeEditDraft = await this.postDraftRepository.findOne({
+        where: {
+          groupId: post.groupId,
+          targetPostId: postId,
+          kind: 'EDIT',
+          isActive: true,
+        },
+        select: { id: true },
+      });
+      hasActiveEditDraft = Boolean(activeEditDraft);
+    }
+
     const dto: PostDetailDto = {
       id: post.id,
       scope: post.scope,
@@ -331,6 +345,7 @@ export class PostService {
       })),
       contributors: contributorDtos,
       permission,
+      hasActiveEditDraft,
     };
     return dto;
   }

--- a/backend/src/seed/seed.ts
+++ b/backend/src/seed/seed.ts
@@ -225,13 +225,15 @@ async function ensureGroupMember(group: Group, user: User) {
 async function upsertSeedDraft(owner: User, group: Group) {
   const draftRepository = dataSource.getRepository(PostDraft);
   const existing = await draftRepository.findOne({
-    where: { groupId: group.id, isActive: true },
+    where: { groupId: group.id, isActive: true, kind: 'CREATE' },
   });
   if (existing) return existing;
 
   const draft = draftRepository.create({
     groupId: group.id,
     ownerActorId: owner.id,
+    kind: 'CREATE',
+    createSlot: 1,
     snapshot: {
       scope: PostScope.GROUP,
       groupId: group.id,

--- a/frontend/src/app/(main)/_components/RecordList.tsx
+++ b/frontend/src/app/(main)/_components/RecordList.tsx
@@ -47,29 +47,36 @@ export default function RecordList({ initialPreviews }: RecordListProps) {
             className="rounded-2xl p-6 shadow-sm border active:scale-[0.98] transition-all cursor-pointer overflow-hidden dark:bg-[#1E1E1E] dark:border-white/5 bg-white border-gray-100"
           >
             <div className="flex items-center justify-between mb-4">
-              <div className="flex items-center gap-2 min-w-0">
-                <h4 className="text-[16px] font-bold truncate dark:text-white text-itta-black">
-                  {record.title}
-                </h4>
-                {record.scope === 'GROUP' ? (
-                  <div className="flex items-center gap-1.5 shrink-0">
-                    <div className="flex items-center gap-1 px-2 py-0.5 rounded-md text-[10px] font-bold bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 shrink-0">
-                      <Users className="w-3 h-3" />
-                      <span>그룹</span>
-                    </div>
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 min-w-0">
+                  <h4 className="text-[16px] font-bold truncate dark:text-white text-itta-black">
+                    {record.title}
+                  </h4>
+                  {record.scope === 'GROUP' ? (
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      <div className="flex items-center gap-1 px-2 py-0.5 rounded-md text-[10px] font-bold bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 shrink-0">
+                        <Users className="w-3 h-3" />
+                        <span>그룹</span>
+                      </div>
 
-                    {/* 그룹명 전용 뱃지 (동그란 점 포함) */}
-                    <div className="px-2 py-0.5 rounded-md text-[10px] font-bold bg-emerald-50 text-emerald-600 border border-emerald-100 dark:bg-emerald-500/10 dark:text-emerald-400 dark:border-emerald-500/20">
-                      <span className="truncate max-w-[70px] inline-block align-bottom">
-                        {record.groupName}
-                      </span>
+                      {/* 그룹명 전용 뱃지 (동그란 점 포함) */}
+                      <div className="px-2 py-0.5 rounded-md text-[10px] font-bold bg-emerald-50 text-emerald-600 border border-emerald-100 dark:bg-emerald-500/10 dark:text-emerald-400 dark:border-emerald-500/20">
+                        <span className="truncate max-w-[70px] inline-block align-bottom">
+                          {record.groupName}
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                ) : (
-                  <div className="flex items-center gap-1 px-2 py-0.5 rounded-md text-[10px] font-bold bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 shrink-0">
-                    <User className="w-3 h-3" />
-                    <span>개인</span>
-                  </div>
+                  ) : (
+                    <div className="flex items-center gap-1 px-2 py-0.5 rounded-md text-[10px] font-bold bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400 shrink-0">
+                      <User className="w-3 h-3" />
+                      <span>개인</span>
+                    </div>
+                  )}
+                </div>
+                {record.hasActiveEditDraft && (
+                  <p className="mt-1 text-[11px] font-medium text-gray-400 dark:text-gray-500">
+                    공동 수정 중...
+                  </p>
                 )}
               </div>
             </div>

--- a/frontend/src/app/(post)/group/[groupId]/(root)/layout.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/(root)/layout.tsx
@@ -1,5 +1,5 @@
 import GroupHeader from '../../_components/GroupHeader';
-import GroupDraftList from '../../_components/GroupDraftList';
+import GroupDraftFloating from '../../_components/GroupDraftFloating';
 
 export default async function GroupRootLayout({
   children,
@@ -13,7 +13,7 @@ export default async function GroupRootLayout({
   return (
     <main className="w-full flex flex-col gap-6 p-6">
       <GroupHeader groupId={groupId} />
-      <GroupDraftList groupId={groupId} />
+      <GroupDraftFloating groupId={groupId} />
       <>
         <div className="flex items-center justify-start px-1">
           <h3 className="text-[10px] font-semibold text-gray-400 uppercase tracking-widest">

--- a/frontend/src/app/(post)/group/[groupId]/(root)/layout.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/(root)/layout.tsx
@@ -1,4 +1,5 @@
 import GroupHeader from '../../_components/GroupHeader';
+import GroupDraftList from '../../_components/GroupDraftList';
 
 export default async function GroupRootLayout({
   children,
@@ -12,6 +13,7 @@ export default async function GroupRootLayout({
   return (
     <main className="w-full flex flex-col gap-6 p-6">
       <GroupHeader groupId={groupId} />
+      <GroupDraftList groupId={groupId} />
       <>
         <div className="flex items-center justify-start px-1">
           <h3 className="text-[10px] font-semibold text-gray-400 uppercase tracking-widest">

--- a/frontend/src/app/(post)/group/_components/GroupDraftFloating.tsx
+++ b/frontend/src/app/(post)/group/_components/GroupDraftFloating.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect, useState, useMemo } from 'react';
+import { Edit3, X } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+import GroupDraftList from './GroupDraftList';
+import { cn } from '@/lib/utils';
+import { useSocketStore } from '@/store/useSocketStore';
+import { groupMyRoleOptions } from '@/lib/api/group';
+import { useNewPostDraft } from '@/hooks/useGrouprRecord';
+import {
+  GroupDraftListItem,
+  GroupDraftListSnapshot,
+} from '@/lib/types/recordCollaboration';
+import { getErrorMessage } from '@/lib/utils/errorHandler';
+
+export default function GroupDraftFloatingButton({
+  groupId,
+}: {
+  groupId: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
+  const { socket } = useSocketStore();
+  const [drafts, setDrafts] = useState<GroupDraftListItem[]>([]);
+
+  // 1. 소켓 데이터 관리 (전역 상태 공유)
+  useEffect(() => {
+    if (!socket || !groupId) return;
+    const handleSnapshot = (payload: GroupDraftListSnapshot) => {
+      if (payload.groupId !== groupId) return;
+      setDrafts(payload.drafts);
+    };
+    const join = () => socket.emit('JOIN_GROUP_DRAFTS', { groupId });
+    socket.on('GROUP_DRAFTS_SNAPSHOT', handleSnapshot);
+    socket.on('connect', join);
+    join();
+    return () => {
+      socket.off('GROUP_DRAFTS_SNAPSHOT', handleSnapshot);
+      socket.off('connect', join);
+      socket.emit('LEAVE_GROUP_DRAFTS', { groupId });
+    };
+  }, [socket, groupId]);
+
+  // 2. 권한 및 작성 로직 관리
+  const { data: roleData } = useQuery({
+    ...groupMyRoleOptions(groupId),
+    enabled: !!groupId,
+  });
+  const isViewer = roleData?.role === 'VIEWER';
+  const { refetch: getNewPostDraft } = useNewPostDraft(groupId);
+
+  const createDraftCount = useMemo(
+    () => drafts.filter((d) => d.kind === 'CREATE').length,
+    [drafts],
+  );
+  const canCreateDraft = !isViewer && createDraftCount < 5;
+
+  const handleCreateDraft = async () => {
+    if (!groupId || !canCreateDraft) return;
+    try {
+      const result = await getNewPostDraft();
+      if (result.error) return toast.error(getErrorMessage(result.error));
+      if (result.data?.redirectUrl) router.push(result.data.redirectUrl);
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+    }
+  };
+
+  return (
+    <div className="absolute bottom-24 right-8 z-50 flex flex-col items-end gap-4">
+      <div
+        className={cn(
+          'w-[320px] sm:w-[400px] max-h-[400px] overflow-hidden rounded-[32px] border shadow-2xl bg-white/95 dark:bg-[#1E1E1E]/95 border-gray-100 dark:border-white/10 flex flex-col transition-all duration-300 ease-out origin-bottom-right',
+          isOpen
+            ? 'opacity-100 scale-100 translate-y-0 visible'
+            : 'opacity-0 scale-95 translate-y-4 invisible',
+        )}
+      >
+        {/* 상단 헤더 */}
+        <div className="sticky top-0 z-20 p-5 border-b dark:border-white/5 border-gray-50 flex items-center justify-between bg-white/80 dark:bg-[#1E1E1E]/80 backdrop-blur-md">
+          <div className="flex flex-col">
+            <h3 className="text-base font-bold dark:text-white text-itta-black">
+              공동 작성 중
+            </h3>
+            <p className="text-[11px] text-gray-400 font-medium">
+              실시간으로 편집 중인 기록들
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleCreateDraft}
+              disabled={!canCreateDraft}
+              className={cn(
+                'p-2 rounded-full transition-all active:scale-95 text-xs',
+                canCreateDraft
+                  ? 'bg-itta-black text-white hover:bg-itta-black/80'
+                  : 'bg-gray-100 text-gray-300 cursor-not-allowed',
+              )}
+            >
+              새 드래프트
+            </button>
+            <button
+              onClick={() => setIsOpen(false)}
+              className="p-2 hover:bg-gray-100 dark:hover:bg-white/10 rounded-full text-gray-500"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+
+        {/* 스크롤 영역 */}
+        <div className="flex-1 overflow-y-auto px-4 pt-2 pb-4! bg-transparent [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+          <GroupDraftList
+            groupId={groupId}
+            drafts={drafts}
+            isViewer={isViewer}
+          />
+        </div>
+      </div>
+
+      {/* 플로팅 버튼 */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={cn(
+          'relative group h-14 w-14 rounded-full flex items-center justify-center shadow-lg transition-all active:scale-95',
+          isOpen
+            ? 'bg-gray-100 dark:bg-white/10 text-gray-600 dark:text-white'
+            : 'bg-itta-black text-white',
+        )}
+      >
+        {isOpen ? <X className="w-7 h-7" /> : <Edit3 className="w-6 h-6" />}
+        {!isOpen && drafts.length > 0 && (
+          <span className="absolute -top-1 -right-1 flex h-5 min-w-[20px] items-center justify-center rounded-full bg-itta-point px-1.5 text-[10px] font-bold text-white ring-2 ring-white dark:ring-[#121212]">
+            {drafts.length}
+          </span>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/group/_components/GroupDraftList.tsx
+++ b/frontend/src/app/(post)/group/_components/GroupDraftList.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Users } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { useSocketStore } from '@/store/useSocketStore';
+import { groupMyRoleOptions } from '@/lib/api/group';
+import { useNewPostDraft } from '@/hooks/useGrouprRecord';
+import {
+  GroupDraftListItem,
+  GroupDraftListSnapshot,
+} from '@/lib/types/recordCollaboration';
+import { formatDotDateString } from '@/lib/date';
+import { cn } from '@/lib/utils';
+import { getErrorMessage } from '@/lib/utils/errorHandler';
+
+interface GroupDraftListProps {
+  groupId: string;
+}
+
+export default function GroupDraftList({ groupId }: GroupDraftListProps) {
+  const router = useRouter();
+  const { socket } = useSocketStore();
+  const [drafts, setDrafts] = useState<GroupDraftListItem[]>([]);
+
+  const { data: roleData } = useQuery({
+    ...groupMyRoleOptions(groupId),
+    enabled: !!groupId,
+  });
+
+  const isViewer = roleData?.role === 'VIEWER';
+  const { refetch: getNewPostDraft } = useNewPostDraft(groupId);
+
+  useEffect(() => {
+    if (!socket || !groupId) return;
+
+    const handleSnapshot = (payload: GroupDraftListSnapshot) => {
+      if (payload.groupId !== groupId) return;
+      setDrafts(payload.drafts);
+    };
+
+    const join = () => {
+      socket.emit('JOIN_GROUP_DRAFTS', { groupId });
+    };
+
+    socket.on('GROUP_DRAFTS_SNAPSHOT', handleSnapshot);
+    socket.on('connect', join);
+    join();
+
+    return () => {
+      socket.off('GROUP_DRAFTS_SNAPSHOT', handleSnapshot);
+      socket.off('connect', join);
+      socket.emit('LEAVE_GROUP_DRAFTS', { groupId });
+    };
+  }, [socket, groupId]);
+
+  const createDraftCount = useMemo(
+    () => drafts.filter((draft) => draft.kind === 'CREATE').length,
+    [drafts],
+  );
+
+  const canCreateDraft = !isViewer && createDraftCount < 5;
+
+  const handleCreateDraft = async () => {
+    if (!groupId) return;
+
+    try {
+      const result = await getNewPostDraft();
+      if (result.error) {
+        toast.error(getErrorMessage(result.error));
+        return;
+      }
+      const redirectUrl = result.data?.redirectUrl;
+      if (!redirectUrl) {
+        toast.error('공동 기록을 시작할 수 없어요.');
+        return;
+      }
+      router.push(redirectUrl);
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+    }
+  };
+
+  if (!groupId) return null;
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between px-1">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] font-semibold text-gray-400 uppercase tracking-widest">
+            공동 작성 중
+          </span>
+          <span className="text-[11px] font-semibold text-gray-400">
+            {drafts.length}개
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={handleCreateDraft}
+          disabled={!canCreateDraft}
+          className={cn(
+            'px-3 py-1.5 rounded-full text-[11px] font-semibold transition-all',
+            canCreateDraft
+              ? 'text-white bg-itta-black hover:bg-itta-black/80 active:scale-95'
+              : 'text-gray-300 bg-gray-200 cursor-not-allowed',
+          )}
+        >
+          새 드래프트
+        </button>
+      </div>
+
+      {drafts.length === 0 ? (
+        <div className="px-4 py-6 rounded-2xl border border-dashed dark:bg-white/5 dark:border-white/10 bg-white border-gray-200">
+          <p className="text-sm font-medium text-gray-400">
+            열려 있는 공동 작성이 없어요.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-3">
+          {drafts.map((draft) => {
+            const title = draft.title?.trim() || '제목 없음';
+            const createdAt = formatDotDateString(draft.createdAt);
+            const updatedAt = formatDotDateString(draft.updatedAt);
+            const kindLabel = draft.kind === 'CREATE' ? '공동 작성' : '공동 수정';
+
+            return (
+              <button
+                key={draft.draftId}
+                type="button"
+                onClick={() =>
+                  !isViewer &&
+                  router.push(`/group/${groupId}/post/${draft.draftId}`)
+                }
+                disabled={isViewer}
+                className={cn(
+                  'w-full text-left rounded-2xl border p-4 shadow-sm transition-all',
+                  'dark:bg-[#1E1E1E] dark:border-white/5 bg-white border-gray-100',
+                  isViewer
+                    ? 'opacity-60 cursor-not-allowed'
+                    : 'hover:shadow-md active:scale-[0.99]',
+                )}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 space-y-2">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span
+                        className={cn(
+                          'px-2 py-0.5 rounded-full text-[10px] font-bold',
+                          draft.kind === 'CREATE'
+                            ? 'bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300'
+                            : 'bg-amber-50 text-amber-600 dark:bg-amber-500/10 dark:text-amber-300',
+                        )}
+                      >
+                        {kindLabel}
+                      </span>
+                      {draft.isPublishing && (
+                        <span className="px-2 py-0.5 rounded-full text-[10px] font-bold bg-red-50 text-red-500 dark:bg-red-500/10 dark:text-red-400">
+                          발행 중
+                        </span>
+                      )}
+                    </div>
+                    <div className="space-y-1">
+                      <h4 className="text-[15px] font-semibold truncate dark:text-white text-itta-black">
+                        {title}
+                      </h4>
+                      <p className="text-[11px] text-gray-400">
+                        작성 {createdAt} · 수정 {updatedAt}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 text-[11px] font-semibold text-gray-500 shrink-0">
+                    <Users className="w-3.5 h-3.5" />
+                    {draft.participantCount}명
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/app/(post)/group/_components/GroupDraftList.tsx
+++ b/frontend/src/app/(post)/group/_components/GroupDraftList.tsx
@@ -1,131 +1,40 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Users } from 'lucide-react';
-import { useQuery } from '@tanstack/react-query';
-import { toast } from 'sonner';
-
-import { useSocketStore } from '@/store/useSocketStore';
-import { groupMyRoleOptions } from '@/lib/api/group';
-import { useNewPostDraft } from '@/hooks/useGrouprRecord';
-import {
-  GroupDraftListItem,
-  GroupDraftListSnapshot,
-} from '@/lib/types/recordCollaboration';
+import { GroupDraftListItem } from '@/lib/types/recordCollaboration';
 import { formatDotDateString } from '@/lib/date';
 import { cn } from '@/lib/utils';
-import { getErrorMessage } from '@/lib/utils/errorHandler';
 
 interface GroupDraftListProps {
   groupId: string;
+  drafts: GroupDraftListItem[];
+  isViewer: boolean;
 }
 
-export default function GroupDraftList({ groupId }: GroupDraftListProps) {
+export default function GroupDraftList({
+  groupId,
+  drafts,
+  isViewer,
+}: GroupDraftListProps) {
   const router = useRouter();
-  const { socket } = useSocketStore();
-  const [drafts, setDrafts] = useState<GroupDraftListItem[]>([]);
-
-  const { data: roleData } = useQuery({
-    ...groupMyRoleOptions(groupId),
-    enabled: !!groupId,
-  });
-
-  const isViewer = roleData?.role === 'VIEWER';
-  const { refetch: getNewPostDraft } = useNewPostDraft(groupId);
-
-  useEffect(() => {
-    if (!socket || !groupId) return;
-
-    const handleSnapshot = (payload: GroupDraftListSnapshot) => {
-      if (payload.groupId !== groupId) return;
-      setDrafts(payload.drafts);
-    };
-
-    const join = () => {
-      socket.emit('JOIN_GROUP_DRAFTS', { groupId });
-    };
-
-    socket.on('GROUP_DRAFTS_SNAPSHOT', handleSnapshot);
-    socket.on('connect', join);
-    join();
-
-    return () => {
-      socket.off('GROUP_DRAFTS_SNAPSHOT', handleSnapshot);
-      socket.off('connect', join);
-      socket.emit('LEAVE_GROUP_DRAFTS', { groupId });
-    };
-  }, [socket, groupId]);
-
-  const createDraftCount = useMemo(
-    () => drafts.filter((draft) => draft.kind === 'CREATE').length,
-    [drafts],
-  );
-
-  const canCreateDraft = !isViewer && createDraftCount < 5;
-
-  const handleCreateDraft = async () => {
-    if (!groupId) return;
-
-    try {
-      const result = await getNewPostDraft();
-      if (result.error) {
-        toast.error(getErrorMessage(result.error));
-        return;
-      }
-      const redirectUrl = result.data?.redirectUrl;
-      if (!redirectUrl) {
-        toast.error('공동 기록을 시작할 수 없어요.');
-        return;
-      }
-      router.push(redirectUrl);
-    } catch (error) {
-      toast.error(getErrorMessage(error));
-    }
-  };
 
   if (!groupId) return null;
 
   return (
     <section className="space-y-3">
-      <div className="flex items-center justify-between px-1">
-        <div className="flex items-center gap-2">
-          <span className="text-[10px] font-semibold text-gray-400 uppercase tracking-widest">
-            공동 작성 중
-          </span>
-          <span className="text-[11px] font-semibold text-gray-400">
-            {drafts.length}개
-          </span>
-        </div>
-        <button
-          type="button"
-          onClick={handleCreateDraft}
-          disabled={!canCreateDraft}
-          className={cn(
-            'px-3 py-1.5 rounded-full text-[11px] font-semibold transition-all',
-            canCreateDraft
-              ? 'text-white bg-itta-black hover:bg-itta-black/80 active:scale-95'
-              : 'text-gray-300 bg-gray-200 cursor-not-allowed',
-          )}
-        >
-          새 드래프트
-        </button>
-      </div>
-
       {drafts.length === 0 ? (
-        <div className="px-4 py-6 rounded-2xl border border-dashed dark:bg-white/5 dark:border-white/10 bg-white border-gray-200">
-          <p className="text-sm font-medium text-gray-400">
+        <div className="px-4 py-8 rounded-2xl border border-dashed dark:bg-white/5 dark:border-white/10 border-gray-100 text-center">
+          <p className="text-xs font-medium text-gray-400">
             열려 있는 공동 작성이 없어요.
           </p>
         </div>
       ) : (
-        <div className="grid gap-3">
+        <div className="grid gap-2.5">
           {drafts.map((draft) => {
             const title = draft.title?.trim() || '제목 없음';
             const createdAt = formatDotDateString(draft.createdAt);
             const updatedAt = formatDotDateString(draft.updatedAt);
-            const kindLabel = draft.kind === 'CREATE' ? '공동 작성' : '공동 수정';
-
             return (
               <button
                 key={draft.draftId}
@@ -150,30 +59,25 @@ export default function GroupDraftList({ groupId }: GroupDraftListProps) {
                         className={cn(
                           'px-2 py-0.5 rounded-full text-[10px] font-bold',
                           draft.kind === 'CREATE'
-                            ? 'bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10 dark:text-emerald-300'
-                            : 'bg-amber-50 text-amber-600 dark:bg-amber-500/10 dark:text-amber-300',
+                            ? 'bg-emerald-50 text-emerald-600 dark:bg-emerald-500/10'
+                            : 'bg-amber-50 text-amber-600 dark:bg-amber-500/10',
                         )}
                       >
-                        {kindLabel}
+                        {draft.kind === 'CREATE' ? '공동 작성' : '공동 수정'}
                       </span>
-                      {draft.isPublishing && (
-                        <span className="px-2 py-0.5 rounded-full text-[10px] font-bold bg-red-50 text-red-500 dark:bg-red-500/10 dark:text-red-400">
-                          발행 중
-                        </span>
-                      )}
                     </div>
                     <div className="space-y-1">
-                      <h4 className="text-[15px] font-semibold truncate dark:text-white text-itta-black">
+                      <h4 className="text-[14px] font-bold truncate dark:text-white text-itta-black">
                         {title}
                       </h4>
-                      <p className="text-[11px] text-gray-400">
+                      <p className="text-[10px] text-gray-400">
                         작성 {createdAt} · 수정 {updatedAt}
                       </p>
                     </div>
                   </div>
-                  <div className="flex items-center gap-1 text-[11px] font-semibold text-gray-500 shrink-0">
-                    <Users className="w-3.5 h-3.5" />
-                    {draft.participantCount}명
+                  <div className="flex items-center gap-1 text-[10px] font-bold text-gray-400 shrink-0">
+                    <Users className="w-3 h-3" />
+                    {draft.participantCount}
                   </div>
                 </div>
               </button>

--- a/frontend/src/app/(post)/record/_components/RecordDetail.tsx
+++ b/frontend/src/app/(post)/record/_components/RecordDetail.tsx
@@ -35,9 +35,16 @@ export default function RecordDetail({ recordId }: RecordDetailProps) {
       </header>
 
       <main className="grow flex flex-col max-w-4xl mx-auto">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">
-          {record.title}
-        </h1>
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            {record.title}
+          </h1>
+          {record.hasActiveEditDraft && (
+            <p className="mt-1 text-xs font-medium text-gray-400 dark:text-gray-500">
+              공동 수정 중...
+            </p>
+          )}
+        </div>
 
         <div className="grow space-y-3">
           {sortedRows.map(([rowNumber, blocks]) => {

--- a/frontend/src/components/DailyDetailRecordItem.tsx
+++ b/frontend/src/components/DailyDetailRecordItem.tsx
@@ -103,10 +103,17 @@ export default function DailyDetailRecordItem({
           className="rounded-lg p-5 border shadow-sm cursor-pointer active:scale-[0.99] transition-all overflow-hidden dark:bg-[#1E1E1E] dark:border-white/5 bg-white border-gray-100/60"
         >
           {/* 제목 & 멤버 아바타 */}
-          <div className="w-full flex justify-between items-center gap-2 mb-4">
-            <h4 className="text-[15px] font-bold truncate dark:text-gray-200 text-itta-black">
-              {record.title}
-            </h4>
+          <div className="w-full flex justify-between items-start gap-2 mb-4">
+            <div className="min-w-0">
+              <h4 className="text-[15px] font-bold truncate dark:text-gray-200 text-itta-black">
+                {record.title}
+              </h4>
+              {record.hasActiveEditDraft && (
+                <p className="mt-1 text-[11px] font-medium text-gray-400 dark:text-gray-500">
+                  공동 수정 중...
+                </p>
+              )}
+            </div>
 
             <div className="flex -space-x-2 shrink-0">
               {groupId &&

--- a/frontend/src/lib/types/record.ts
+++ b/frontend/src/lib/types/record.ts
@@ -228,6 +228,7 @@ export interface RecordDetailResponse {
   updatedAt: string;
   blocks: Block[];
   contributors: Contributor[];
+  hasActiveEditDraft?: boolean;
 }
 
 // 지도 리스트 아이템

--- a/frontend/src/lib/types/recordCollaboration.ts
+++ b/frontend/src/lib/types/recordCollaboration.ts
@@ -48,3 +48,19 @@ export interface SocketExceptionResponse {
   };
   data?: SocketExceptionData;
 }
+
+export interface GroupDraftListItem {
+  draftId: string;
+  kind: 'CREATE' | 'EDIT';
+  targetPostId: string | null;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  participantCount: number;
+  isPublishing: boolean;
+}
+
+export interface GroupDraftListSnapshot {
+  groupId: string;
+  drafts: GroupDraftListItem[];
+}

--- a/frontend/src/lib/types/recordResponse.ts
+++ b/frontend/src/lib/types/recordResponse.ts
@@ -27,6 +27,7 @@ export interface RecordDetail {
   updatedAt: string;
   blocks: RecordBlock[];
   contributors: Contributor[];
+  hasActiveEditDraft?: boolean;
 }
 
 export interface RecordPreview {
@@ -44,6 +45,7 @@ export interface RecordPreview {
   emotion: string[];
   rating: RatingValue['rating'] | null;
   blocks: Block[];
+  hasActiveEditDraft?: boolean;
 }
 
 export interface newGroupResponse {

--- a/frontend/src/store/useSocketStore.ts
+++ b/frontend/src/store/useSocketStore.ts
@@ -97,6 +97,10 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
     });
 
     socket.on('exception', async (data: SocketExceptionResponse) => {
+      if (data.message === 'Draft is full.') {
+        toast.warning('참여 인원이 가득 찼어요.');
+        return;
+      }
       if (data.message === 'Invalid access token.' || data.status === 'error') {
         await handleAuthError();
         return;


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

## 작업 내용 + 스크린샷
- STREAM fanout 완화(샘플링/volatile/드롭)
- publish 종료 이벤트에 currentVersion 포함 + 프론트 동기화
- CREATE draft 5개 제한 + JOIN 10명 제한
- 그룹함 드래프트 목록 소켓 구독/3초 갱신
- 피드/타임라인/상세 “공동 수정 중” 라벨 추가

## 실제 걸린 시간
약 10시간 

## 작업하며 고민했던 점(선택)
- 슬롯 방식 vs DB/락 방식 중 슬롯+트랜잭션으로 선택
## 테스트 실행 여부

- [x] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
