### PR TITLE
게시글 수정 시 새로운 기록이 추가되는 문제 해결

### DIFF
--- a/frontend/src/app/(post)/add/page.tsx
+++ b/frontend/src/app/(post)/add/page.tsx
@@ -47,5 +47,12 @@ export default async function AddPostPage({ searchParams }: AddPostPageProps) {
     logger.error('post editor 데이터 로드 실패', error);
   }
 
-  return <PostEditor groupId={groupId} mode={mode} initialPost={initialPost} />;
+  return (
+    <PostEditor
+      groupId={groupId}
+      postId={postId}
+      mode={mode}
+      initialPost={initialPost}
+    />
+  );
 }

--- a/frontend/src/app/(post)/group/_components/GroupDraftList.tsx
+++ b/frontend/src/app/(post)/group/_components/GroupDraftList.tsx
@@ -21,6 +21,17 @@ export default function GroupDraftList({
 
   if (!groupId) return null;
 
+  const getDraftUrl = (draft: GroupDraftListItem) => {
+    const baseUrl = `/group/${groupId}/post/${draft.draftId}`;
+
+    // 수정 모드일 경우 쿼리 파라미터 추가
+    if (draft.kind === 'EDIT' && draft.targetPostId) {
+      return `${baseUrl}?mode=edit&postId=${draft.targetPostId}`;
+    }
+
+    return baseUrl;
+  };
+
   return (
     <section className="space-y-3">
       {drafts.length === 0 ? (
@@ -39,10 +50,7 @@ export default function GroupDraftList({
               <button
                 key={draft.draftId}
                 type="button"
-                onClick={() =>
-                  !isViewer &&
-                  router.push(`/group/${groupId}/post/${draft.draftId}`)
-                }
+                onClick={() => !isViewer && router.push(getDraftUrl(draft))}
                 disabled={isViewer}
                 className={cn(
                   'w-full text-left rounded-2xl border p-4 shadow-sm transition-all',


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)
- #245 

## 작업 내용 + 스크린샷
기존에 수정 버튼을 눌렀는데 새 게시글이 추가되는 버그를 수정했습니다

### 개인 게시글 수정 시 생성되는 에러
원인은
제가 서버 컴포넌트에서 쿼리 파라미터에 있는 postId를 전달하여, 해당 postId가 있다면 edit 관련 api 를 호출하도록 로직을 구성해놨었는데, 개인 기록에서 postId 를 제대로 props 로 안 넘기고 있었습니다!

그래서 해당 부분 `props 로 추가하여 수정 완료`되는 것 확인했습니다.

### 그룹 게시글 플로팅 버튼 내에서 항상 새 게시글 작성 로직으로 가지는 에러

또한, 플로팅 버튼에서 게시글 작성이냐, 수정이냐에 따라 쿼리 파라미터를 다르게 전달하여 **그룹 내에서도 edit,create** 를 구분해야했는데 구분 되어있지 않고 **모두 게시글 작성으로 전달**되고 있기에 해당 부분도 
아이템 클릭 시 `이동하는 URL 을 수정/작성이냐에 따라 구분하여 처리`되도록 수정했습니다.

## 실제 걸린 시간
1h보다 적게 ..?
 
## 작업하며 고민했던 점(선택)

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
