### PR TITLE
페이지 라우팅 로딩 시간 최적화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,25 @@ jobs:
         env:
           NEXT_PUBLIC_PRODUCTION_API_URL: ${{ secrets.NEXT_PUBLIC_PRODUCTION_API_URL }}
 
+      - name: Start Next.js server
+        run: pnpm --filter frontend start &
+        env:
+          NEXT_PUBLIC_PRODUCTION_API_URL: ${{ secrets.NEXT_PUBLIC_PRODUCTION_API_URL }}
+
+      - name: Wait for server to be ready
+        run: |
+          for i in {1..30}; do
+            if curl -sf http://localhost:3000 > /dev/null; then
+              echo "Server is ready"
+              exit 0
+            fi
+            echo "Waiting for server... ($i/30)"
+            sleep 2
+          done
+          echo "Server did not start in time"
+          exit 1
+
       - name: Run Lighthouse CI
-        # npx lhci는 루트에서 실행하되
-        # --config 경로는 frontend 폴더 안의 파일을 가리킴
         run: |
           npx @lhci/cli collect --config=./frontend/lighthouse.js
           npx @lhci/cli upload --config=./frontend/lighthouse.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Lighthouse CI
+on: [push, pull_request]
+
+jobs:
+  lhci:
+    name: Lighthouse CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build Next.js
+        run: pnpm build
+
+      - name: Run Lighthouse CI
+        run: npx lhci collect --config=./lighthouse.js && npx lhci upload --config=./lighthouse.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,9 @@ jobs:
           exit 1
 
       - name: Run Lighthouse CI
+        continue-on-error: true
         run: |
-          pnpm --filter frontend exec lhci collect --config=./frontend/lighthouse.js
-          pnpm --filter frontend exec lhci upload --config=./frontend/lighthouse.js
+          pnpm --filter frontend exec lhci collect --config=./lighthouse.js
+          pnpm --filter frontend exec lhci upload --config=./lighthouse.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run Lighthouse CI
         run: |
-          npx @lhci/cli collect --config=./frontend/lighthouse.js
-          npx @lhci/cli upload --config=./frontend/lighthouse.js
+          pnpm --filter frontend exec lhci collect --config=./frontend/lighthouse.js
+          pnpm --filter frontend exec lhci upload --config=./frontend/lighthouse.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Build Next.js
         run: pnpm run build:fe
+        env:
+          NEXT_PUBLIC_PRODUCTION_API_URL: ${{ secrets.NEXT_PUBLIC_PRODUCTION_API_URL }}
 
       - name: Run Lighthouse CI
         # npx lhci는 루트에서 실행하되

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,13 @@ jobs:
         run: pnpm install
 
       - name: Build Next.js
-        run: pnpm build
+        run: pnpm run build:fe
 
       - name: Run Lighthouse CI
-        run: npx lhci collect --config=./lighthouse.js && npx lhci upload --config=./lighthouse.js
+        # npx lhci는 루트에서 실행하되
+        # --config 경로는 frontend 폴더 안의 파일을 가리킴
+        run: |
+          npx lhci collect --config=./frontend/lighthouse.js
+          npx lhci upload --config=./frontend/lighthouse.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         # npx lhci는 루트에서 실행하되
         # --config 경로는 frontend 폴더 안의 파일을 가리킴
         run: |
-          npx lhci collect --config=./frontend/lighthouse.js
-          npx lhci upload --config=./frontend/lighthouse.js
+          npx @lhci/cli collect --config=./frontend/lighthouse.js
+          npx @lhci/cli upload --config=./frontend/lighthouse.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -52,3 +52,6 @@ storybook-static
 .claude/*
 # Sentry Config File
 .env.sentry-build-plugin
+
+# lighthouse
+.lighthouseci/

--- a/frontend/.lighthouserc.js
+++ b/frontend/.lighthouserc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  ci: {
+    collect: {
+      // staticDistDir: '.next',
+      startServerCommand: 'pnpm run start',
+      startServerReadyPattern: 'ready on',
+      startServerReadyTimeout: 60000,
+      numberOfRuns: 3,
+      url: ['http://localhost:3000'],
+    },
+    upload: {
+      target: 'temporary-public-storage',
+    },
+  },
+};

--- a/frontend/lighthouse.js
+++ b/frontend/lighthouse.js
@@ -3,7 +3,7 @@ module.exports = {
   ci: {
     collect: {
       startServerCommand: 'pnpm --filter frontend start',
-      startServerReadyPattern: 'started server on',
+      startServerReadyPattern: 'Ready in',
       // 측정 전 게스트 로그인 자동화
       puppeteerScript: './frontend/lighthouse.puppeteer.js',
       url: [
@@ -13,7 +13,7 @@ module.exports = {
         'http://localhost:3000/search', // 검색
         'http://localhost:3000/my', // 내 기록
         'http://localhost:3000/add', // 기록 추가
-        'http://localhost:3000/share', // 함께 기록함
+        'http://localhost:3000/shared', // 함께 기록함
         'http://localhost:3000/map', // 지도
       ],
       numberOfRuns: 3,

--- a/frontend/lighthouse.js
+++ b/frontend/lighthouse.js
@@ -1,0 +1,25 @@
+/** @type {import('@lhci/cli').LighthouseConfig} */
+module.exports = {
+  ci: {
+    collect: {
+      startServerCommand: 'pnpm --filter frontend start',
+      startServerReadyPattern: 'started server on',
+      // 측정 전 게스트 로그인 자동화
+      puppeteerScript: './lighthouse.puppeteer.js',
+      url: [
+        'http://localhost:3000/login', // 로그인 (public)
+        'http://localhost:3000/', // 홈
+        'http://localhost:3000/profile', // 프로필
+        'http://localhost:3000/search', // 검색
+        'http://localhost:3000/my', // 내 기록
+        'http://localhost:3000/add', // 기록 추가
+        'http://localhost:3000/share', // 함께 기록함
+        'http://localhost:3000/map', // 지도
+      ],
+      numberOfRuns: 3,
+    },
+    upload: {
+      target: 'temporary-public-storage',
+    },
+  },
+};

--- a/frontend/lighthouse.js
+++ b/frontend/lighthouse.js
@@ -3,7 +3,7 @@ module.exports = {
   ci: {
     collect: {
       // 측정 전 게스트 로그인 자동화
-      puppeteerScript: './frontend/lighthouse.puppeteer.js',
+      puppeteerScript: './lighthouse.puppeteer.js',
       url: [
         // 'http://localhost:3000/login', // 로그인 (public)
         'http://localhost:3000/', // 홈

--- a/frontend/lighthouse.js
+++ b/frontend/lighthouse.js
@@ -5,7 +5,7 @@ module.exports = {
       // 측정 전 게스트 로그인 자동화
       puppeteerScript: './frontend/lighthouse.puppeteer.js',
       url: [
-        'http://localhost:3000/login', // 로그인 (public)
+        // 'http://localhost:3000/login', // 로그인 (public)
         'http://localhost:3000/', // 홈
         'http://localhost:3000/profile', // 프로필
         'http://localhost:3000/search', // 검색

--- a/frontend/lighthouse.js
+++ b/frontend/lighthouse.js
@@ -5,7 +5,7 @@ module.exports = {
       startServerCommand: 'pnpm --filter frontend start',
       startServerReadyPattern: 'started server on',
       // 측정 전 게스트 로그인 자동화
-      puppeteerScript: './lighthouse.puppeteer.js',
+      puppeteerScript: './frontend/lighthouse.puppeteer.js',
       url: [
         'http://localhost:3000/login', // 로그인 (public)
         'http://localhost:3000/', // 홈

--- a/frontend/lighthouse.js
+++ b/frontend/lighthouse.js
@@ -2,8 +2,6 @@
 module.exports = {
   ci: {
     collect: {
-      startServerCommand: 'pnpm --filter frontend start',
-      startServerReadyPattern: 'Ready in',
       // 측정 전 게스트 로그인 자동화
       puppeteerScript: './frontend/lighthouse.puppeteer.js',
       url: [

--- a/frontend/lighthouse.puppeteer.js
+++ b/frontend/lighthouse.puppeteer.js
@@ -1,0 +1,78 @@
+'use strict';
+
+/**
+ * Lighthouse CI Puppeteer setup script
+ * Authenticates as a guest user before running Lighthouse measurements
+ */
+module.exports = async (browser, _context) => {
+  const page = await browser.newPage();
+
+  // 도메인 컨텍스트 확보를 위해 로그인 페이지로 이동
+  await page.goto('http://localhost:3000/login', {
+    waitUntil: 'domcontentloaded',
+  });
+
+  // 브라우저 컨텍스트 안에서 게스트 API 호출
+  const authResult = await page.evaluate(async () => {
+    try {
+      const res = await fetch('/api/auth/guest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      });
+      const authHeader =
+        res.headers.get('Authorization') ||
+        res.headers.get('authorization');
+      const accessToken = authHeader ? authHeader.replace('Bearer ', '') : null;
+      const data = await res.json();
+      return { data, accessToken, ok: res.ok };
+    } catch (e) {
+      return { error: e.message, ok: false };
+    }
+  });
+
+  if (!authResult.ok || !authResult.accessToken) {
+    throw new Error(`Guest auth failed: ${JSON.stringify(authResult)}`);
+  }
+
+  const { accessToken, data } = authResult;
+  const { guestSessionId } = data;
+
+  // Zustand persist 상태를 localStorage에 직접 설정
+  await page.evaluate(
+    (state) => {
+      localStorage.setItem('auth-storage', JSON.stringify(state));
+    },
+    {
+      state: {
+        userType: 'guest',
+        userId: null,
+        guestSessionId,
+        guestAccessToken: accessToken,
+        guestSessionExpiresAt: guestSessionId,
+        isLoggedIn: true,
+      },
+      version: 0,
+    },
+  );
+
+  // 쿠키 설정 (API 요청 시 인증에 사용)
+  await page.setCookie(
+    {
+      name: 'x-guest-session-id',
+      value: guestSessionId,
+      domain: 'localhost',
+      path: '/',
+      sameSite: 'Lax',
+    },
+    {
+      name: 'x-guest-access-token',
+      value: accessToken,
+      domain: 'localhost',
+      path: '/',
+      sameSite: 'Lax',
+    },
+  );
+
+  await page.close();
+};

--- a/frontend/lighthouse.puppeteer.js
+++ b/frontend/lighthouse.puppeteer.js
@@ -6,14 +6,21 @@
  */
 module.exports = async (browser, _context) => {
   // Node.js fetch로 직접 게스트 토큰 발급 (page.goto 불필요)
-  const res = await fetch('http://localhost:3000/api/auth/guest', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: '{}',
-  });
+  let res;
+  try {
+    res = await fetch('http://localhost:3000/api/auth/guest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+  } catch (e) {
+    console.warn(`Guest auth request failed (backend unreachable): ${e.message} - skipping auth setup`);
+    return;
+  }
 
   if (!res.ok) {
-    throw new Error(`Guest auth failed: HTTP ${res.status}`);
+    console.warn(`Guest auth failed: HTTP ${res.status} - skipping auth setup`);
+    return;
   }
 
   const authHeader = res.headers.get('Authorization') || res.headers.get('authorization');
@@ -22,7 +29,8 @@ module.exports = async (browser, _context) => {
   const { guestSessionId } = data;
 
   if (!accessToken || !guestSessionId) {
-    throw new Error(`Guest auth missing token: ${JSON.stringify({ accessToken, guestSessionId })}`);
+    console.warn(`Guest auth missing token - skipping auth setup`);
+    return;
   }
 
   // 쿠키를 도메인에 설정 (브라우저 컨텍스트 전체에 적용)

--- a/frontend/lighthouse.puppeteer.js
+++ b/frontend/lighthouse.puppeteer.js
@@ -5,59 +5,28 @@
  * Authenticates as a guest user before running Lighthouse measurements
  */
 module.exports = async (browser, _context) => {
-  const page = await browser.newPage();
-
-  // 도메인 컨텍스트 확보를 위해 로그인 페이지로 이동
-  await page.goto('http://localhost:3000/login', {
-    waitUntil: 'domcontentloaded',
+  // Node.js fetch로 직접 게스트 토큰 발급 (page.goto 불필요)
+  const res = await fetch('http://localhost:3000/api/auth/guest', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}',
   });
 
-  // 브라우저 컨텍스트 안에서 게스트 API 호출
-  const authResult = await page.evaluate(async () => {
-    try {
-      const res = await fetch('/api/auth/guest', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: '{}',
-      });
-      const authHeader =
-        res.headers.get('Authorization') ||
-        res.headers.get('authorization');
-      const accessToken = authHeader ? authHeader.replace('Bearer ', '') : null;
-      const data = await res.json();
-      return { data, accessToken, ok: res.ok };
-    } catch (e) {
-      return { error: e.message, ok: false };
-    }
-  });
-
-  if (!authResult.ok || !authResult.accessToken) {
-    throw new Error(`Guest auth failed: ${JSON.stringify(authResult)}`);
+  if (!res.ok) {
+    throw new Error(`Guest auth failed: HTTP ${res.status}`);
   }
 
-  const { accessToken, data } = authResult;
+  const authHeader = res.headers.get('Authorization') || res.headers.get('authorization');
+  const accessToken = authHeader ? authHeader.replace('Bearer ', '') : null;
+  const data = await res.json();
   const { guestSessionId } = data;
 
-  // Zustand persist 상태를 localStorage에 직접 설정
-  await page.evaluate(
-    (state) => {
-      localStorage.setItem('auth-storage', JSON.stringify(state));
-    },
-    {
-      state: {
-        userType: 'guest',
-        userId: null,
-        guestSessionId,
-        guestAccessToken: accessToken,
-        guestSessionExpiresAt: guestSessionId,
-        isLoggedIn: true,
-      },
-      version: 0,
-    },
-  );
+  if (!accessToken || !guestSessionId) {
+    throw new Error(`Guest auth missing token: ${JSON.stringify({ accessToken, guestSessionId })}`);
+  }
 
-  // 쿠키 설정 (API 요청 시 인증에 사용)
-  await page.setCookie(
+  // 쿠키를 도메인에 설정 (브라우저 컨텍스트 전체에 적용)
+  await browser.defaultBrowserContext().setCookie(
     {
       name: 'x-guest-session-id',
       value: guestSessionId,
@@ -74,5 +43,27 @@ module.exports = async (browser, _context) => {
     },
   );
 
+  // Zustand persist 상태를 localStorage에 설정 (최소한의 페이지 이동만)
+  const page = await browser.newPage();
+  await page.goto('http://localhost:3000', {
+    waitUntil: 'domcontentloaded',
+    timeout: 60000,
+  });
+  await page.evaluate(
+    (state) => {
+      localStorage.setItem('auth-storage', JSON.stringify(state));
+    },
+    {
+      state: {
+        userType: 'guest',
+        userId: null,
+        guestSessionId,
+        guestAccessToken: accessToken,
+        guestSessionExpiresAt: guestSessionId,
+        isLoggedIn: true,
+      },
+      version: 0,
+    },
+  );
   await page.close();
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@googlemaps/markerclusterer": "^2.6.2",
+    "@lhci/cli": "^0.15.1",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.4",

--- a/frontend/src/app/(main)/_components/HomeData.tsx
+++ b/frontend/src/app/(main)/_components/HomeData.tsx
@@ -1,0 +1,43 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { recordPreviewListOptions } from '@/lib/api/records';
+import { userRecordPatternOptions } from '@/lib/api/profile';
+import { formatDateISO } from '@/lib/date';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
+import HomePageSkeleton from './HomePageSkeleton';
+import StreakStats from './StreakStats';
+import RecordList from './RecordList';
+
+export default async function HomeData() {
+  const queryClient = new QueryClient();
+  const today = formatDateISO();
+
+  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
+    queryClient.setQueryData(recordPreviewListOptions(today).queryKey, []);
+    queryClient.setQueryData(userRecordPatternOptions().queryKey, {
+      streak: 0,
+      monthlyRecordingDays: 0,
+    });
+  } else {
+    await Promise.all([
+      queryClient.prefetchQuery(recordPreviewListOptions(today)),
+      queryClient.prefetchQuery(userRecordPatternOptions()),
+    ]);
+  }
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ErrorHandlingWrapper
+        fallbackComponent={ErrorFallback}
+        suspenseFallback={<HomePageSkeleton />}
+      >
+        <StreakStats />
+        <div className="flex-1 w-full overflow-y-auto scrollbar-hide px-5 space-y-6 pt-7 pb-bottom-nav transition-colors duration-300 dark:bg-[#121212] bg-[#F9F9F9]">
+          <div className="w-full flex flex-col gap-6">
+            <RecordList imageLayout="responsive" />
+          </div>
+        </div>
+      </ErrorHandlingWrapper>
+    </HydrationBoundary>
+  );
+}

--- a/frontend/src/app/(main)/_components/HomePageSkeleton.tsx
+++ b/frontend/src/app/(main)/_components/HomePageSkeleton.tsx
@@ -1,0 +1,59 @@
+function StreakStatsSkeleton() {
+  return (
+    <div className="border-t-[0.5px] border-gray-100 dark:border-gray-800 flex w-full p-2 py-3 sm:p-3 sm:py-4 animate-pulse">
+      <div className="flex w-full justify-between gap-1.5 sm:gap-3 items-center border-r px-2 sm:px-3 pr-3 sm:pr-5">
+        <div className="h-3.5 w-12 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="flex items-center gap-1 sm:gap-1.5">
+          <div className="h-5 sm:h-6 w-6 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-3.5 w-14 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+      </div>
+      <div className="flex w-full justify-between gap-1.5 sm:gap-3 items-center px-2 sm:px-3 pl-3 sm:pl-5">
+        <div className="h-3.5 w-14 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="flex items-center gap-1 sm:gap-1.5">
+          <div className="h-5 sm:h-6 w-5 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-3.5 w-4 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RecordItemSkeleton() {
+  return (
+    <div className="rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-sm border dark:bg-[#1E1E1E] dark:border-white/5 bg-white border-gray-100 animate-pulse">
+      <div className="flex items-center justify-between mb-3 sm:mb-4 mt-1">
+        <div className="flex items-center gap-1.5 sm:gap-2">
+          <div className="h-4.5 sm:h-6 w-28 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-4.5 w-10 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+      </div>
+      <div className="space-y-2 sm:space-y-3">
+        <div className="h-3 w-full bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-3 w-4/5 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="w-full aspect-video bg-gray-200 dark:bg-gray-700 rounded-lg" />
+      </div>
+    </div>
+  );
+}
+
+export default function HomePageSkeleton() {
+  return (
+    <>
+      <StreakStatsSkeleton />
+      <div className="flex-1 w-full overflow-y-auto scrollbar-hide px-5 space-y-6 pt-7 pb-bottom-nav transition-colors duration-300 dark:bg-[#121212] bg-[#F9F9F9]">
+        <div className="w-full flex flex-col gap-6">
+          <div className="flex flex-col space-y-3 sm:space-y-4">
+            <div className="flex items-center justify-between px-0.5 sm:px-1 animate-pulse">
+              <div className="h-3.5 sm:h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded" />
+              <div className="h-3 w-10 bg-gray-200 dark:bg-gray-700 rounded" />
+            </div>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <RecordItemSkeleton key={i} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/app/(main)/_components/HomePageSkeleton.tsx
+++ b/frontend/src/app/(main)/_components/HomePageSkeleton.tsx
@@ -19,7 +19,7 @@ function StreakStatsSkeleton() {
   );
 }
 
-function RecordItemSkeleton() {
+export function RecordItemSkeleton() {
   return (
     <div className="rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-sm border dark:bg-[#1E1E1E] dark:border-white/5 bg-white border-gray-100 animate-pulse">
       <div className="flex items-center justify-between mb-3 sm:mb-4 mt-1">

--- a/frontend/src/app/(main)/_components/RecordList.tsx
+++ b/frontend/src/app/(main)/_components/RecordList.tsx
@@ -2,35 +2,29 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { formatDateISO } from '@/lib/date';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { recordPreviewListOptions } from '@/lib/api/records';
 import BlockContent from '@/components/BlockContent';
 import { Block } from '@/lib/types/record';
 import { cn } from '@/lib/utils';
 import { BookOpen, Plus, Users, User } from 'lucide-react';
-import { RecordPreview } from '@/lib/types/recordResponse';
 
 type ImageLayout = 'carousel' | 'tile' | 'responsive';
 
 interface RecordListProps {
-  initialPreviews: RecordPreview[];
   imageLayout?: ImageLayout;
 }
 
-export default function RecordList({
-  initialPreviews,
-  imageLayout = 'tile',
-}: RecordListProps) {
+export default function RecordList({ imageLayout = 'tile' }: RecordListProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
   // URL에서 date 파라미터 읽기, 없으면 오늘 날짜
   const selectedDateStr = searchParams.get('date') || formatDateISO();
 
-  const { data: records = [] } = useQuery({
-    ...recordPreviewListOptions(selectedDateStr),
-    initialData: initialPreviews,
-  });
+  const { data: records } = useSuspenseQuery(
+    recordPreviewListOptions(selectedDateStr),
+  );
 
   return (
     <div className="space-y-3 sm:space-y-4 w-full">
@@ -67,7 +61,7 @@ export default function RecordList({
 
                       {/* 그룹명 전용 뱃지 (동그란 점 포함) */}
                       <div className="px-1.5 sm:px-2 py-0.5 rounded-md text-[9px] sm:text-[10px] font-bold bg-emerald-50 text-emerald-600 border border-emerald-100 dark:bg-emerald-500/10 dark:text-emerald-400 dark:border-emerald-500/20">
-                        <span className="truncate max-w-[60px] sm:max-w-[70px] inline-block align-bottom">
+                        <span className="truncate max-w-15 sm:max-w-17.5 inline-block align-bottom">
                           {record.groupName}
                         </span>
                       </div>

--- a/frontend/src/app/(main)/_components/RecordList.tsx
+++ b/frontend/src/app/(main)/_components/RecordList.tsx
@@ -2,13 +2,14 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { formatDateISO } from '@/lib/date';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
+import { RecordItemSkeleton } from './HomePageSkeleton';
 import { recordPreviewListOptions } from '@/lib/api/records';
 import BlockContent from '@/components/BlockContent';
 import { Block } from '@/lib/types/record';
 import { cn } from '@/lib/utils';
 import { BookOpen, Plus, Users, User } from 'lucide-react';
-import { memo, useMemo } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { RecordPreview } from '@/lib/types/recordResponse';
 
 type ImageLayout = 'carousel' | 'tile' | 'responsive';
@@ -140,28 +141,67 @@ export default function RecordList({ imageLayout = 'tile' }: RecordListProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // URL에서 date 파라미터 읽기, 없으면 오늘 날짜
-  const selectedDateStr = searchParams.get('date') || formatDateISO();
+  const urlDateStr = searchParams.get('date') || formatDateISO();
 
-  const { data: records } = useSuspenseQuery(
+  // WeekCalendar 클릭 즉시 날짜를 받아 skeleton을 바로 표시 (URL 커밋 전)
+  const [pendingDate, setPendingDate] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = (e: Event) =>
+      setPendingDate((e as CustomEvent<string>).detail);
+    window.addEventListener('itda:dateChange', handler);
+    return () => window.removeEventListener('itda:dateChange', handler);
+  }, []);
+
+  // URL이 커밋되면 pendingDate 초기화
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      setPendingDate(null);
+    });
+
+    return () => {
+      cancelAnimationFrame(raf);
+    };
+  }, [urlDateStr]);
+
+  const selectedDateStr = pendingDate ?? urlDateStr;
+
+  const { data: records, isLoading } = useQuery(
     recordPreviewListOptions(selectedDateStr),
   );
+
+  const dayLabel =
+    selectedDateStr === formatDateISO()
+      ? '오늘의 기록'
+      : `${selectedDateStr.split('-')[2]}일의 기록`;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3 sm:space-y-4 w-full">
+        <div className="flex items-center justify-between px-0.5 sm:px-1 animate-pulse">
+          <div className="h-3.5 sm:h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-3 w-10 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <RecordItemSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-3 sm:space-y-4 w-full">
       <div className="flex items-center justify-between px-0.5 sm:px-1">
         <h3 className="text-[13px] sm:text-[14px] font-bold dark:text-white text-itta-black">
-          {selectedDateStr === formatDateISO()
-            ? '오늘의 기록'
-            : `${selectedDateStr.split('-')[2]}일의 기록`}
+          {dayLabel}
         </h3>
         <span className="text-[10px] sm:text-[11px] text-[#10B981] font-bold">
-          총 {records.length}개
+          총 {(records ?? []).length}개
         </span>
       </div>
 
-      {records.length > 0 ? (
-        records.map((record) => (
+      {(records ?? []).length > 0 ? (
+        (records ?? []).map((record) => (
           <RecordItem
             key={record.postId}
             record={record}

--- a/frontend/src/app/(main)/_components/StreakStats.tsx
+++ b/frontend/src/app/(main)/_components/StreakStats.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { userRecordPatternOptions } from '@/lib/api/profile';
+
+export default function StreakStats() {
+  const { data: streakData } = useSuspenseQuery(userRecordPatternOptions());
+
+  return (
+    <div className="border-t-[0.5px] border-gray-100 dark:border-gray-800 flex w-full p-2 sm:p-3 transition-colors duration-300 bg-transparent">
+      <div className="flex w-full justify-between gap-1.5 sm:gap-3 items-center border-r px-2 sm:px-3 pr-3 sm:pr-5">
+        <span className="text-[11px] sm:text-[12px] whitespace-nowrap">
+          오늘 작성
+        </span>
+        <div className="flex justify-start items-center gap-1 sm:gap-1.5">
+          <span className="text-itta-point font-semibold text-sm sm:text-base">
+            {streakData.streak}
+          </span>
+          <span className="text-[11px] sm:text-[12px] font-medium text-gray-400 whitespace-nowrap">
+            일째 작성 중
+          </span>
+        </div>
+      </div>
+      <div className="flex w-full justify-between gap-1.5 sm:gap-3 items-center px-2 sm:px-3 pl-3 sm:pl-5">
+        <span className="text-[11px] sm:text-[12px] whitespace-nowrap">
+          이번달 기록
+        </span>
+        <div className="flex justify-start items-center gap-1 sm:gap-1.5">
+          <span className="text-itta-point font-semibold text-sm sm:text-base">
+            {streakData.monthlyRecordingDays}
+          </span>
+          <span className="text-[11px] sm:text-[12px] font-medium text-gray-400 whitespace-nowrap">
+            일
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/_components/WeekCalendar.tsx
+++ b/frontend/src/app/(main)/_components/WeekCalendar.tsx
@@ -16,11 +16,21 @@ export default function WeekCalendar() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  // URL에서 date 파라미터 읽기 (서버에서 이미 리다이렉트 처리됨)
-  const selectedDateStr = searchParams.get('date') || formatDateISO();
+  // URL에서 date 파라미터 읽기
+  const urlDateStr = searchParams.get('date') || formatDateISO();
+
+  // 클릭 즉시 강조 표시를 위한 낙관적 상태 (URL 커밋 전에도 즉시 반영)
+  const [optimisticDate, setOptimisticDate] = useState(urlDateStr);
+
+  // URL이 커밋되면 동기화
+  useEffect(() => {
+    setOptimisticDate(urlDateStr);
+  }, [urlDateStr]);
+
+  const selectedDateStr = optimisticDate;
 
   const [currentWeekStart, setCurrentWeekStart] = useState(() =>
-    getStartOfWeek(parseLocalDate(selectedDateStr)),
+    getStartOfWeek(parseLocalDate(urlDateStr)),
   );
   const [direction, setDirection] = useState(0); // -1: 이전, 1: 다음
   const [isMounted, setIsMounted] = useState(false); // 초기 마운트 추적
@@ -110,6 +120,10 @@ export default function WeekCalendar() {
       return;
     }
 
+    // 클릭 즉시 강조 표시 반영
+    setOptimisticDate(dateStr);
+    // RecordList에 즉시 알림 (URL 커밋 전)
+    window.dispatchEvent(new CustomEvent('itda:dateChange', { detail: dateStr }));
     // URL 쿼리 파라미터로 날짜 설정
     router.push(`/?date=${dateStr}`);
     calculateYearMonth(dateStr);

--- a/frontend/src/app/(main)/loading.tsx
+++ b/frontend/src/app/(main)/loading.tsx
@@ -1,0 +1,21 @@
+import HomePageSkeleton from './_components/HomePageSkeleton';
+
+function WeekCalendarSkeleton() {
+  return (
+    <>
+      <div className="flex flex-col gap-2 px-2 py-2 sm:px-6 sm:py-4 animate-pulse self-start">
+        <div className="mb-2 h-4 sm:h-5 w-16 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+      <div className="mx-2 mb-2 sm:mx-6 h-13.5 sm:h-14.5 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+    </>
+  );
+}
+
+export default function Loading() {
+  return (
+    <div className="flex flex-col h-screen overflow-hidden">
+      <WeekCalendarSkeleton />
+      <HomePageSkeleton />
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/page.tsx
+++ b/frontend/src/app/(main)/page.tsx
@@ -1,15 +1,17 @@
 import RecordList from './_components/RecordList';
 import WeekCalendar from './_components/WeekCalendar';
+import StreakStats from './_components/StreakStats';
+import HomePageSkeleton from './_components/HomePageSkeleton';
 import {
   dehydrate,
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query';
-import { getCachedRecordPreviewList } from '@/lib/api/records';
-import { getCachedUserRecordStats } from '@/lib/api/profile';
 import { formatDateISO } from '@/lib/date';
-import { RecordPreview } from '@/lib/types/recordResponse';
-import { RecordPatternResponse } from '@/lib/types/profileResponse';
+import { recordPreviewListOptions } from '@/lib/api/records';
+import { userRecordPatternOptions } from '@/lib/api/profile';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
 
 interface HomePageProps {
   searchParams: Promise<{ date?: string }>;
@@ -40,69 +42,40 @@ export default async function HomePage({ searchParams }: HomePageProps) {
   const selectedDate = date || formatDateISO();
 
   const queryClient = new QueryClient();
-  let streakData: RecordPatternResponse = {
-    streak: 0,
-    monthlyRecordingDays: 0,
-  };
-  let recordPreviews: RecordPreview[];
 
-  if (process.env.NEXT_PUBLIC_MOCK !== 'true') {
-    [recordPreviews, streakData] = await Promise.all([
-      getCachedRecordPreviewList(selectedDate),
-      getCachedUserRecordStats(),
-    ]);
-
-    // QueryClient에 직접 넣어서 HydrationBoundary로 클라이언트에 전달
-    // recordPreviewListOptions의 queryKey와 일치시켜야 함
+  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
     queryClient.setQueryData(
-      ['records', 'preview', selectedDate, 'personal'],
-      recordPreviews,
+      recordPreviewListOptions(selectedDate).queryKey,
+      [],
     );
+    queryClient.setQueryData(userRecordPatternOptions().queryKey, {
+      streak: 0,
+      monthlyRecordingDays: 0,
+    });
   } else {
-    recordPreviews = [];
+    await Promise.all([
+      queryClient.prefetchQuery(recordPreviewListOptions(selectedDate)),
+      queryClient.prefetchQuery(userRecordPatternOptions()),
+    ]);
   }
 
   return (
     <div className="flex flex-col h-screen overflow-hidden">
       <WeekCalendar />
-      <div className="border-t-[0.5px] border-gray-100 dark:border-gray-800 flex w-full p-2 sm:p-3 transition-colors duration-300 bg-transparent">
-        <div className="flex w-full justify-between gap-1.5 sm:gap-3 items-center border-r px-2 sm:px-3 pr-3 sm:pr-5">
-          <span className="text-[11px] sm:text-[12px] whitespace-nowrap">
-            오늘 작성
-          </span>
-          <div className="flex justify-start items-center gap-1 sm:gap-1.5">
-            <span className="text-itta-point font-semibold text-sm sm:text-base">
-              {streakData.streak}
-            </span>
-            <span className="text-[11px] sm:text-[12px] font-medium text-gray-400 whitespace-nowrap">
-              일째 작성 중
-            </span>
+      {/* <WeekCalendarSkeleton /> */}
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ErrorHandlingWrapper
+          fallbackComponent={ErrorFallback}
+          suspenseFallback={<HomePageSkeleton />}
+        >
+          <StreakStats />
+          <div className="flex-1 w-full overflow-y-auto scrollbar-hide px-5 space-y-6 pt-7 pb-bottom-nav transition-colors duration-300 dark:bg-[#121212] bg-[#F9F9F9]">
+            <div className="w-full flex flex-col gap-6">
+              <RecordList imageLayout="responsive" />
+            </div>
           </div>
-        </div>
-        <div className="flex w-full justify-between gap-1.5 sm:gap-3 items-center px-2 sm:px-3 pl-3 sm:pl-5">
-          <span className="text-[11px] sm:text-[12px] whitespace-nowrap">
-            이번달 기록
-          </span>
-          <div className="flex justify-start items-center gap-1 sm:gap-1.5">
-            <span className="text-itta-point font-semibold text-sm sm:text-base">
-              {streakData.monthlyRecordingDays}
-            </span>
-            <span className="text-[11px] sm:text-[12px] font-medium text-gray-400 whitespace-nowrap">
-              일
-            </span>
-          </div>
-        </div>
-      </div>
-      <div className="flex-1 w-full overflow-y-auto scrollbar-hide px-5 space-y-6 pt-7 pb-bottom-nav transition-colors duration-300 dark:bg-[#121212] bg-[#F9F9F9]">
-        <div className="w-full flex flex-col gap-6">
-          <HydrationBoundary state={dehydrate(queryClient)}>
-            <RecordList
-              initialPreviews={recordPreviews}
-              imageLayout="responsive"
-            />
-          </HydrationBoundary>
-        </div>
-      </div>
+        </ErrorHandlingWrapper>
+      </HydrationBoundary>
     </div>
   );
 }

--- a/frontend/src/app/(main)/page.tsx
+++ b/frontend/src/app/(main)/page.tsx
@@ -42,11 +42,11 @@ export default async function HomePage({ searchParams }: HomePageProps) {
   const { date } = await searchParams;
 
   // 날짜가 없으면 오늘 날짜로 리다이렉트
-  if (!date) {
-    redirect(`/?date=${formatDateISO()}`);
-  }
+  // if (!date) {
+  //   redirect(`/?date=${formatDateISO()}`);
+  // }
 
-  const selectedDate = date;
+  const selectedDate = date || formatDateISO();
 
   const queryClient = new QueryClient();
 

--- a/frontend/src/app/(main)/page.tsx
+++ b/frontend/src/app/(main)/page.tsx
@@ -12,6 +12,7 @@ import { recordPreviewListOptions } from '@/lib/api/records';
 import { userRecordPatternOptions } from '@/lib/api/profile';
 import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
 import ErrorFallback from '@/components/ErrorFallback';
+import { redirect } from 'next/navigation';
 
 interface HomePageProps {
   searchParams: Promise<{ date?: string }>;
@@ -39,7 +40,13 @@ export async function generateMetadata() {
 
 export default async function HomePage({ searchParams }: HomePageProps) {
   const { date } = await searchParams;
-  const selectedDate = date || formatDateISO();
+
+  // 날짜가 없으면 오늘 날짜로 리다이렉트
+  if (!date) {
+    redirect(`/?date=${formatDateISO()}`);
+  }
+
+  const selectedDate = date;
 
   const queryClient = new QueryClient();
 

--- a/frontend/src/app/(main)/page.tsx
+++ b/frontend/src/app/(main)/page.tsx
@@ -1,22 +1,7 @@
-import RecordList from './_components/RecordList';
 import WeekCalendar from './_components/WeekCalendar';
-import StreakStats from './_components/StreakStats';
+import HomeData from './_components/HomeData';
 import HomePageSkeleton from './_components/HomePageSkeleton';
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
-import { formatDateISO } from '@/lib/date';
-import { recordPreviewListOptions } from '@/lib/api/records';
-import { userRecordPatternOptions } from '@/lib/api/profile';
-import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
-import ErrorFallback from '@/components/ErrorFallback';
-import { redirect } from 'next/navigation';
-
-interface HomePageProps {
-  searchParams: Promise<{ date?: string }>;
-}
+import { Suspense } from 'react';
 
 export async function generateMetadata() {
   return {
@@ -38,51 +23,13 @@ export async function generateMetadata() {
   };
 }
 
-export default async function HomePage({ searchParams }: HomePageProps) {
-  const { date } = await searchParams;
-
-  // 날짜가 없으면 오늘 날짜로 리다이렉트
-  // if (!date) {
-  //   redirect(`/?date=${formatDateISO()}`);
-  // }
-
-  const selectedDate = date || formatDateISO();
-
-  const queryClient = new QueryClient();
-
-  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
-    queryClient.setQueryData(
-      recordPreviewListOptions(selectedDate).queryKey,
-      [],
-    );
-    queryClient.setQueryData(userRecordPatternOptions().queryKey, {
-      streak: 0,
-      monthlyRecordingDays: 0,
-    });
-  } else {
-    await Promise.all([
-      queryClient.prefetchQuery(recordPreviewListOptions(selectedDate)),
-      queryClient.prefetchQuery(userRecordPatternOptions()),
-    ]);
-  }
-
+export default function HomePage() {
   return (
     <div className="flex flex-col h-screen overflow-hidden">
       <WeekCalendar />
-      {/* <WeekCalendarSkeleton /> */}
-      <HydrationBoundary state={dehydrate(queryClient)}>
-        <ErrorHandlingWrapper
-          fallbackComponent={ErrorFallback}
-          suspenseFallback={<HomePageSkeleton />}
-        >
-          <StreakStats />
-          <div className="flex-1 w-full overflow-y-auto scrollbar-hide px-5 space-y-6 pt-7 pb-bottom-nav transition-colors duration-300 dark:bg-[#121212] bg-[#F9F9F9]">
-            <div className="w-full flex flex-col gap-6">
-              <RecordList imageLayout="responsive" />
-            </div>
-          </div>
-        </ErrorHandlingWrapper>
-      </HydrationBoundary>
+      <Suspense fallback={<HomePageSkeleton />}>
+        <HomeData />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/src/app/(main)/profile/_components/EmotionDashboard.tsx
+++ b/frontend/src/app/(main)/profile/_components/EmotionDashboard.tsx
@@ -7,8 +7,9 @@ import { Smile } from 'lucide-react';
 import { EMOTION_MAP } from '@/lib/constants/constants';
 import { useQuery } from '@tanstack/react-query';
 import { userProfileEmotionSummaryOptions } from '@/lib/api/profile';
+import { memo, useMemo } from 'react';
 
-export default function EmotionDashboard() {
+const EmotionDashboard = memo(function EmotionDashboard() {
   const router = useRouter();
 
   const {
@@ -16,6 +17,13 @@ export default function EmotionDashboard() {
     isLoading,
     isError,
   } = useQuery(userProfileEmotionSummaryOptions(10));
+
+  // 정렬 및 슬라이스 작업을 useMemo로 최적화
+  const topEmotions = useMemo(() => {
+    return [...currentEmotions.emotion]
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+  }, [currentEmotions.emotion]);
 
   if (isLoading) {
     return (
@@ -84,10 +92,7 @@ export default function EmotionDashboard() {
         {/* 리스트 형태로 감정 데이터 표시 */}
         <div className="mt-4 sm:mt-5 mb-5 sm:mb-6">
           <div className="space-y-1.5 sm:space-y-2">
-            {[...currentEmotions.emotion]
-              .sort((a, b) => b.count - a.count)
-              .slice(0, 5)
-              .map((emotion, index) => {
+            {topEmotions.map((emotion, index) => {
                 const totalCount = currentEmotions.totalCount;
                 const percentage = (
                   (emotion.count / totalCount) *
@@ -145,4 +150,6 @@ export default function EmotionDashboard() {
       </div>
     </section>
   );
-}
+});
+
+export default EmotionDashboard;

--- a/frontend/src/app/(main)/profile/_components/MonthlyUsageChart.tsx
+++ b/frontend/src/app/(main)/profile/_components/MonthlyUsageChart.tsx
@@ -12,24 +12,27 @@ import {
   ResponsiveContainer,
   XAxis,
 } from 'recharts';
+import { memo, useMemo } from 'react';
 
-export default function MonthlyUsageChart() {
+const MonthlyUsageChart = memo(function MonthlyUsageChart() {
   const { theme } = useTheme();
 
   const { data: profile, isLoading, isError } = useQuery(userProfileOptions());
 
-  // API 응답을 차트 데이터 형식으로 변환
-  const monthlyUsageData = profile?.stats.monthlyCounts
-    .slice()
-    .reverse()
-    .slice(0, 6)
-    .map((record) => {
-      const [year, month] = record.month.split('-');
-      return {
-        name: `${year.slice(2)}.${month}`,
-        value: record.count,
-      };
-    });
+  // API 응답을 차트 데이터 형식으로 변환 (useMemo로 최적화)
+  const monthlyUsageData = useMemo(() => {
+    return profile?.stats.monthlyCounts
+      .slice()
+      .reverse()
+      .slice(0, 6)
+      .map((record) => {
+        const [year, month] = record.month.split('-');
+        return {
+          name: `${year.slice(2)}.${month}`,
+          value: record.count,
+        };
+      });
+  }, [profile?.stats.monthlyCounts]);
 
   // 모든 데이터가 0인지 확인
   const hasNoData =
@@ -148,4 +151,6 @@ export default function MonthlyUsageChart() {
       </div>
     </section>
   );
-}
+});
+
+export default MonthlyUsageChart;

--- a/frontend/src/app/(main)/profile/_components/PlaceDashboard.tsx
+++ b/frontend/src/app/(main)/profile/_components/PlaceDashboard.tsx
@@ -4,8 +4,9 @@ import { userProfileOptions } from '@/lib/api/profile';
 import { cn } from '@/lib/utils';
 import { MapPin } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
+import { memo } from 'react';
 
-export default function PlaceDashboard() {
+const PlaceDashboard = memo(function PlaceDashboard() {
   const { data: profile, isLoading, isError } = useQuery(userProfileOptions());
 
   if (isLoading) {
@@ -96,4 +97,6 @@ export default function PlaceDashboard() {
       </div>
     </section>
   );
-}
+});
+
+export default PlaceDashboard;

--- a/frontend/src/app/(main)/profile/_components/Profile.tsx
+++ b/frontend/src/app/(main)/profile/_components/Profile.tsx
@@ -5,8 +5,9 @@ import { userProfileOptions } from '@/lib/api/profile';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import AssetImage from '@/components/AssetImage';
+import { memo } from 'react';
 
-export default function Profile() {
+const Profile = memo(function Profile() {
   const router = useRouter();
 
   const { data: userProfile } = useSuspenseQuery(userProfileOptions());
@@ -48,4 +49,6 @@ export default function Profile() {
       </div>
     </div>
   );
-}
+});
+
+export default Profile;

--- a/frontend/src/app/(main)/profile/_components/Profile.tsx
+++ b/frontend/src/app/(main)/profile/_components/Profile.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { userProfileOptions } from '@/lib/api/profile';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
@@ -9,34 +9,7 @@ import AssetImage from '@/components/AssetImage';
 export default function Profile() {
   const router = useRouter();
 
-  const {
-    data: userProfile,
-    isLoading,
-    isError,
-  } = useQuery(userProfileOptions());
-
-  if (isLoading) {
-    return (
-      <div className="rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-xs border flex items-center gap-3 sm:gap-5 transition-colors duration-300 dark:bg-[#1E1E1E] dark:border-white/5 bg-white border-gray-100 animate-pulse">
-        <div className="w-14 h-14 sm:w-20 sm:h-20 rounded-full bg-gray-200 dark:bg-gray-700" />
-        <div className="flex-1">
-          <div className="h-5 sm:h-5 w-20 sm:w-24 bg-gray-200 dark:bg-gray-700 rounded mb-2" />
-          <div className="h-4 w-24 sm:w-32 bg-gray-200 dark:bg-gray-700 rounded mb-2.5 sm:mb-3" />
-          <div className="h-5.5 sm:h-7 w-16 sm:w-20 bg-gray-200 dark:bg-gray-700 rounded" />
-        </div>
-      </div>
-    );
-  }
-
-  if (isError || !userProfile) {
-    return (
-      <div className="rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-xs border flex items-center justify-center transition-colors duration-300 dark:bg-[#1E1E1E] dark:border-white/5 bg-white border-gray-100">
-        <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
-          프로필을 불러올 수 없습니다.
-        </p>
-      </div>
-    );
-  }
+  const { data: userProfile } = useSuspenseQuery(userProfileOptions());
 
   return (
     <div className="rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-xs border flex items-center gap-3 sm:gap-5 transition-colors duration-300 dark:bg-[#1E1E1E] dark:border-white/5 bg-white border-gray-100">

--- a/frontend/src/app/(main)/profile/_components/ProfileData.tsx
+++ b/frontend/src/app/(main)/profile/_components/ProfileData.tsx
@@ -1,0 +1,37 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { userProfileOptions, userProfileTagSummaryOptions } from '@/lib/api/profile';
+import { createMockTagStats } from '@/lib/mocks/mock';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
+import ProfilePageSkeleton from './ProfilePageSkeleton';
+import Profile from './Profile';
+import TagDashboard from './TagDashboard';
+import RecordStatistics from './RecordStatistics';
+import Setting from './Setting';
+
+export default async function ProfileData() {
+  const queryClient = new QueryClient();
+
+  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
+    queryClient.setQueryData(userProfileTagSummaryOptions(10).queryKey, createMockTagStats());
+  } else {
+    await Promise.all([
+      queryClient.prefetchQuery(userProfileOptions()),
+      queryClient.prefetchQuery(userProfileTagSummaryOptions(10)),
+    ]);
+  }
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ErrorHandlingWrapper
+        fallbackComponent={ErrorFallback}
+        suspenseFallback={<ProfilePageSkeleton />}
+      >
+        <Profile />
+        <TagDashboard />
+        <RecordStatistics />
+      </ErrorHandlingWrapper>
+      <Setting />
+    </HydrationBoundary>
+  );
+}

--- a/frontend/src/app/(main)/profile/_components/ProfilePageSkeleton.tsx
+++ b/frontend/src/app/(main)/profile/_components/ProfilePageSkeleton.tsx
@@ -1,0 +1,65 @@
+function ProfileCardSkeleton() {
+  return (
+    <div className="rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-xs border flex items-center gap-3 sm:gap-5 transition-colors duration-300 dark:bg-[#1E1E1E] dark:border-white/5 bg-white border-gray-100 animate-pulse">
+      <div className="w-14 h-14 sm:w-20 sm:h-20 rounded-full bg-gray-200 dark:bg-gray-700" />
+      <div className="flex-1">
+        <div className="h-5 w-20 sm:w-24 bg-gray-200 dark:bg-gray-700 rounded mb-2" />
+        <div className="h-4 w-24 sm:w-32 bg-gray-200 dark:bg-gray-700 rounded mb-2.5 sm:mb-3" />
+        <div className="h-5.5 sm:h-7 w-16 sm:w-20 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+    </div>
+  );
+}
+
+function TagDashboardSkeleton() {
+  return (
+    <div className="rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-xs border transition-colors duration-300 dark:bg-[#1E1E1E] dark:border-white/5 bg-white border-gray-100 animate-pulse">
+      <div className="flex items-center justify-between mb-4 sm:mb-6">
+        <div className="h-4 w-8 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-7 w-28 bg-gray-200 dark:bg-gray-700 rounded-xl" />
+      </div>
+      <div className="flex flex-wrap gap-1.5 sm:gap-2 mb-4 sm:mb-6">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-7 rounded-lg bg-gray-200 dark:bg-gray-700"
+            style={{ width: `${60 + i * 10}px` }}
+          />
+        ))}
+      </div>
+      <div className="flex items-center gap-2 border-t pt-3 sm:pt-5 dark:border-white/5 border-gray-50">
+        <div className="flex-1 h-9 bg-gray-200 dark:bg-gray-700 rounded-xl" />
+        <div className="w-px h-3 sm:h-4 dark:bg-white/5 bg-gray-100" />
+        <div className="flex-1 h-7 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+    </div>
+  );
+}
+
+function RecordStatisticsSkeleton() {
+  return (
+    <div className="rounded-xl sm:rounded-2xl p-4 sm:p-6 shadow-xs border transition-colors duration-300 dark:bg-[#1E1E1E] dark:border-white/5 bg-white border-gray-200/60 animate-pulse">
+      <div className="h-4 w-24 bg-gray-200 dark:bg-gray-700 rounded mb-4" />
+      <div className="space-y-2">
+        <div className="flex justify-between">
+          <div className="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-4 w-10 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+        <div className="flex justify-between">
+          <div className="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-4 w-10 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ProfilePageSkeleton() {
+  return (
+    <>
+      <ProfileCardSkeleton />
+      <TagDashboardSkeleton />
+      <RecordStatisticsSkeleton />
+    </>
+  );
+}

--- a/frontend/src/app/(main)/profile/_components/RecordStatistics.tsx
+++ b/frontend/src/app/(main)/profile/_components/RecordStatistics.tsx
@@ -34,24 +34,21 @@ export default function RecordStatistics() {
         </svg>
       </button>
 
-      <div
-        className={cn(
-          'overflow-hidden transition-all duration-300 ease-in-out',
-          isChartVisible ? 'max-h-300 opacity-100' : 'max-h-0 opacity-0',
-        )}
-      >
-        <div className="pt-2 sm:pt-3">
-          <MonthlyUsageChart />
-        </div>
+      {isChartVisible && (
+        <div className="overflow-hidden transition-all duration-300 ease-in-out animate-in fade-in slide-in-from-top-2">
+          <div className="pt-2 sm:pt-3">
+            <MonthlyUsageChart />
+          </div>
 
-        <div className="pt-6 sm:pt-8">
-          <PlaceDashboard />
-        </div>
+          <div className="pt-6 sm:pt-8">
+            <PlaceDashboard />
+          </div>
 
-        <div className="pt-6 sm:pt-8">
-          <EmotionDashboard />
+          <div className="pt-6 sm:pt-8">
+            <EmotionDashboard />
+          </div>
         </div>
-      </div>
+      )}
     </section>
   );
 }

--- a/frontend/src/app/(main)/profile/_components/TagDashboard.tsx
+++ b/frontend/src/app/(main)/profile/_components/TagDashboard.tsx
@@ -13,12 +13,21 @@ import { cn } from '@/lib/utils';
 import { Search, X, Tag } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { userProfileTagSummaryOptions } from '@/lib/api/profile';
 
-interface TagDashboardProps {
-  tags: ProfileTag;
-}
+export default function TagDashboard() {
+  const { data: tagStats } = useSuspenseQuery(userProfileTagSummaryOptions(10));
 
-export default function TagDashboard({ tags }: TagDashboardProps) {
+  const allTags = [...tagStats.recentTags, ...tagStats.frequentTags];
+  const uniqueAll = Array.from(
+    new Map(allTags.map((item) => [item.tag, item])).values(),
+  );
+  const tags: ProfileTag = {
+    recent: tagStats.recentTags,
+    frequent: tagStats.frequentTags,
+    all: uniqueAll,
+  };
   const [tagTab, setTagTab] = useState<'recent' | 'frequent'>('recent');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const router = useRouter();
@@ -36,7 +45,7 @@ export default function TagDashboard({ tags }: TagDashboardProps) {
   const handleCombinationSearch = () => {
     // 검색 페이지로 이동하며 선택된 태그들을 쿼리로 전달
     // TODO: 검색 페이지에서 쿼리로 전달받은 태그를 입력창에 입력해주기(query)
-    const query = selectedTags.map((t) => `#${t}`).join(' ');
+    const _query = selectedTags.map((t) => `#${t}`).join(' ');
     const tagQuery = selectedTags.join(',');
     router.push(`/search?tags=${encodeURIComponent(tagQuery)}`);
   };

--- a/frontend/src/app/(main)/profile/_components/TagDashboard.tsx
+++ b/frontend/src/app/(main)/profile/_components/TagDashboard.tsx
@@ -12,22 +12,26 @@ import { ProfileTag } from '@/lib/types/profile';
 import { cn } from '@/lib/utils';
 import { Search, X, Tag } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { userProfileTagSummaryOptions } from '@/lib/api/profile';
 
 export default function TagDashboard() {
   const { data: tagStats } = useSuspenseQuery(userProfileTagSummaryOptions(10));
 
-  const allTags = [...tagStats.recentTags, ...tagStats.frequentTags];
-  const uniqueAll = Array.from(
-    new Map(allTags.map((item) => [item.tag, item])).values(),
-  );
-  const tags: ProfileTag = {
-    recent: tagStats.recentTags,
-    frequent: tagStats.frequentTags,
-    all: uniqueAll,
-  };
+  // 태그 처리를 useMemo로 최적화
+  const tags = useMemo(() => {
+    const allTags = [...tagStats.recentTags, ...tagStats.frequentTags];
+    const uniqueAll = Array.from(
+      new Map(allTags.map((item) => [item.tag, item])).values(),
+    );
+    return {
+      recent: tagStats.recentTags,
+      frequent: tagStats.frequentTags,
+      all: uniqueAll,
+    } satisfies ProfileTag;
+  }, [tagStats]);
+
   const [tagTab, setTagTab] = useState<'recent' | 'frequent'>('recent');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const router = useRouter();

--- a/frontend/src/app/(main)/profile/_components/TagDashboard.tsx
+++ b/frontend/src/app/(main)/profile/_components/TagDashboard.tsx
@@ -178,6 +178,21 @@ export default function TagDashboard() {
                     </button>
                   );
                 })}
+                {tags.all.length === 0 && (
+                  <div className="w-full py-6 sm:py-8 flex flex-col items-center justify-center gap-2">
+                    <div className="w-10 h-10 sm:w-12 sm:h-12 rounded-full flex items-center justify-center dark:bg-[#10B981]/10 bg-[#10B981]/10">
+                      <Tag className="w-4 h-4 sm:w-5 sm:h-5 text-[#10B981]" />
+                    </div>
+                    <div className="space-y-1 text-center">
+                      <p className="text-xs sm:text-sm font-bold dark:text-gray-200 text-gray-700">
+                        아직 사용한 태그가 없어요
+                      </p>
+                      <p className="text-[11px] sm:text-xs text-gray-400">
+                        태그를 추가하여 기록을 분류해보세요
+                      </p>
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
             <div className="flex gap-3 sm:gap-4">

--- a/frontend/src/app/(main)/profile/_components/WritingRecordStatistics.tsx
+++ b/frontend/src/app/(main)/profile/_components/WritingRecordStatistics.tsx
@@ -2,8 +2,9 @@
 
 import { userProfileOptions } from '@/lib/api/profile';
 import { useQuery } from '@tanstack/react-query';
+import { memo } from 'react';
 
-export default function WritingRecordStatistics() {
+const WritingRecordStatistics = memo(function WritingRecordStatistics() {
   const { data: profile } = useQuery(userProfileOptions());
 
   return (
@@ -46,4 +47,6 @@ export default function WritingRecordStatistics() {
       </div>
     </>
   );
-}
+});
+
+export default WritingRecordStatistics;

--- a/frontend/src/app/(main)/profile/all-emotions/_components/AllEmotionsContent.tsx
+++ b/frontend/src/app/(main)/profile/all-emotions/_components/AllEmotionsContent.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+  userProfileOptions,
+  userProfileEmotionSummaryOptions,
+} from '@/lib/api/profile';
+import EmotionList from './EmotionList';
+
+export default function AllEmotionsContent() {
+  const { data: profile } = useSuspenseQuery(userProfileOptions());
+  const { data: emotionData } = useSuspenseQuery(
+    userProfileEmotionSummaryOptions(),
+  );
+
+  return (
+    <div className="p-4 sm:p-5">
+      <div className="rounded-xl p-4 sm:p-6 transition-colors dark:bg-white/5 bg-gray-50">
+        <p className="text-[13px] sm:text-sm leading-relaxed mb-1 dark:text-gray-400 text-gray-500">
+          <span className="font-bold">{profile.user.nickname}</span> 님은
+        </p>
+        <p className="text-[13px] sm:text-sm leading-relaxed dark:text-gray-400 text-gray-500">
+          <span className="font-black text-itta-black dark:text-white">
+            {emotionData.emotion.length}
+          </span>
+          &nbsp;개의 감정을 사용하고 있어요.
+        </p>
+      </div>
+
+      <EmotionList emotions={emotionData.emotion} />
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/profile/all-emotions/_components/AllEmotionsData.tsx
+++ b/frontend/src/app/(main)/profile/all-emotions/_components/AllEmotionsData.tsx
@@ -1,0 +1,26 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { userProfileOptions, userProfileEmotionSummaryOptions } from '@/lib/api/profile';
+import AllEmotionsContent from './AllEmotionsContent';
+import AllEmotionsSkeleton from './AllEmotionsSkeleton';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default async function AllEmotionsData() {
+  const queryClient = new QueryClient();
+
+  await Promise.all([
+    queryClient.prefetchQuery(userProfileOptions()),
+    queryClient.prefetchQuery(userProfileEmotionSummaryOptions()),
+  ]);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ErrorHandlingWrapper
+        fallbackComponent={ErrorFallback}
+        suspenseFallback={<AllEmotionsSkeleton />}
+      >
+        <AllEmotionsContent />
+      </ErrorHandlingWrapper>
+    </HydrationBoundary>
+  );
+}

--- a/frontend/src/app/(main)/profile/all-emotions/_components/AllEmotionsSkeleton.tsx
+++ b/frontend/src/app/(main)/profile/all-emotions/_components/AllEmotionsSkeleton.tsx
@@ -1,0 +1,35 @@
+export default function AllEmotionsSkeleton() {
+  return (
+    <div className="p-4 sm:p-5 animate-pulse">
+      {/* 요약 카드 */}
+      <div className="rounded-xl p-4 sm:p-6 dark:bg-white/5 bg-gray-50">
+        <div className="h-[14px] w-28 bg-gray-200 dark:bg-gray-700 rounded mb-2" />
+        <div className="h-[14px] w-40 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+
+      {/* 탭 바 */}
+      <div className="flex border-b dark:border-white/5 border-gray-50 mt-4 sm:mt-5">
+        <div className="flex-1 py-3 sm:py-4 flex justify-center">
+          <div className="h-[14px] w-16 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+        <div className="flex-1 py-3 sm:py-4 flex justify-center">
+          <div className="h-[14px] w-16 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+      </div>
+
+      {/* 리스트 아이템 */}
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center justify-between px-4 py-3.5 sm:px-6 sm:py-5"
+        >
+          <div className="flex items-center gap-1.5">
+            <div className="h-5 w-5 bg-gray-200 dark:bg-gray-700 rounded" />
+            <div className="h-[14px] w-16 bg-gray-200 dark:bg-gray-700 rounded" />
+          </div>
+          <div className="h-[14px] w-6 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/profile/all-emotions/loading.tsx
+++ b/frontend/src/app/(main)/profile/all-emotions/loading.tsx
@@ -1,0 +1,11 @@
+import ProfileAllEmotionsHeaderActions from './_components/ProfileAllEmotionsHeaderActions';
+import AllEmotionsSkeleton from './_components/AllEmotionsSkeleton';
+
+export default function Loading() {
+  return (
+    <div className="w-full pb-20 flex flex-col min-h-screen dark:bg-[#121212] dark:text-white bg-white text-itta-black">
+      <ProfileAllEmotionsHeaderActions />
+      <AllEmotionsSkeleton />
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/profile/all-emotions/page.tsx
+++ b/frontend/src/app/(main)/profile/all-emotions/page.tsx
@@ -1,37 +1,15 @@
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
-import {
-  userProfileOptions,
-  userProfileEmotionSummaryOptions,
-} from '@/lib/api/profile';
 import ProfileAllEmotionsHeaderActions from './_components/ProfileAllEmotionsHeaderActions';
-import AllEmotionsContent from './_components/AllEmotionsContent';
+import AllEmotionsData from './_components/AllEmotionsData';
 import AllEmotionsSkeleton from './_components/AllEmotionsSkeleton';
-import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
-import ErrorFallback from '@/components/ErrorFallback';
+import { Suspense } from 'react';
 
-export default async function ProfileAllEmotionsPage() {
-  const queryClient = new QueryClient();
-
-  await Promise.all([
-    queryClient.prefetchQuery(userProfileOptions()),
-    queryClient.prefetchQuery(userProfileEmotionSummaryOptions()),
-  ]);
-
+export default function ProfileAllEmotionsPage() {
   return (
     <div className="w-full pb-20 flex flex-col min-h-screen dark:bg-[#121212] dark:text-white bg-white text-itta-black">
       <ProfileAllEmotionsHeaderActions />
-      <HydrationBoundary state={dehydrate(queryClient)}>
-        <ErrorHandlingWrapper
-          fallbackComponent={ErrorFallback}
-          suspenseFallback={<AllEmotionsSkeleton />}
-        >
-          <AllEmotionsContent />
-        </ErrorHandlingWrapper>
-      </HydrationBoundary>
+      <Suspense fallback={<AllEmotionsSkeleton />}>
+        <AllEmotionsData />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/src/app/(main)/profile/all-tags/_components/AllTagsContent.tsx
+++ b/frontend/src/app/(main)/profile/all-tags/_components/AllTagsContent.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+  userProfileOptions,
+  userProfileTagSummaryOptions,
+} from '@/lib/api/profile';
+import TagList from './TagList';
+
+export default function AllTagsContent() {
+  const { data: profile } = useSuspenseQuery(userProfileOptions());
+  const { data: tagData } = useSuspenseQuery(userProfileTagSummaryOptions());
+
+  return (
+    <div className="p-4 sm:p-5">
+      <div className="rounded-xl p-4 sm:p-6 transition-colors dark:bg-white/5 bg-gray-50">
+        <p className="text-[13px] sm:text-sm leading-relaxed mb-1 dark:text-gray-400 text-gray-500">
+          <span className="font-bold">{profile.user.nickname}</span> 님은
+        </p>
+        <p className="text-[13px] sm:text-sm leading-relaxed dark:text-gray-400 text-gray-500">
+          <span className="font-black text-itta-black dark:text-white">
+            {tagData.frequentTags.length}
+          </span>
+          &nbsp;개의 태그를 사용하고 있어요.
+        </p>
+      </div>
+
+      <TagList tags={tagData} />
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/profile/all-tags/_components/AllTagsData.tsx
+++ b/frontend/src/app/(main)/profile/all-tags/_components/AllTagsData.tsx
@@ -1,0 +1,26 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { userProfileOptions, userProfileTagSummaryOptions } from '@/lib/api/profile';
+import AllTagsContent from './AllTagsContent';
+import AllTagsSkeleton from './AllTagsSkeleton';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
+
+export default async function AllTagsData() {
+  const queryClient = new QueryClient();
+
+  await Promise.all([
+    queryClient.prefetchQuery(userProfileOptions()),
+    queryClient.prefetchQuery(userProfileTagSummaryOptions()),
+  ]);
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ErrorHandlingWrapper
+        fallbackComponent={ErrorFallback}
+        suspenseFallback={<AllTagsSkeleton />}
+      >
+        <AllTagsContent />
+      </ErrorHandlingWrapper>
+    </HydrationBoundary>
+  );
+}

--- a/frontend/src/app/(main)/profile/all-tags/_components/AllTagsSkeleton.tsx
+++ b/frontend/src/app/(main)/profile/all-tags/_components/AllTagsSkeleton.tsx
@@ -1,0 +1,35 @@
+export default function AllTagsSkeleton() {
+  return (
+    <div className="p-4 sm:p-5 animate-pulse">
+      {/* 요약 카드 */}
+      <div className="rounded-xl p-4 sm:p-6 dark:bg-white/5 bg-gray-50">
+        <div className="h-[14px] w-28 bg-gray-200 dark:bg-gray-700 rounded mb-2" />
+        <div className="h-[14px] w-40 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+
+      {/* 탭 바 */}
+      <div className="flex border-b dark:border-white/5 border-gray-50 mt-4 sm:mt-5">
+        <div className="flex-1 py-3 sm:py-4 flex justify-center">
+          <div className="h-[14px] w-16 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+        <div className="flex-1 py-3 sm:py-4 flex justify-center">
+          <div className="h-[14px] w-16 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+      </div>
+
+      {/* 리스트 아이템 */}
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center justify-between px-4 py-3.5 sm:px-6 sm:py-5 border-b dark:border-white/5 border-gray-50"
+        >
+          <div className="flex items-center gap-0.5">
+            <div className="h-[14px] w-4 bg-gray-200 dark:bg-gray-700 rounded mr-0.5" />
+            <div className="h-[14px] w-20 bg-gray-200 dark:bg-gray-700 rounded" />
+          </div>
+          <div className="h-[14px] w-6 bg-gray-200 dark:bg-gray-700 rounded" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/profile/all-tags/loading.tsx
+++ b/frontend/src/app/(main)/profile/all-tags/loading.tsx
@@ -1,0 +1,11 @@
+import ProfileAllTagsHeaderActions from './_components/ProfileAllTagsHeaderActions';
+import AllTagsSkeleton from './_components/AllTagsSkeleton';
+
+export default function Loading() {
+  return (
+    <div className="w-full pb-20 flex flex-col min-h-screen dark:bg-[#121212] dark:text-white bg-white text-itta-black">
+      <ProfileAllTagsHeaderActions />
+      <AllTagsSkeleton />
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/profile/all-tags/page.tsx
+++ b/frontend/src/app/(main)/profile/all-tags/page.tsx
@@ -1,35 +1,37 @@
-import ProfileAllTagsHeaderActions from './_components/ProfileAllTagsHeaderActions';
-import TagList from './_components/TagList';
 import {
-  getCachedUserProfile,
-  getCachedUserTagSummary,
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query';
+import {
+  userProfileOptions,
+  userProfileTagSummaryOptions,
 } from '@/lib/api/profile';
+import ProfileAllTagsHeaderActions from './_components/ProfileAllTagsHeaderActions';
+import AllTagsContent from './_components/AllTagsContent';
+import AllTagsSkeleton from './_components/AllTagsSkeleton';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
 
 export default async function ProfileAllTagsPage() {
-  const [tagData, profile] = await Promise.all([
-    getCachedUserTagSummary(),
-    getCachedUserProfile(),
+  const queryClient = new QueryClient();
+
+  await Promise.all([
+    queryClient.prefetchQuery(userProfileOptions()),
+    queryClient.prefetchQuery(userProfileTagSummaryOptions()),
   ]);
 
   return (
     <div className="w-full pb-20 flex flex-col min-h-screen dark:bg-[#121212] dark:text-white bg-white text-itta-black">
       <ProfileAllTagsHeaderActions />
-
-      <div className="p-4 sm:p-5">
-        <div className="rounded-xl p-4 sm:p-6 transition-colors dark:bg-white/5 bg-gray-50">
-          <p className="text-[13px] sm:text-sm leading-relaxed mb-1 dark:text-gray-400 text-gray-500">
-            <span className="font-bold">{profile.user.nickname}</span> 님은
-          </p>
-          <p className="text-[13px] sm:text-sm leading-relaxed dark:text-gray-400 text-gray-500">
-            <span className="font-black text-itta-black dark:text-white">
-              {tagData.frequentTags.length}
-            </span>
-            &nbsp;개의 태그를 사용하고 있어요.
-          </p>
-        </div>
-
-        <TagList tags={tagData} />
-      </div>
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ErrorHandlingWrapper
+          fallbackComponent={ErrorFallback}
+          suspenseFallback={<AllTagsSkeleton />}
+        >
+          <AllTagsContent />
+        </ErrorHandlingWrapper>
+      </HydrationBoundary>
     </div>
   );
 }

--- a/frontend/src/app/(main)/profile/all-tags/page.tsx
+++ b/frontend/src/app/(main)/profile/all-tags/page.tsx
@@ -1,37 +1,15 @@
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
-import {
-  userProfileOptions,
-  userProfileTagSummaryOptions,
-} from '@/lib/api/profile';
 import ProfileAllTagsHeaderActions from './_components/ProfileAllTagsHeaderActions';
-import AllTagsContent from './_components/AllTagsContent';
+import AllTagsData from './_components/AllTagsData';
 import AllTagsSkeleton from './_components/AllTagsSkeleton';
-import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
-import ErrorFallback from '@/components/ErrorFallback';
+import { Suspense } from 'react';
 
-export default async function ProfileAllTagsPage() {
-  const queryClient = new QueryClient();
-
-  await Promise.all([
-    queryClient.prefetchQuery(userProfileOptions()),
-    queryClient.prefetchQuery(userProfileTagSummaryOptions()),
-  ]);
-
+export default function ProfileAllTagsPage() {
   return (
     <div className="w-full pb-20 flex flex-col min-h-screen dark:bg-[#121212] dark:text-white bg-white text-itta-black">
       <ProfileAllTagsHeaderActions />
-      <HydrationBoundary state={dehydrate(queryClient)}>
-        <ErrorHandlingWrapper
-          fallbackComponent={ErrorFallback}
-          suspenseFallback={<AllTagsSkeleton />}
-        >
-          <AllTagsContent />
-        </ErrorHandlingWrapper>
-      </HydrationBoundary>
+      <Suspense fallback={<AllTagsSkeleton />}>
+        <AllTagsData />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/src/app/(main)/profile/edit/_components/ProfileEditClient.tsx
+++ b/frontend/src/app/(main)/profile/edit/_components/ProfileEditClient.tsx
@@ -3,7 +3,7 @@
 import ProfileEditProvider from './ProfileEditContext';
 import ProfileEditHeaderActions from '@/components/ProfileEditHeaderActions';
 import ProfileInfo from '@/components/ProfileInfo';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useSuspenseQuery, useQueryClient } from '@tanstack/react-query';
 import { userProfileOptions } from '@/lib/api/profile';
 import { useState } from 'react';
 import { useApiPatch } from '@/hooks/useApi';
@@ -14,7 +14,7 @@ import * as Sentry from '@sentry/nextjs';
 import { logger } from '@/lib/utils/logger';
 
 export default function ProfileEditClient() {
-  const { data: profile } = useQuery(userProfileOptions());
+  const { data: profile } = useSuspenseQuery(userProfileOptions());
   const queryClient = useQueryClient();
   const [isPending, setIsPending] = useState(false);
 

--- a/frontend/src/app/(main)/profile/edit/_components/ProfileEditSkeleton.tsx
+++ b/frontend/src/app/(main)/profile/edit/_components/ProfileEditSkeleton.tsx
@@ -1,0 +1,47 @@
+export default function ProfileEditSkeleton() {
+  return (
+    <div className="animate-pulse">
+      {/* 헤더 - ProfileEditHeaderActions와 동일한 패딩 */}
+      <div className="sticky top-0 z-50 px-4 py-3 sm:p-6 flex items-center justify-between bg-white/95 dark:bg-[#121212]/95">
+        <div className="h-5 w-5 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-3.5 w-16 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-3.5 w-8 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+
+      {/* 컨텐츠 - ProfileEditClient의 p-8 래퍼 */}
+      <div className="p-8 pb-32">
+        {/* ProfileInfo의 py-8 flex flex-col gap-10 */}
+        <div className="py-8 flex flex-col gap-10">
+          {/* 프로필 이미지 */}
+          <div className="flex flex-col items-center">
+            <div className="relative">
+              <div className="w-24 h-24 sm:w-28 sm:h-28 rounded-full border-4 bg-gray-200 dark:bg-gray-700 border-gray-50 dark:border-[#1E1E1E]" />
+              {/* 카메라 버튼 */}
+              <div className="absolute bottom-0 right-0 w-10 h-10 rounded-full bg-gray-300 dark:bg-gray-600 border-2 border-white" />
+            </div>
+          </div>
+
+          {/* 입력 필드 영역 */}
+          <div className="w-full space-y-8 mt-2">
+            {/* 닉네임 - border-b-2 라인 형태 */}
+            <div className="space-y-2">
+              <div className="h-3.5 w-10 bg-gray-200 dark:bg-gray-700 rounded" />
+              <div className="border-b-2 border-gray-100 dark:border-white/5 py-4">
+                <div className="h-5.5 w-2/3 bg-gray-200 dark:bg-gray-700 rounded" />
+              </div>
+              <div className="h-2.5 w-48 bg-gray-100 dark:bg-gray-800 rounded" />
+            </div>
+
+            {/* 이메일 - 둥근 박스 형태 */}
+            <div className="space-y-1">
+              <div className="h-3 w-14 bg-gray-200 dark:bg-gray-700 rounded" />
+              <div className="border rounded-lg px-3 py-3 border-gray-100 dark:border-white/5 bg-gray-50 dark:bg-white/5">
+                <div className="h-4.5 w-40 bg-gray-200 dark:bg-gray-700 rounded" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/profile/edit/loading.tsx
+++ b/frontend/src/app/(main)/profile/edit/loading.tsx
@@ -1,0 +1,9 @@
+import ProfileEditSkeleton from './_components/ProfileEditSkeleton';
+
+export default function Loading() {
+  return (
+    <div className="w-full flex flex-col min-h-screen dark:bg-[#121212] dark:text-white bg-white text-itta-black">
+      <ProfileEditSkeleton />
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/profile/edit/page.tsx
+++ b/frontend/src/app/(main)/profile/edit/page.tsx
@@ -1,20 +1,31 @@
-import { QueryClient } from '@tanstack/react-query';
+import {
+  dehydrate,
+  HydrationBoundary,
+  QueryClient,
+} from '@tanstack/react-query';
+import { userProfileOptions } from '@/lib/api/profile';
 import ProfileEditClient from './_components/ProfileEditClient';
-import { getCachedUserProfile } from '@/lib/api/profile';
+import ProfileEditSkeleton from './_components/ProfileEditSkeleton';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
 
 export default async function ProfileEditPage() {
   const queryClient = new QueryClient();
 
   if (process.env.NEXT_PUBLIC_MOCK !== 'true') {
-    const profile = await getCachedUserProfile();
-
-    // QueryClient에 직접 넣어서 HydrationBoundary로 클라이언트에 전달
-    queryClient.setQueryData(['profile', 'me'], profile);
+    await queryClient.prefetchQuery(userProfileOptions());
   }
 
   return (
     <div className="w-full flex flex-col min-h-screen dark:bg-[#121212] dark:text-white bg-white text-itta-black">
-      <ProfileEditClient />
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ErrorHandlingWrapper
+          fallbackComponent={ErrorFallback}
+          suspenseFallback={<ProfileEditSkeleton />}
+        >
+          <ProfileEditClient />
+        </ErrorHandlingWrapper>
+      </HydrationBoundary>
     </div>
   );
 }

--- a/frontend/src/app/(main)/profile/loading.tsx
+++ b/frontend/src/app/(main)/profile/loading.tsx
@@ -1,0 +1,13 @@
+import ProfilePageSkeleton from './_components/ProfilePageSkeleton';
+import ProfileHeaderActions from './_components/ProfileHeaderActions';
+
+export default function ProfileLoading() {
+  return (
+    <div className="w-full flex flex-col min-h-screen pb-25 dark:bg-[#121212] bg-[#F9F9F9]">
+      <ProfileHeaderActions />
+      <div className="p-4 sm:p-5 space-y-4 sm:space-y-5">
+        <ProfilePageSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(main)/profile/page.tsx
+++ b/frontend/src/app/(main)/profile/page.tsx
@@ -1,73 +1,49 @@
-import {
-  EmotionStatSummary,
-  ProfileTag,
-  TagStatSummary,
-} from '@/lib/types/profile';
 import Profile from './_components/Profile';
 import ProfileHeaderActions from './_components/ProfileHeaderActions';
 import TagDashboard from './_components/TagDashboard';
 import Setting from './_components/Setting';
 import RecordStatistics from './_components/RecordStatistics';
-import {
-  getCachedUserEmotionSummary,
-  getCachedUserTagSummary,
-} from '@/lib/api/profile';
 import { createMockTagStats } from '@/lib/mocks/mock';
-import { getCachedMyMonthlyRecordList } from '@/lib/api/my';
 import {
   dehydrate,
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query';
-import { MonthlyRecordList } from '@/lib/types/recordResponse';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
+import ProfilePageSkeleton from './_components/ProfilePageSkeleton';
+import { userProfileOptions, userProfileTagSummaryOptions } from '@/lib/api/profile';
 
 export default async function ProfilePage() {
-  let tagStats: TagStatSummary;
-  let emotionStats: EmotionStatSummary;
-  let monthlyRecordList: MonthlyRecordList[];
   const queryClient = new QueryClient();
 
   if (process.env.NEXT_PUBLIC_MOCK === 'true') {
-    tagStats = createMockTagStats();
-  } else {
-    const year = String(new Date().getFullYear());
-    [tagStats, emotionStats, monthlyRecordList] = await Promise.all([
-      getCachedUserTagSummary(10),
-      getCachedUserEmotionSummary(10),
-      getCachedMyMonthlyRecordList(year),
-    ]);
-
-    // QueryClient에 직접 넣어서 HydrationBoundary로 클라이언트에 전달
-    queryClient.setQueryData(['profile', 'tags', 'summary'], tagStats);
-    queryClient.setQueryData(['profile', 'emotions', 'summary'], emotionStats);
     queryClient.setQueryData(
-      ['my', 'records', 'month', year],
-      monthlyRecordList,
+      userProfileTagSummaryOptions(10).queryKey,
+      createMockTagStats(),
     );
+  } else {
+    await Promise.all([
+      queryClient.prefetchQuery(userProfileOptions()),
+      queryClient.prefetchQuery(userProfileTagSummaryOptions(10)),
+    ]);
   }
-
-  const allTags = [...tagStats.recentTags, ...tagStats.frequentTags];
-
-  const uniqueAll = Array.from(
-    new Map(allTags.map((item) => [item.tag, item])).values(),
-  );
-
-  const tags: ProfileTag = {
-    recent: tagStats.recentTags,
-    frequent: tagStats.frequentTags,
-    all: uniqueAll,
-  };
 
   return (
     <div className="w-full flex flex-col h-full pb-25 dark:bg-[#121212] bg-[#F9F9F9]">
       <ProfileHeaderActions />
       <div className="p-4 sm:p-5 space-y-4 sm:space-y-5">
-        <Profile />
         <HydrationBoundary state={dehydrate(queryClient)}>
-          <TagDashboard tags={tags} />
-          <RecordStatistics />
+          <ErrorHandlingWrapper
+            fallbackComponent={ErrorFallback}
+            suspenseFallback={<ProfilePageSkeleton />}
+          >
+            <Profile />
+            <TagDashboard />
+            <RecordStatistics />
+          </ErrorHandlingWrapper>
+          <Setting />
         </HydrationBoundary>
-        <Setting />
       </div>
     </div>
   );

--- a/frontend/src/app/(main)/profile/page.tsx
+++ b/frontend/src/app/(main)/profile/page.tsx
@@ -1,49 +1,16 @@
-import Profile from './_components/Profile';
 import ProfileHeaderActions from './_components/ProfileHeaderActions';
-import TagDashboard from './_components/TagDashboard';
-import Setting from './_components/Setting';
-import RecordStatistics from './_components/RecordStatistics';
-import { createMockTagStats } from '@/lib/mocks/mock';
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
-import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
-import ErrorFallback from '@/components/ErrorFallback';
+import ProfileData from './_components/ProfileData';
 import ProfilePageSkeleton from './_components/ProfilePageSkeleton';
-import { userProfileOptions, userProfileTagSummaryOptions } from '@/lib/api/profile';
+import { Suspense } from 'react';
 
-export default async function ProfilePage() {
-  const queryClient = new QueryClient();
-
-  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
-    queryClient.setQueryData(
-      userProfileTagSummaryOptions(10).queryKey,
-      createMockTagStats(),
-    );
-  } else {
-    await Promise.all([
-      queryClient.prefetchQuery(userProfileOptions()),
-      queryClient.prefetchQuery(userProfileTagSummaryOptions(10)),
-    ]);
-  }
-
+export default function ProfilePage() {
   return (
     <div className="w-full flex flex-col h-full pb-25 dark:bg-[#121212] bg-[#F9F9F9]">
       <ProfileHeaderActions />
       <div className="p-4 sm:p-5 space-y-4 sm:space-y-5">
-        <HydrationBoundary state={dehydrate(queryClient)}>
-          <ErrorHandlingWrapper
-            fallbackComponent={ErrorFallback}
-            suspenseFallback={<ProfilePageSkeleton />}
-          >
-            <Profile />
-            <TagDashboard />
-            <RecordStatistics />
-          </ErrorHandlingWrapper>
-          <Setting />
-        </HydrationBoundary>
+        <Suspense fallback={<ProfilePageSkeleton />}>
+          <ProfileData />
+        </Suspense>
       </div>
     </div>
   );

--- a/frontend/src/app/(post)/_components/GalleryDrawer.tsx
+++ b/frontend/src/app/(post)/_components/GalleryDrawer.tsx
@@ -53,7 +53,8 @@ export default function GalleryDrawer({
     return personalQuery;
   }, [type, month, groupMonthlyQuery, groupQuery, personalQuery]);
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = currentQuery;
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isPending } =
+    currentQuery;
 
   const items = (data?.pages ?? []).flatMap((page) =>
     (page?.sections ?? []).flatMap((section) => section.items ?? []),
@@ -83,7 +84,16 @@ export default function GalleryDrawer({
 
   return (
     <div className="flex flex-col w-full gap-2.5">
-      {items.length === 0 ? (
+      {isPending ? (
+        <div className="p-1 grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-1.5 sm:gap-2 max-h-[40vh] sm:max-h-[45vh] overflow-hidden mb-6 sm:mb-8">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="aspect-square rounded-xl bg-gray-200 dark:bg-gray-800 animate-pulse"
+            />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
         <div className="py-14 sm:py-20 flex flex-col items-center justify-center text-center space-y-3 sm:space-y-4 rounded-2xl sm:rounded-3xl border-2 border-dashed border-gray-100 dark:border-white/5 bg-gray-50/30 dark:bg-white/5">
           <div className="w-12 h-12 sm:w-16 sm:h-16 bg-white dark:bg-neutral-800 rounded-xl sm:rounded-2xl flex items-center justify-center shadow-sm">
             <ImageIcon className="w-6 h-6 sm:w-8 sm:h-8 text-gray-300 dark:text-neutral-600" />

--- a/frontend/src/app/(post)/_components/MonthRecords.tsx
+++ b/frontend/src/app/(post)/_components/MonthRecords.tsx
@@ -12,28 +12,26 @@ import {
   DrawerTitle,
 } from '@/components/ui/drawer';
 import { BookOpen, Plus, X } from 'lucide-react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery, useQueryClient } from '@tanstack/react-query';
 import {
   MontlyCoverUpdateResponse,
   MonthlyRecordList,
 } from '@/lib/types/recordResponse';
 import { useApiPatch } from '@/hooks/useApi';
 import { myMonthlyRecordListOptions } from '@/lib/api/my';
-import { convertMontRecords } from '../_utils/convertMonthRecords';
+
 import {
   groupMonthlyRecordListOptions,
   groupMyRoleOptions,
 } from '@/lib/api/group';
 
 interface MonthRecordsProps {
-  monthRecords?: MonthlyRecordList[];
   cardRoute: string;
   groupId?: string;
 }
 
 export default function MonthRecords({
   groupId,
-  monthRecords,
   cardRoute,
 }: MonthRecordsProps) {
   const queryClient = useQueryClient();
@@ -48,11 +46,7 @@ export default function MonthRecords({
     ? groupMonthlyRecordListOptions(groupId, year)
     : myMonthlyRecordListOptions(year);
 
-  const { data: months = [] } = useQuery({
-    ...options,
-    ...(monthRecords && { initialData: monthRecords }),
-    select: (data: MonthlyRecordList[]) => convertMontRecords(data),
-  });
+  const { data: months } = useSuspenseQuery(options);
 
   // 그룹 게시글인 경우 권한 확인
   const { data: roleData } = useQuery({

--- a/frontend/src/app/(post)/_components/MonthRecords.tsx
+++ b/frontend/src/app/(post)/_components/MonthRecords.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { RecordCard } from '@/components/ui/RecordCard';
 import GalleryDrawer from '@/app/(post)/_components/GalleryDrawer';
 import {
@@ -25,12 +25,56 @@ import {
   groupMyRoleOptions,
 } from '@/lib/api/group';
 
+// convertMontRecords의 반환 타입 추론
+type ConvertedMonthRecord = {
+  id: string;
+  name: string;
+  count: number;
+  latestTitle: string;
+  latestLocation: string;
+  cover: { assetId: string; width: number; height: number; mimeType: string } | null;
+};
+
+// 개별 월 카드 컴포넌트 - 콜백 최적화
+const MonthCard = memo(function MonthCard({
+  month,
+  onNavigate,
+  onChangeCover,
+  canChangeCover,
+}: {
+  month: ConvertedMonthRecord;
+  onNavigate: (monthId: string) => void;
+  onChangeCover: (monthId: string) => void;
+  canChangeCover: boolean;
+}) {
+  const handleClick = useCallback(() => {
+    onNavigate(month.id);
+  }, [onNavigate, month.id]);
+
+  const handleChangeCover = useCallback(() => {
+    onChangeCover(month.id);
+  }, [onChangeCover, month.id]);
+
+  return (
+    <RecordCard
+      id={month.id}
+      name={month.name}
+      count={month.count}
+      latestTitle={month.latestTitle}
+      latestLocation={month.latestLocation}
+      cover={month.cover}
+      onClick={handleClick}
+      onChangeCover={canChangeCover ? handleChangeCover : undefined}
+    />
+  );
+});
+
 interface MonthRecordsProps {
   cardRoute: string;
   groupId?: string;
 }
 
-export default function MonthRecords({
+const MonthRecords = memo(function MonthRecords({
   groupId,
   cardRoute,
 }: MonthRecordsProps) {
@@ -55,11 +99,16 @@ export default function MonthRecords({
   });
 
   const isViewer = roleData?.role === 'VIEWER';
+  const canChangeCover = !(groupId && isViewer);
 
-  const openGallery = (monthId: string) => {
+  const handleNavigate = useCallback((monthId: string) => {
+    router.push(`${cardRoute}/${monthId}`);
+  }, [router, cardRoute]);
+
+  const openGallery = useCallback((monthId: string) => {
     setActiveMonthId(monthId);
     setIsDrawerOpen(true);
-  };
+  }, []);
 
   const cacheKey = groupId
     ? ['group', groupId, 'records', 'month']
@@ -144,16 +193,12 @@ export default function MonthRecords({
     <>
       <div className="grid grid-cols-2 gap-4 md:grid-cols-3 pb-16 sm:pb-32">
         {months.map((m) => (
-          <RecordCard
+          <MonthCard
             key={m.id}
-            id={m.id}
-            name={m.name}
-            count={m.count}
-            latestTitle={m.latestTitle}
-            latestLocation={m.latestLocation}
-            cover={m.cover}
-            onClick={() => router.push(`${cardRoute}/${m.id}`)}
-            onChangeCover={groupId && isViewer ? undefined : openGallery}
+            month={m}
+            onNavigate={handleNavigate}
+            onChangeCover={openGallery}
+            canChangeCover={canChangeCover}
           />
         ))}
       </div>
@@ -190,4 +235,6 @@ export default function MonthRecords({
       </Drawer>
     </>
   );
-}
+});
+
+export default MonthRecords;

--- a/frontend/src/app/(post)/_components/MonthRecordsSkeleton.tsx
+++ b/frontend/src/app/(post)/_components/MonthRecordsSkeleton.tsx
@@ -1,0 +1,27 @@
+function RecordCardSkeleton() {
+  return (
+    <div className="h-42 sm:h-50 rounded-2xl bg-gray-200 dark:bg-gray-800 animate-pulse relative overflow-hidden">
+      <div className="absolute bottom-0 left-0 right-0 p-3 sm:p-4 space-y-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <div className="h-3 w-2/3 bg-gray-300 dark:bg-gray-700 rounded" />
+          <div className="h-4 w-7 bg-gray-300 dark:bg-gray-700 rounded-lg" />
+        </div>
+        <div className="h-2.5 w-4/5 bg-gray-300 dark:bg-gray-700 rounded" />
+        <div className="flex justify-between">
+          <div className="h-2 w-1/3 bg-gray-300 dark:bg-gray-700 rounded" />
+          <div className="h-2 w-10 bg-gray-300 dark:bg-gray-700 rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function MonthRecordsSkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <RecordCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/_components/MonthlyDetailRecords.tsx
+++ b/frontend/src/app/(post)/_components/MonthlyDetailRecords.tsx
@@ -3,18 +3,17 @@
 import { DayRecord } from '@/lib/types/record';
 import { DateRecordCard } from '../../../components/ui/RecordCard';
 import ViewOnMapButton from './ViewOnMapButton';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
 import { SortOption } from './MonthlyDetailHeaderActions';
 import { useMemo } from 'react';
 import { myDailyRecordListOptions } from '@/lib/api/my';
-import { DailyRecordList } from '@/lib/types/recordResponse';
+
 import { groupDailyRecordListOptions } from '@/lib/api/group';
 import { BookOpen } from 'lucide-react';
 
 interface MonthlyDetailRecordsProps {
   month: string;
-  serverSideData?: DailyRecordList[];
   routePath: string;
   viewMapRoutePath: string;
   groupId?: string;
@@ -33,7 +32,6 @@ const sortRecords = (groups: DayRecord[], sortBy: SortOption): DayRecord[] => {
 };
 
 export default function MonthlyDetailRecords({
-  serverSideData,
   month,
   routePath,
   viewMapRoutePath,
@@ -46,10 +44,7 @@ export default function MonthlyDetailRecords({
     ? groupDailyRecordListOptions(groupId, month)
     : myDailyRecordListOptions(month);
 
-  const { data: dayRecords = [] } = useQuery({
-    ...option,
-    ...(serverSideData && { initialData: serverSideData }),
-  });
+  const { data: dayRecords } = useSuspenseQuery(option);
 
   const sortedGroups = useMemo(() => {
     if (sortBy === 'date-desc') return dayRecords;

--- a/frontend/src/app/(post)/_components/MonthlyDetailRecordsSkeleton.tsx
+++ b/frontend/src/app/(post)/_components/MonthlyDetailRecordsSkeleton.tsx
@@ -1,0 +1,26 @@
+function DateRecordCardSkeleton() {
+  return (
+    <div className="aspect-square rounded-2xl bg-gray-200 dark:bg-gray-800 animate-pulse relative overflow-hidden">
+      {/* 좌상단 날짜 뱃지 */}
+      <div className="absolute top-3 left-3 w-9 h-10 rounded-xl bg-gray-300 dark:bg-gray-700" />
+      {/* 하단 오버레이 */}
+      <div className="absolute bottom-0 left-0 right-0 p-3 sm:p-4 space-y-1.5">
+        <div className="h-3 w-3/4 bg-gray-300 dark:bg-gray-700 rounded" />
+        <div className="flex items-center justify-between">
+          <div className="h-2.5 w-1/3 bg-gray-300 dark:bg-gray-700 rounded" />
+          <div className="h-4 w-7 bg-gray-300 dark:bg-gray-700 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function MonthlyDetailRecordsSkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-4 xs:grid-cols-3 md:grid-cols-4">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <DateRecordCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
+++ b/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef, useCallback, memo, useMemo } from 'react';
 import { GripVertical, User } from 'lucide-react';
 
 // 컴포넌트 및 필드 임포트
@@ -44,7 +44,7 @@ import { useCreateRecord } from '@/hooks/useCreateRecord';
 import { mapBlocksToPayload } from '@/lib/utils/mapBlocksToPayload';
 
 import { usePostEditorInitializer } from '../../_hooks/useRecordEditorInitializer';
-import { useDraftPresence } from '@/hooks/useDraftPresence';
+import { useDraftPresence, PresenceMember } from '@/hooks/useDraftPresence';
 import { LockResponsePayload, useLockManager } from '@/hooks/useLockManager';
 import { useSocketStore } from '@/store/useSocketStore';
 import { useRecordCollaboration } from '@/hooks/useRecordCollaboration';
@@ -69,6 +69,149 @@ interface PostEditorProps {
   groupId?: string;
   postId?: string;
 }
+
+// 개별 블록 아이템 컴포넌트 - 콜백 최적화
+const BlockItem = memo(function BlockItem({
+  block,
+  isDraggingId,
+  locks,
+  mySessionId,
+  members,
+  streamingValues,
+  requestLock,
+  handleFieldUpdate,
+  handleFieldCommit,
+  removeBlock,
+  onOpenDrawer,
+  contentBlockCount,
+  handlePointerDown,
+  handlePointerMove,
+  handleDragEnd,
+}: {
+  block: RecordBlock;
+  isDraggingId: string | null;
+  locks: Record<string, string>;
+  mySessionId: string | null;
+  members: PresenceMember[];
+  streamingValues: Record<string, BlockValue>;
+  requestLock: (key: string) => void;
+  handleFieldUpdate: (
+    blockId: string,
+    newValue: BlockValue,
+    shouldStream?: boolean,
+  ) => void;
+  handleFieldCommit: (id: string, value: BlockValue) => void;
+  removeBlock: (id: string) => void;
+  onOpenDrawer: (
+    type: FieldType | 'layout' | 'saveLayout',
+    id?: string,
+  ) => void;
+  contentBlockCount: number;
+  handlePointerDown: (e: React.PointerEvent, blockId: string) => void;
+  handlePointerMove: (e: React.PointerEvent) => void;
+  handleDragEnd: () => void;
+}) {
+  const lockKey = `block:${block.id}`;
+  const ownerSessionId = locks[lockKey];
+  const isMyLock = !!ownerSessionId && ownerSessionId === mySessionId;
+  const isLockedByOther = !!ownerSessionId && !isMyLock;
+  const owner = useMemo(
+    () => members.find((m) => m.sessionId === ownerSessionId),
+    [members, ownerSessionId],
+  );
+  const isLastContentBlock = contentBlockCount === 1;
+
+  const handlePointerDownWrapper = useCallback(
+    (e: React.PointerEvent) => {
+      handlePointerDown(e, block.id);
+    },
+    [handlePointerDown, block.id],
+  );
+
+  const handleOpenDrawer = useCallback(
+    (type: FieldType | 'layout' | 'saveLayout', id?: string) => {
+      onOpenDrawer(type, id);
+    },
+    [onOpenDrawer],
+  );
+
+  const handleRemove = useCallback(() => {
+    removeBlock(block.id);
+  }, [removeBlock, block.id]);
+
+  const handleUpdate = useCallback(
+    (blockId: string, newValue: BlockValue, shouldStream?: boolean) => {
+      handleFieldUpdate(blockId, newValue, shouldStream);
+    },
+    [handleFieldUpdate],
+  );
+
+  const handleCommit = useCallback(
+    (id: string, value: BlockValue) => {
+      handleFieldCommit(id, value);
+    },
+    [handleFieldCommit],
+  );
+
+  return (
+    <div
+      data-block-id={block.id}
+      className={`cursor-grab touch-none relative group/field ${block.layout.span === 1 ? 'col-span-1' : 'col-span-2'} ${isDraggingId === block.id ? 'opacity-20 scale-95 pointer-events-none' : 'opacity-100'} ${!isDraggingId ? 'transition-all duration-300' : ''}`}
+    >
+      <div
+        className={`relative w-full flex flex-row gap-2 items-center ${
+          block.layout.col === 1 ? 'justify-start' : 'justify-end'
+        }`}
+      >
+        {isLockedByOther && owner && (
+          <div className="w-5 sm:w-6 h-5 sm:h-6 rounded-full ring-2 ring-itta-point animate-pulse">
+            {owner.profileImageId ? (
+              <AssetImage
+                assetId={owner.profileImageId}
+                alt={`${owner.displayName} 편집 중`}
+                width={24}
+                height={24}
+                className="w-full h-full rounded-full"
+                title={owner.displayName}
+              />
+            ) : (
+              <Image
+                width={24}
+                height={24}
+                src={'/profile_base.png'}
+                alt={`${owner.displayName} 편집 중`}
+                className="w-full h-full rounded-full"
+              />
+            )}
+          </div>
+        )}
+        <div
+          onPointerDown={handlePointerDownWrapper}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handleDragEnd}
+          className="flex items-center justify-center w-3.5 sm:w-4 h-full opacity-30 transition-opacity cursor-grab active:cursor-grabbing"
+        >
+          <GripVertical className="w-3.5 sm:w-4 h-3.5 sm:h-4 text-gray-500 dark:text-gray-200" />
+        </div>
+        <RecordFieldRenderer
+          block={block}
+          streamingValue={streamingValues[block.id]}
+          requestLock={requestLock}
+          onUpdate={handleUpdate}
+          onCommit={handleCommit}
+          onRemove={handleRemove}
+          onOpenDrawer={handleOpenDrawer}
+          isLastContentBlock={isLastContentBlock}
+          lock={{
+            lockKey,
+            isMyLock,
+            isLockedByOther,
+          }}
+        />
+      </div>
+    </div>
+  );
+});
 
 export default function PostEditor({
   mode,
@@ -649,6 +792,14 @@ export default function PostEditor({
     addOrShowBlock(type);
   };
 
+  // BlockItem용 drawer 핸들러
+  const handleOpenDrawerWrapper = useCallback(
+    (type: FieldType | 'layout' | 'saveLayout', id?: string) => {
+      setActiveDrawer({ type, id });
+    },
+    [setActiveDrawer],
+  );
+
   return (
     <div className="w-full flex flex-col h-full bg-white dark:bg-[#121212]">
       {(isPublishing || (isMediaUploading && !draftId)) && (
@@ -677,7 +828,11 @@ export default function PostEditor({
         )}
       </div>
 
-      <main className={cn('px-4 sm:px-6 space-y-4 sm:space-y-5 pb-40 sm:pb-48 overflow-y-auto py-2 sm:py-3')}>
+      <main
+        className={cn(
+          'px-4 sm:px-6 space-y-4 sm:space-y-5 pb-40 sm:pb-48 overflow-y-auto py-2 sm:py-3',
+        )}
+      >
         <RecordTitleInput
           title={title}
           setTitle={setTitle}
@@ -694,79 +849,26 @@ export default function PostEditor({
             isDraggingId ? '' : 'transition-all duration-300'
           }`}
         >
-          {blocks.map((block) => {
-            const lockKey = `block:${block.id}`;
-            const ownerSessionId = locks[lockKey];
-
-            const isMyLock = !!ownerSessionId && ownerSessionId === mySessionId;
-            const isLockedByOther = !!ownerSessionId && !isMyLock;
-
-            const owner = members.find((m) => m.sessionId === ownerSessionId);
-
-            const contentBlockCount = blocks.filter(
-              (b) => b.type === 'content',
-            ).length;
-            const isLastContentBlock = contentBlockCount === 1;
-            return (
-              <div
-                data-block-id={block.id}
-                key={block.id}
-                className={`cursor-grab touch-none relative group/field ${block.layout.span === 1 ? 'col-span-1' : 'col-span-2'} ${isDraggingId === block.id ? 'opacity-20 scale-95 pointer-events-none' : 'opacity-100'} ${!isDraggingId ? 'transition-all duration-300' : ''}`}
-              >
-                <div
-                  className={`relative w-full flex flex-row gap-2 items-center ${
-                    block.layout.col === 1 ? 'justify-start' : 'justify-end'
-                  }`}
-                >
-                  {isLockedByOther && owner && (
-                    <div className="w-5 sm:w-6 h-5 sm:h-6 rounded-full ring-2 ring-itta-point animate-pulse">
-                      {owner.profileImageId ? (
-                        <AssetImage
-                          assetId={owner.profileImageId}
-                          alt={`${owner.displayName} 편집 중`}
-                          width={24}
-                          height={24}
-                          className="w-full h-full rounded-full"
-                          title={owner.displayName}
-                        />
-                      ) : (
-                        <Image
-                          width={24}
-                          height={24}
-                          src={'/profile_base.png'}
-                          alt={`${owner.displayName} 편집 중`}
-                          className="w-full h-full rounded-full"
-                        />
-                      )}
-                    </div>
-                  )}
-                  <div
-                    onPointerDown={(e) => handlePointerDown(e, block.id)}
-                    onPointerMove={(e) => handlePointerMove(e)}
-                    onPointerUp={handleDragEnd}
-                    className="flex items-center justify-center w-3.5 sm:w-4 h-full opacity-30 transition-opacity cursor-grab active:cursor-grabbing"
-                  >
-                    <GripVertical className="w-3.5 sm:w-4 h-3.5 sm:h-4 text-gray-500 dark:text-gray-200" />
-                  </div>
-                  <RecordFieldRenderer
-                    block={block}
-                    streamingValue={streamingValues[block.id]}
-                    requestLock={requestLock}
-                    onUpdate={handleFieldUpdate}
-                    onCommit={handleFieldCommit}
-                    onRemove={removeBlock}
-                    onOpenDrawer={(type, id) => setActiveDrawer({ type, id })}
-                    isLastContentBlock={isLastContentBlock}
-                    lock={{
-                      lockKey,
-                      isMyLock,
-                      isLockedByOther,
-                    }}
-                  />
-                </div>
-              </div>
-            );
-          })}
+          {blocks.map((block) => (
+            <BlockItem
+              key={block.id}
+              block={block}
+              isDraggingId={isDraggingId}
+              locks={locks}
+              mySessionId={mySessionId}
+              members={members}
+              streamingValues={streamingValues}
+              requestLock={requestLock}
+              handleFieldUpdate={handleFieldUpdate}
+              handleFieldCommit={handleFieldCommit}
+              removeBlock={removeBlock}
+              onOpenDrawer={handleOpenDrawerWrapper}
+              contentBlockCount={blocks.filter((b) => b.type === 'content').length}
+              handlePointerDown={handlePointerDown}
+              handlePointerMove={handlePointerMove}
+              handleDragEnd={handleDragEnd}
+            />
+          ))}
         </div>
       </main>
       <Toolbar

--- a/frontend/src/app/(post)/group/[groupId]/(root)/loading.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/(root)/loading.tsx
@@ -1,0 +1,5 @@
+import MonthRecordsSkeleton from '@/app/(post)/_components/MonthRecordsSkeleton';
+
+export default function Loading() {
+  return <MonthRecordsSkeleton />;
+}

--- a/frontend/src/app/(post)/group/[groupId]/(root)/page.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/(root)/page.tsx
@@ -1,12 +1,14 @@
 import MonthRecords from '@/app/(post)/_components/MonthRecords';
-import { getCachedGroupMonthlyRecordList } from '@/lib/api/group';
+import MonthRecordsSkeleton from '@/app/(post)/_components/MonthRecordsSkeleton';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
 import { createMockGroupMonthlyRecords } from '@/lib/mocks/mock';
-import { MonthlyRecordList } from '@/lib/types/recordResponse';
 import {
   dehydrate,
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query';
+import { groupMonthlyRecordListOptions } from '@/lib/api/group';
 
 interface GroupPageProps {
   params: Promise<{ groupId: string }>;
@@ -15,39 +17,27 @@ interface GroupPageProps {
 export default async function GroupPage({ params }: GroupPageProps) {
   const { groupId } = await params;
   const year = String(new Date().getFullYear());
-
-  let monthlyRecords: MonthlyRecordList[];
   const queryClient = new QueryClient();
 
   if (process.env.NEXT_PUBLIC_MOCK === 'true') {
-    monthlyRecords = createMockGroupMonthlyRecords();
-  } else {
-    monthlyRecords = await getCachedGroupMonthlyRecordList(groupId, year);
-
-    // QueryClient에 원본 데이터를 저장 (select 함수가 클라이언트에서 변환)
     queryClient.setQueryData(
       ['group', groupId, 'records', 'month', year],
-      monthlyRecords || [],
+      createMockGroupMonthlyRecords(),
     );
+  } else {
+    await queryClient.prefetchQuery(groupMonthlyRecordListOptions(groupId, year));
   }
 
   return (
     <>
       {groupId && (
         <HydrationBoundary state={dehydrate(queryClient)}>
-          {process.env.NEXT_PUBLIC_MOCK === 'true' ? (
-            <MonthRecords
-              groupId={groupId}
-              monthRecords={monthlyRecords}
-              cardRoute={`/group/${groupId}/month`}
-            />
-          ) : (
-            <MonthRecords
-              groupId={groupId}
-              monthRecords={monthlyRecords}
-              cardRoute={`/group/${groupId}/month`}
-            />
-          )}
+          <ErrorHandlingWrapper
+            fallbackComponent={ErrorFallback}
+            suspenseFallback={<MonthRecordsSkeleton />}
+          >
+            <MonthRecords groupId={groupId} cardRoute={`/group/${groupId}/month`} />
+          </ErrorHandlingWrapper>
         </HydrationBoundary>
       )}
     </>

--- a/frontend/src/app/(post)/group/[groupId]/(root)/year/[year]/loading.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/(root)/year/[year]/loading.tsx
@@ -1,0 +1,5 @@
+import MonthRecordsSkeleton from '@/app/(post)/_components/MonthRecordsSkeleton';
+
+export default function Loading() {
+  return <MonthRecordsSkeleton />;
+}

--- a/frontend/src/app/(post)/group/[groupId]/(root)/year/[year]/page.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/(root)/year/[year]/page.tsx
@@ -1,12 +1,14 @@
 import MonthRecords from '@/app/(post)/_components/MonthRecords';
-import { getCachedGroupMonthlyRecordList } from '@/lib/api/group';
+import MonthRecordsSkeleton from '@/app/(post)/_components/MonthRecordsSkeleton';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
 import { createMockGroupMonthlyRecords } from '@/lib/mocks/mock';
-import { MonthlyRecordList } from '@/lib/types/recordResponse';
 import {
   dehydrate,
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query';
+import { groupMonthlyRecordListOptions } from '@/lib/api/group';
 
 interface GroupYearPageProps {
   params: Promise<{ groupId: string; year: string }>;
@@ -14,39 +16,27 @@ interface GroupYearPageProps {
 
 export default async function GroupYearPage({ params }: GroupYearPageProps) {
   const { groupId, year } = await params;
-
-  let monthlyRecords: MonthlyRecordList[];
   const queryClient = new QueryClient();
 
   if (process.env.NEXT_PUBLIC_MOCK === 'true') {
-    monthlyRecords = createMockGroupMonthlyRecords();
-  } else {
-    monthlyRecords = await getCachedGroupMonthlyRecordList(groupId, year);
-
-    // QueryClient에 직접 넣어서 HydrationBoundary로 클라이언트에 전달
     queryClient.setQueryData(
       ['group', groupId, 'records', 'month', year],
-      monthlyRecords,
+      createMockGroupMonthlyRecords(),
     );
+  } else {
+    await queryClient.prefetchQuery(groupMonthlyRecordListOptions(groupId, year));
   }
 
   return (
     <>
       {groupId && (
         <HydrationBoundary state={dehydrate(queryClient)}>
-          {process.env.NEXT_PUBLIC_MOCK === 'true' ? (
-            <MonthRecords
-              groupId={groupId}
-              monthRecords={monthlyRecords}
-              cardRoute={`/group/${groupId}/month`}
-            />
-          ) : (
-            <MonthRecords
-              monthRecords={monthlyRecords}
-              groupId={groupId}
-              cardRoute={`/group/${groupId}/month`}
-            />
-          )}
+          <ErrorHandlingWrapper
+            fallbackComponent={ErrorFallback}
+            suspenseFallback={<MonthRecordsSkeleton />}
+          >
+            <MonthRecords groupId={groupId} cardRoute={`/group/${groupId}/month`} />
+          </ErrorHandlingWrapper>
         </HydrationBoundary>
       )}
     </>

--- a/frontend/src/app/(post)/group/[groupId]/detail/[date]/_components/GroupDailyDetailData.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/detail/[date]/_components/GroupDailyDetailData.tsx
@@ -1,0 +1,43 @@
+import DailyDetailFloatingActions from '@/app/(post)/_components/DailyDetailFloatingActions';
+import DailyDetailRecords from '@/components/DailyDetailRecords';
+import DailyDetailRecordsSkeleton from '@/components/DailyDetailRecordsSkeleton';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
+import { createMockRecordPreviews } from '@/lib/mocks/mock';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { recordPreviewListOptions } from '@/lib/api/records';
+
+interface GroupDailyDetailDataProps {
+  date: string;
+  groupId: string;
+}
+
+export default async function GroupDailyDetailData({
+  date,
+  groupId,
+}: GroupDailyDetailDataProps) {
+  const queryClient = new QueryClient();
+
+  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
+    queryClient.setQueryData(
+      ['group', groupId, 'records', 'daily', date],
+      createMockRecordPreviews(date),
+    );
+  } else {
+    await queryClient.prefetchQuery(recordPreviewListOptions(date, 'groups', groupId));
+  }
+
+  return (
+    <div className="p-4 sm:p-6 pb-14 sm:pb-16">
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ErrorHandlingWrapper
+          fallbackComponent={ErrorFallback}
+          suspenseFallback={<DailyDetailRecordsSkeleton />}
+        >
+          <DailyDetailRecords date={date} scope="groups" groupId={groupId} />
+        </ErrorHandlingWrapper>
+      </HydrationBoundary>
+      <DailyDetailFloatingActions date={date} groupId={groupId} />
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/group/[groupId]/detail/[date]/loading.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/detail/[date]/loading.tsx
@@ -1,0 +1,20 @@
+import DailyDetailRecordsSkeleton from '@/components/DailyDetailRecordsSkeleton';
+import Back from '@/components/Back';
+
+export default function Loading() {
+  return (
+    <div className="h-full transition-colors duration-300 dark:bg-[#121212] bg-[#FDFDFD]">
+      <header className="sticky top-0 z-50 backdrop-blur-md px-4 py-3 sm:p-6 flex items-center justify-between transition-colors duration-300 dark:bg-[#121212]/80 bg-white/80">
+        <Back />
+        <div className="flex flex-col items-center gap-1">
+          <div className="h-2.5 w-16 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+          <div className="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+        </div>
+        <div className="w-6 sm:w-8" />
+      </header>
+      <div className="p-4 sm:p-6">
+        <DailyDetailRecordsSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/group/[groupId]/detail/[date]/page.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/detail/[date]/page.tsx
@@ -1,14 +1,16 @@
 import DailyDetailFloatingActions from '@/app/(post)/_components/DailyDetailFloatingActions';
 import DailyDetailRecords from '@/components/DailyDetailRecords';
+import DailyDetailRecordsSkeleton from '@/components/DailyDetailRecordsSkeleton';
 import Back from '@/components/Back';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
 import { createMockRecordPreviews } from '@/lib/mocks/mock';
-import { RecordPreview } from '@/lib/types/recordResponse';
 import {
   dehydrate,
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query';
-import { getCachedRecordPreviewList } from '@/lib/api/records';
+import { recordPreviewListOptions } from '@/lib/api/records';
 
 interface GroupDailyDetailPageProps {
   params: Promise<{ date: string; groupId: string }>;
@@ -20,19 +22,13 @@ export default async function GroupDailyDetailPage({
   const { date, groupId } = await params;
   const queryClient = new QueryClient();
 
-  let records: RecordPreview[];
-
-  if (process.env.NEXT_PUBLIC_MOCK !== 'true') {
-    records = await getCachedRecordPreviewList(date, 'groups', groupId);
-
-    // QueryClient에 직접 넣어서 HydrationBoundary로 클라이언트에 전달
-    // recordPreviewListOptions의 queryKey와 일치시켜야 함
+  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
     queryClient.setQueryData(
       ['group', groupId, 'records', 'daily', date],
-      records,
+      createMockRecordPreviews(date),
     );
   } else {
-    records = createMockRecordPreviews(date);
+    await queryClient.prefetchQuery(recordPreviewListOptions(date, 'groups', groupId));
   }
 
   return (
@@ -52,16 +48,12 @@ export default async function GroupDailyDetailPage({
 
       <div className="p-4 sm:p-6 pb-14 sm:pb-16">
         <HydrationBoundary state={dehydrate(queryClient)}>
-          {process.env.NEXT_PUBLIC_MOCK === 'true' ? (
-            <DailyDetailRecords
-              memories={records}
-              date={date}
-              scope="groups"
-              groupId={groupId}
-            />
-          ) : (
+          <ErrorHandlingWrapper
+            fallbackComponent={ErrorFallback}
+            suspenseFallback={<DailyDetailRecordsSkeleton />}
+          >
             <DailyDetailRecords date={date} scope="groups" groupId={groupId} />
-          )}
+          </ErrorHandlingWrapper>
         </HydrationBoundary>
         <DailyDetailFloatingActions date={date} groupId={groupId} />
       </div>

--- a/frontend/src/app/(post)/group/[groupId]/detail/[date]/page.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/detail/[date]/page.tsx
@@ -1,16 +1,7 @@
-import DailyDetailFloatingActions from '@/app/(post)/_components/DailyDetailFloatingActions';
-import DailyDetailRecords from '@/components/DailyDetailRecords';
-import DailyDetailRecordsSkeleton from '@/components/DailyDetailRecordsSkeleton';
 import Back from '@/components/Back';
-import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
-import ErrorFallback from '@/components/ErrorFallback';
-import { createMockRecordPreviews } from '@/lib/mocks/mock';
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
-import { recordPreviewListOptions } from '@/lib/api/records';
+import DailyDetailRecordsSkeleton from '@/components/DailyDetailRecordsSkeleton';
+import { Suspense } from 'react';
+import GroupDailyDetailData from './_components/GroupDailyDetailData';
 
 interface GroupDailyDetailPageProps {
   params: Promise<{ date: string; groupId: string }>;
@@ -20,16 +11,6 @@ export default async function GroupDailyDetailPage({
   params,
 }: GroupDailyDetailPageProps) {
   const { date, groupId } = await params;
-  const queryClient = new QueryClient();
-
-  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
-    queryClient.setQueryData(
-      ['group', groupId, 'records', 'daily', date],
-      createMockRecordPreviews(date),
-    );
-  } else {
-    await queryClient.prefetchQuery(recordPreviewListOptions(date, 'groups', groupId));
-  }
 
   return (
     <div className="h-full transition-colors duration-300 dark:bg-[#121212] bg-[#FDFDFD]">
@@ -45,18 +26,9 @@ export default async function GroupDailyDetailPage({
         </div>
         <div className="w-6 sm:w-8" />
       </header>
-
-      <div className="p-4 sm:p-6 pb-14 sm:pb-16">
-        <HydrationBoundary state={dehydrate(queryClient)}>
-          <ErrorHandlingWrapper
-            fallbackComponent={ErrorFallback}
-            suspenseFallback={<DailyDetailRecordsSkeleton />}
-          >
-            <DailyDetailRecords date={date} scope="groups" groupId={groupId} />
-          </ErrorHandlingWrapper>
-        </HydrationBoundary>
-        <DailyDetailFloatingActions date={date} groupId={groupId} />
-      </div>
+      <Suspense fallback={<div className="p-4 sm:p-6"><DailyDetailRecordsSkeleton /></div>}>
+        <GroupDailyDetailData date={date} groupId={groupId} />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/src/app/(post)/group/[groupId]/edit/_components/GroupEditClient.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/edit/_components/GroupEditClient.tsx
@@ -6,29 +6,14 @@ import GroupMemberManagement from './GroupMemberManagement';
 import GroupDangerousZone from './GroupDangerousZone';
 import GroupEditHeaderActions from './GroupEditHeaderActions';
 import { groupDetailOptions } from '@/lib/api/group';
-import { useQuery } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
-import { GroupEditResponse } from '@/lib/types/groupResponse';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 interface GroupEditClientProps {
   groupId: string;
-  profile: GroupEditResponse;
 }
 
-export default function GroupEditClient({
-  groupId,
-  profile,
-}: GroupEditClientProps) {
-  const router = useRouter();
-  const { data } = useQuery({
-    ...groupDetailOptions(groupId),
-    initialData: profile,
-  });
-
-  if (!data) {
-    router.push(`/group/${groupId}`);
-    return;
-  }
+export default function GroupEditClient({ groupId }: GroupEditClientProps) {
+  const { data } = useSuspenseQuery(groupDetailOptions(groupId));
 
   const { group, me, members } = data;
   return (

--- a/frontend/src/app/(post)/group/[groupId]/edit/_components/GroupEditSkeleton.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/edit/_components/GroupEditSkeleton.tsx
@@ -1,0 +1,72 @@
+export default function GroupEditSkeleton() {
+  return (
+    <div className="animate-pulse">
+      {/* 헤더 */}
+      <header className="sticky top-0 z-50 px-4 py-3 sm:p-6 flex items-center justify-between bg-white/95 dark:bg-[#121212]/95">
+        <div className="h-5 w-5 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-3.5 w-20 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-3.5 w-8 bg-gray-200 dark:bg-gray-700 rounded" />
+      </header>
+
+      {/* 컨텐츠 */}
+      <div className="px-6 pb-10 pt-15 space-y-10">
+        {/* GroupInfo */}
+        <section className="space-y-4">
+          {/* 그룹 썸네일 */}
+          <div className="flex flex-col items-center mb-6">
+            <div className="relative">
+              <div className="w-22 h-22 sm:w-24 sm:h-24 rounded-[32px] bg-gray-200 dark:bg-gray-700 border-4 border-white dark:border-[#121212]" />
+              <div className="absolute -bottom-1 -right-1 w-8 h-8 rounded-xl bg-gray-300 dark:bg-gray-600 border-2 border-white" />
+            </div>
+          </div>
+
+          {/* 그룹 이름 */}
+          <div className="space-y-2">
+            <div className="h-2.5 w-12 bg-gray-200 dark:bg-gray-700 rounded" />
+            <div className="border-b-2 border-gray-100 dark:border-white/5 py-4">
+              <div className="h-5 w-1/2 bg-gray-200 dark:bg-gray-700 rounded" />
+            </div>
+          </div>
+
+          {/* 나의 그룹 프로필 */}
+          <section className="space-y-4">
+            <div className="h-2.5 w-24 bg-gray-200 dark:bg-gray-700 rounded" />
+            <div className="w-full flex items-center justify-between px-3 py-4 sm:p-4 rounded-3xl border dark:bg-[#10B981]/5 dark:border-[#10B981]/10 bg-[#10B981]/5 border-[#10B981]/10">
+              <div className="flex items-center gap-4">
+                <div className="w-12 h-12 rounded-full bg-gray-200 dark:bg-gray-700 shrink-0" />
+                <div className="space-y-1.5">
+                  <div className="h-3.5 w-16 bg-gray-200 dark:bg-gray-700 rounded" />
+                  <div className="h-2.75 w-28 bg-gray-200 dark:bg-gray-700 rounded" />
+                </div>
+              </div>
+              <div className="h-5 w-5 bg-gray-200 dark:bg-gray-700 rounded" />
+            </div>
+          </section>
+        </section>
+
+        {/* GroupMemberManagement */}
+        <section className="space-y-4">
+          <div className="h-3.5 w-16 bg-gray-200 dark:bg-gray-700 rounded" />
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex items-center justify-between py-2">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-full bg-gray-200 dark:bg-gray-700 shrink-0" />
+                <div className="space-y-1.5">
+                  <div className="h-3.5 w-20 bg-gray-200 dark:bg-gray-700 rounded" />
+                  <div className="h-2.75 w-12 bg-gray-100 dark:bg-gray-800 rounded" />
+                </div>
+              </div>
+              <div className="h-6 w-12 bg-gray-100 dark:bg-gray-800 rounded-full" />
+            </div>
+          ))}
+        </section>
+
+        {/* GroupDangerousZone */}
+        <section className="space-y-4">
+          <div className="h-3.5 w-16 bg-gray-200 dark:bg-gray-700 rounded" />
+          <div className="h-12 w-full bg-gray-100 dark:bg-gray-800 rounded-2xl" />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/group/[groupId]/edit/_components/GroupInfo.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/edit/_components/GroupInfo.tsx
@@ -17,19 +17,20 @@ import GalleryDrawer from '@/app/(post)/_components/GalleryDrawer';
 import { cn } from '@/lib/utils';
 import AssetImage from '@/components/AssetImage';
 import { GroupEditResponse } from '@/lib/types/groupResponse';
+import { memo, useCallback, useMemo } from 'react';
 
 type GroupInfoProps = Pick<Group, 'groupThumnail'> & {
   groupId: string;
   me: GroupEditResponse['me'];
 };
 
-export default function GroupInfo({ groupId, me }: GroupInfoProps) {
+const GroupInfo = memo(function GroupInfo({ groupId, me }: GroupInfoProps) {
   const { groupName, setGroupName, groupThumbnail, setGroupThumbnail } =
     useGroupEdit();
   const router = useRouter();
 
-  // 그룹 이름 유효성 검사
-  const getGroupNameError = () => {
+  // 그룹 이름 유효성 검사 - useMemo로 최적화
+  const groupNameError = useMemo(() => {
     if (groupName.length < 2) return '그룹 이름은 최소 2자 이상이어야 합니다.';
     if (groupName.length > 10)
       return '그룹 이름은 최대 10자까지 입력 가능합니다.';
@@ -47,9 +48,23 @@ export default function GroupInfo({ groupId, me }: GroupInfoProps) {
     }
 
     return null;
-  };
+  }, [groupName]);
 
-  const groupNameError = getGroupNameError();
+  const handleThumbnailSelect = useCallback((assetId: string, postId: string) => {
+    setGroupThumbnail({ assetId, postId });
+  }, [setGroupThumbnail]);
+
+  const handleGroupNameClear = useCallback(() => {
+    setGroupName('');
+  }, [setGroupName]);
+
+  const handleGroupNameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setGroupName(e.target.value);
+  }, [setGroupName]);
+
+  const handleNavigateToProfile = useCallback(() => {
+    router.push(`/group/${groupId}/edit/profile`);
+  }, [router, groupId]);
 
   return (
     <section className="space-y-4">
@@ -101,9 +116,7 @@ export default function GroupInfo({ groupId, me }: GroupInfoProps) {
             <GalleryDrawer
               type="group"
               groupId={groupId}
-              onSelect={(assetId, postId) =>
-                setGroupThumbnail({ assetId, postId })
-              }
+              onSelect={handleThumbnailSelect}
             />
           </DrawerContent>
         </Drawer>
@@ -119,7 +132,7 @@ export default function GroupInfo({ groupId, me }: GroupInfoProps) {
             disabled={me.role === 'VIEWER'}
             value={groupName}
             placeholder="그룹명을 작성해주세요."
-            onChange={(e) => setGroupName(e.target.value)}
+            onChange={handleGroupNameChange}
             className={`w-full border-b-2 bg-transparent px-1 py-4 text-sm font-semibold transition-all outline-none dark:text-white dark:placeholder-gray-700 text-itta-black placeholder-gray-300 ${
               groupNameError
                 ? 'border-red-500 dark:border-red-500 focus:border-red-500 dark:focus:border-red-500'
@@ -128,7 +141,7 @@ export default function GroupInfo({ groupId, me }: GroupInfoProps) {
           />
           {groupName && (
             <button
-              onClick={() => setGroupName('')}
+              onClick={handleGroupNameClear}
               className="cursor-pointer absolute right-0 top-1/2 -translate-y-1/2 p-1 text-gray-300"
             >
               <X className="w-4 h-4" />
@@ -147,7 +160,7 @@ export default function GroupInfo({ groupId, me }: GroupInfoProps) {
           나의 그룹 프로필
         </label>
         <button
-          onClick={() => router.push(`/group/${groupId}/edit/profile`)}
+          onClick={handleNavigateToProfile}
           className="cursor-pointer mt-4 w-full flex items-center justify-between px-3 py-4 sm:p-4 rounded-3xl border transition-all active:scale-[0.98] dark:bg-[#10B981]/5 dark:border-[#10B981]/10 dark:hover:bg-[#10B981]/10 bg-[#10B981]/5 border-[#10B981]/10 hover:bg-[#10B981]/10"
         >
           <div className="flex items-center rounded-full gap-4 overflow-hidden">
@@ -182,4 +195,6 @@ export default function GroupInfo({ groupId, me }: GroupInfoProps) {
       </section>
     </section>
   );
-}
+});
+
+export default GroupInfo;

--- a/frontend/src/app/(post)/group/[groupId]/edit/_components/GroupInfo.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/edit/_components/GroupInfo.tsx
@@ -14,10 +14,9 @@ import {
   DrawerTrigger,
 } from '@/components/ui/drawer';
 import GalleryDrawer from '@/app/(post)/_components/GalleryDrawer';
-import { cn } from '@/lib/utils';
 import AssetImage from '@/components/AssetImage';
 import { GroupEditResponse } from '@/lib/types/groupResponse';
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback } from 'react';
 
 type GroupInfoProps = Pick<Group, 'groupThumnail'> & {
   groupId: string;
@@ -30,7 +29,7 @@ const GroupInfo = memo(function GroupInfo({ groupId, me }: GroupInfoProps) {
   const router = useRouter();
 
   // 그룹 이름 유효성 검사 - useMemo로 최적화
-  const groupNameError = useMemo(() => {
+  const getGroupNameError = () => {
     if (groupName.length < 2) return '그룹 이름은 최소 2자 이상이어야 합니다.';
     if (groupName.length > 10)
       return '그룹 이름은 최대 10자까지 입력 가능합니다.';
@@ -48,23 +47,31 @@ const GroupInfo = memo(function GroupInfo({ groupId, me }: GroupInfoProps) {
     }
 
     return null;
-  }, [groupName]);
+  };
 
-  const handleThumbnailSelect = useCallback((assetId: string, postId: string) => {
-    setGroupThumbnail({ assetId, postId });
-  }, [setGroupThumbnail]);
+  const handleThumbnailSelect = useCallback(
+    (assetId: string, postId: string) => {
+      setGroupThumbnail({ assetId, postId });
+    },
+    [setGroupThumbnail],
+  );
 
   const handleGroupNameClear = useCallback(() => {
     setGroupName('');
   }, [setGroupName]);
 
-  const handleGroupNameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setGroupName(e.target.value);
-  }, [setGroupName]);
+  const handleGroupNameChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setGroupName(e.target.value);
+    },
+    [setGroupName],
+  );
 
   const handleNavigateToProfile = useCallback(() => {
     router.push(`/group/${groupId}/edit/profile`);
   }, [router, groupId]);
+
+  const groupNameError = getGroupNameError();
 
   return (
     <section className="space-y-4">

--- a/frontend/src/app/(post)/group/[groupId]/edit/loading.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/edit/loading.tsx
@@ -1,0 +1,5 @@
+import GroupEditSkeleton from './_components/GroupEditSkeleton';
+
+export default function Loading() {
+  return <GroupEditSkeleton />;
+}

--- a/frontend/src/app/(post)/group/[groupId]/edit/page.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/edit/page.tsx
@@ -1,13 +1,15 @@
 import GroupEditClient from './_components/GroupEditClient';
+import GroupEditSkeleton from './_components/GroupEditSkeleton';
 import {
   dehydrate,
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query';
-import { getCachedGroupDetail } from '@/lib/api/group';
+import { getCachedGroupDetail, groupDetailOptions } from '@/lib/api/group';
 import { redirect } from 'next/navigation';
 import { createMockGroupSettings } from '@/lib/mocks/mock';
-import { GroupEditResponse } from '@/lib/types/groupResponse';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
 
 interface GroupEditPageProps {
   params: Promise<{ groupId: string }>;
@@ -16,13 +18,11 @@ interface GroupEditPageProps {
 export default async function GroupEditPage({ params }: GroupEditPageProps) {
   const { groupId } = await params;
   const queryClient = new QueryClient();
-  let groupProfile: GroupEditResponse;
 
   if (process.env.NEXT_PUBLIC_MOCK !== 'true') {
     try {
-      groupProfile = await getCachedGroupDetail(groupId);
-      // QueryClient에 직접 넣어서 HydrationBoundary로 클라이언트에 전달
-      queryClient.setQueryData(['group', groupId, 'edit'], groupProfile);
+      const groupProfile = await getCachedGroupDetail(groupId);
+      queryClient.setQueryData(groupDetailOptions(groupId).queryKey, groupProfile);
     } catch (error: unknown) {
       const code =
         error && typeof error === 'object' && 'code' in error
@@ -34,16 +34,20 @@ export default async function GroupEditPage({ params }: GroupEditPageProps) {
       throw error;
     }
   } else {
-    groupProfile = createMockGroupSettings(groupId);
     queryClient.setQueryData(
-      ['group', groupId, 'edit'],
+      groupDetailOptions(groupId).queryKey,
       createMockGroupSettings(groupId),
     );
   }
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <GroupEditClient profile={groupProfile} groupId={groupId} />
+      <ErrorHandlingWrapper
+        fallbackComponent={ErrorFallback}
+        suspenseFallback={<GroupEditSkeleton />}
+      >
+        <GroupEditClient groupId={groupId} />
+      </ErrorHandlingWrapper>
     </HydrationBoundary>
   );
 }

--- a/frontend/src/app/(post)/group/[groupId]/edit/profile/_components/GroupProfileEditSkeleton.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/edit/profile/_components/GroupProfileEditSkeleton.tsx
@@ -1,0 +1,37 @@
+export default function GroupProfileEditSkeleton() {
+  return (
+    <div className="w-full flex flex-col min-h-screen dark:bg-[#121212] dark:text-white bg-white text-itta-black animate-pulse">
+      {/* 헤더 - ProfileEditHeaderActions와 동일한 패딩 */}
+      <div className="sticky top-0 z-50 px-4 py-3 sm:p-6 flex items-center justify-between bg-white/95 dark:bg-[#121212]/95">
+        <div className="h-5 w-5 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-3.5 w-24 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-3.5 w-8 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+
+      {/* 컨텐츠 - p-6 flex flex-col gap-10 */}
+      <div className="flex p-6 flex-col gap-10">
+        {/* ProfileInfo의 py-8 flex flex-col gap-10 */}
+        <div className="py-8 flex flex-col gap-10">
+          {/* 프로필 이미지 */}
+          <div className="flex flex-col items-center">
+            <div className="relative">
+              <div className="w-24 h-24 sm:w-28 sm:h-28 rounded-full border-4 bg-gray-200 dark:bg-gray-700 border-gray-50 dark:border-[#1E1E1E]" />
+              <div className="absolute bottom-0 right-0 w-10 h-10 rounded-full bg-gray-300 dark:bg-gray-600 border-2 border-white" />
+            </div>
+          </div>
+
+          {/* 닉네임만 (이메일 없음) */}
+          <div className="w-full space-y-8 mt-2">
+            <div className="space-y-2">
+              <div className="h-2.5 w-10 bg-gray-200 dark:bg-gray-700 rounded" />
+              <div className="border-b-2 border-gray-100 dark:border-white/5 py-4">
+                <div className="h-5.5 w-2/3 bg-gray-200 dark:bg-gray-700 rounded" />
+              </div>
+              <div className="h-2.5 w-48 bg-gray-100 dark:bg-gray-800 rounded" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/group/[groupId]/edit/profile/loading.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/edit/profile/loading.tsx
@@ -1,0 +1,5 @@
+import GroupProfileEditSkeleton from './_components/GroupProfileEditSkeleton';
+
+export default function Loading() {
+  return <GroupProfileEditSkeleton />;
+}

--- a/frontend/src/app/(post)/group/[groupId]/month/[month]/_components/GroupMonthlyDetailData.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/month/[month]/_components/GroupMonthlyDetailData.tsx
@@ -1,0 +1,49 @@
+import MonthlyDetailRecords from '@/app/(post)/_components/MonthlyDetailRecords';
+import MonthlyDetailRecordsSkeleton from '@/app/(post)/_components/MonthlyDetailRecordsSkeleton';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
+import { getMonthRange } from '@/lib/date';
+import { createMockGroupDailyRecords } from '@/lib/mocks/mock';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { groupDailyRecordListOptions } from '@/lib/api/group';
+
+interface GroupMonthlyDetailDataProps {
+  groupId: string;
+  month: string;
+}
+
+export default async function GroupMonthlyDetailData({
+  groupId,
+  month,
+}: GroupMonthlyDetailDataProps) {
+  const queryClient = new QueryClient();
+
+  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
+    queryClient.setQueryData(
+      ['group', groupId, 'records', 'daily', month],
+      createMockGroupDailyRecords(),
+    );
+  } else {
+    await queryClient.prefetchQuery(groupDailyRecordListOptions(groupId, month));
+  }
+
+  const { startDate, endDate } = getMonthRange(month);
+
+  return (
+    <div className="p-4 sm:p-6 pb-28 sm:pb-40">
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ErrorHandlingWrapper
+          fallbackComponent={ErrorFallback}
+          suspenseFallback={<MonthlyDetailRecordsSkeleton />}
+        >
+          <MonthlyDetailRecords
+            groupId={groupId}
+            month={month}
+            routePath={`/group/${groupId}/detail`}
+            viewMapRoutePath={`/group/${groupId}/map?start=${startDate}&end=${endDate}`}
+          />
+        </ErrorHandlingWrapper>
+      </HydrationBoundary>
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/group/[groupId]/month/[month]/loading.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/month/[month]/loading.tsx
@@ -1,0 +1,18 @@
+import MonthlyDetailRecordsSkeleton from '@/app/(post)/_components/MonthlyDetailRecordsSkeleton';
+
+export default function Loading() {
+  return (
+    <div className="h-full transition-colors duration-300 dark:bg-[#121212] bg-[#FDFDFD]">
+      <div className="py-3 px-4 sm:py-6 sm:px-6 sticky top-0 z-50 transition-colors duration-300 dark:bg-[#121212] bg-white">
+        <div className="flex items-center justify-between">
+          <div className="h-4 w-6 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+          <div className="h-5 w-24 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+          <div className="h-4 w-6 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+        </div>
+      </div>
+      <div className="p-4 sm:p-6 pb-28 sm:pb-40">
+        <MonthlyDetailRecordsSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/group/[groupId]/month/[month]/page.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/month/[month]/page.tsx
@@ -1,16 +1,7 @@
 import MonthlyDetailHeaderActions from '@/app/(post)/_components/MonthlyDetailHeaderActions';
-import MonthlyDetailRecords from '@/app/(post)/_components/MonthlyDetailRecords';
 import MonthlyDetailRecordsSkeleton from '@/app/(post)/_components/MonthlyDetailRecordsSkeleton';
-import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
-import ErrorFallback from '@/components/ErrorFallback';
-import { getMonthRange } from '@/lib/date';
-import { createMockGroupDailyRecords } from '@/lib/mocks/mock';
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
-import { groupDailyRecordListOptions } from '@/lib/api/group';
+import { Suspense } from 'react';
+import GroupMonthlyDetailData from './_components/GroupMonthlyDetailData';
 
 interface GroupMonthlyDetailPageProps {
   params: Promise<{ month: string; groupId: string }>;
@@ -20,18 +11,7 @@ export default async function GroupMonthlyDetailPage({
   params,
 }: GroupMonthlyDetailPageProps) {
   const { groupId, month } = await params;
-  const queryClient = new QueryClient();
 
-  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
-    queryClient.setQueryData(
-      ['group', groupId, 'records', 'daily', month],
-      createMockGroupDailyRecords(),
-    );
-  } else {
-    await queryClient.prefetchQuery(groupDailyRecordListOptions(groupId, month));
-  }
-
-  const { startDate, endDate } = getMonthRange(month);
   return (
     <div className="h-full transition-colors duration-300 dark:bg-[#121212] bg-[#FDFDFD]">
       <div className="py-3 px-4 sm:py-6 sm:px-6 sticky top-0 z-50 transition-colors duration-300 dark:bg-[#121212] bg-white">
@@ -39,22 +19,9 @@ export default async function GroupMonthlyDetailPage({
           <MonthlyDetailHeaderActions month={month} title="Together archive" />
         </header>
       </div>
-
-      <div className="p-4 sm:p-6 pb-28 sm:pb-40">
-        <HydrationBoundary state={dehydrate(queryClient)}>
-          <ErrorHandlingWrapper
-            fallbackComponent={ErrorFallback}
-            suspenseFallback={<MonthlyDetailRecordsSkeleton />}
-          >
-            <MonthlyDetailRecords
-              groupId={groupId}
-              month={month}
-              routePath={`/group/${groupId}/detail`}
-              viewMapRoutePath={`/group/${groupId}/map?start=${startDate}&end=${endDate}`}
-            />
-          </ErrorHandlingWrapper>
-        </HydrationBoundary>
-      </div>
+      <Suspense fallback={<div className="p-4 sm:p-6"><MonthlyDetailRecordsSkeleton /></div>}>
+        <GroupMonthlyDetailData groupId={groupId} month={month} />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/src/app/(post)/my/(root)/loading.tsx
+++ b/frontend/src/app/(post)/my/(root)/loading.tsx
@@ -1,0 +1,5 @@
+import MonthRecordsSkeleton from '@/app/(post)/_components/MonthRecordsSkeleton';
+
+export default function Loading() {
+  return <MonthRecordsSkeleton />;
+}

--- a/frontend/src/app/(post)/my/(root)/year/[year]/loading.tsx
+++ b/frontend/src/app/(post)/my/(root)/year/[year]/loading.tsx
@@ -1,0 +1,5 @@
+import MonthRecordsSkeleton from '@/app/(post)/_components/MonthRecordsSkeleton';
+
+export default function Loading() {
+  return <MonthRecordsSkeleton />;
+}

--- a/frontend/src/app/(post)/my/detail/[date]/_components/MyDailyDetailData.tsx
+++ b/frontend/src/app/(post)/my/detail/[date]/_components/MyDailyDetailData.tsx
@@ -1,0 +1,39 @@
+import DailyDetailRecords from '@/components/DailyDetailRecords';
+import DailyDetailRecordsSkeleton from '@/components/DailyDetailRecordsSkeleton';
+import DailyDetailFloatingActions from '@/app/(post)/_components/DailyDetailFloatingActions';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
+import { createMockRecordPreviews } from '@/lib/mocks/mock';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { recordPreviewListOptions } from '@/lib/api/records';
+
+interface MyDailyDetailDataProps {
+  date: string;
+}
+
+export default async function MyDailyDetailData({ date }: MyDailyDetailDataProps) {
+  const queryClient = new QueryClient();
+
+  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
+    queryClient.setQueryData(
+      ['records', 'preview', date, 'personal'],
+      createMockRecordPreviews(date),
+    );
+  } else {
+    await queryClient.prefetchQuery(recordPreviewListOptions(date, 'personal'));
+  }
+
+  return (
+    <div className="py-4 sm:py-6 pb-14 sm:pb-16">
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ErrorHandlingWrapper
+          fallbackComponent={ErrorFallback}
+          suspenseFallback={<DailyDetailRecordsSkeleton />}
+        >
+          <DailyDetailRecords date={date} scope="personal" />
+        </ErrorHandlingWrapper>
+      </HydrationBoundary>
+      <DailyDetailFloatingActions date={date} />
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/my/detail/[date]/loading.tsx
+++ b/frontend/src/app/(post)/my/detail/[date]/loading.tsx
@@ -1,0 +1,20 @@
+import DailyDetailRecordsSkeleton from '@/components/DailyDetailRecordsSkeleton';
+import Back from '@/components/Back';
+
+export default function Loading() {
+  return (
+    <div className="-mt-4 sm:-mt-6 h-full transition-colors duration-300 dark:bg-[#121212] bg-[#FDFDFD]">
+      <header className="-mx-4 sm:-mx-6 sticky top-0 z-50 backdrop-blur-md px-4 py-3 sm:p-6 flex items-center justify-between transition-colors duration-300 dark:bg-[#121212]/80 bg-white/80">
+        <Back />
+        <div className="flex flex-col items-center gap-1">
+          <div className="h-2.5 w-16 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+          <div className="h-4 w-20 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+        </div>
+        <div className="w-6 sm:w-8" />
+      </header>
+      <div className="py-4 sm:py-6">
+        <DailyDetailRecordsSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/my/detail/[date]/page.tsx
+++ b/frontend/src/app/(post)/my/detail/[date]/page.tsx
@@ -1,14 +1,16 @@
 import DailyDetailRecords from '../../../../../components/DailyDetailRecords';
+import DailyDetailRecordsSkeleton from '@/components/DailyDetailRecordsSkeleton';
 import DailyDetailFloatingActions from '@/app/(post)/_components/DailyDetailFloatingActions';
 import Back from '@/components/Back';
-import { getCachedRecordPreviewList } from '@/lib/api/records';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
 import { createMockRecordPreviews } from '@/lib/mocks/mock';
-import { RecordPreview } from '@/lib/types/recordResponse';
 import {
   dehydrate,
   HydrationBoundary,
   QueryClient,
 } from '@tanstack/react-query';
+import { recordPreviewListOptions } from '@/lib/api/records';
 
 interface MyMonthlyDetailPageProps {
   params: Promise<{ date: string }>;
@@ -20,15 +22,13 @@ export default async function MyDateDetailPage({
   const { date } = await params;
   const queryClient = new QueryClient();
 
-  let records: RecordPreview[];
-
-  if (process.env.NEXT_PUBLIC_MOCK !== 'true') {
-    records = await getCachedRecordPreviewList(date, 'personal');
-
-    // QueryClient에 직접 넣어서 HydrationBoundary로 클라이언트에 전달
-    queryClient.setQueryData(['records', 'preview', date, 'personal'], records);
+  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
+    queryClient.setQueryData(
+      ['records', 'preview', date, 'personal'],
+      createMockRecordPreviews(date),
+    );
   } else {
-    records = createMockRecordPreviews(date);
+    await queryClient.prefetchQuery(recordPreviewListOptions(date, 'personal'));
   }
 
   return (
@@ -48,15 +48,12 @@ export default async function MyDateDetailPage({
 
       <div className="py-4 sm:py-6 pb-14 sm:pb-16">
         <HydrationBoundary state={dehydrate(queryClient)}>
-          {process.env.NEXT_PUBLIC_MOCK === 'true' ? (
-            <DailyDetailRecords
-              memories={records}
-              date={date}
-              scope="personal"
-            />
-          ) : (
+          <ErrorHandlingWrapper
+            fallbackComponent={ErrorFallback}
+            suspenseFallback={<DailyDetailRecordsSkeleton />}
+          >
             <DailyDetailRecords date={date} scope="personal" />
-          )}
+          </ErrorHandlingWrapper>
         </HydrationBoundary>
         <DailyDetailFloatingActions date={date} />
       </div>

--- a/frontend/src/app/(post)/my/detail/[date]/page.tsx
+++ b/frontend/src/app/(post)/my/detail/[date]/page.tsx
@@ -1,16 +1,7 @@
-import DailyDetailRecords from '../../../../../components/DailyDetailRecords';
-import DailyDetailRecordsSkeleton from '@/components/DailyDetailRecordsSkeleton';
-import DailyDetailFloatingActions from '@/app/(post)/_components/DailyDetailFloatingActions';
 import Back from '@/components/Back';
-import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
-import ErrorFallback from '@/components/ErrorFallback';
-import { createMockRecordPreviews } from '@/lib/mocks/mock';
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
-import { recordPreviewListOptions } from '@/lib/api/records';
+import DailyDetailRecordsSkeleton from '@/components/DailyDetailRecordsSkeleton';
+import { Suspense } from 'react';
+import MyDailyDetailData from './_components/MyDailyDetailData';
 
 interface MyMonthlyDetailPageProps {
   params: Promise<{ date: string }>;
@@ -20,16 +11,6 @@ export default async function MyDateDetailPage({
   params,
 }: MyMonthlyDetailPageProps) {
   const { date } = await params;
-  const queryClient = new QueryClient();
-
-  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
-    queryClient.setQueryData(
-      ['records', 'preview', date, 'personal'],
-      createMockRecordPreviews(date),
-    );
-  } else {
-    await queryClient.prefetchQuery(recordPreviewListOptions(date, 'personal'));
-  }
 
   return (
     <div className="-mt-4 sm:-mt-6 h-full transition-colors duration-300 dark:bg-[#121212] bg-[#FDFDFD]">
@@ -45,18 +26,9 @@ export default async function MyDateDetailPage({
         </div>
         <div className="w-6 sm:w-8" />
       </header>
-
-      <div className="py-4 sm:py-6 pb-14 sm:pb-16">
-        <HydrationBoundary state={dehydrate(queryClient)}>
-          <ErrorHandlingWrapper
-            fallbackComponent={ErrorFallback}
-            suspenseFallback={<DailyDetailRecordsSkeleton />}
-          >
-            <DailyDetailRecords date={date} scope="personal" />
-          </ErrorHandlingWrapper>
-        </HydrationBoundary>
-        <DailyDetailFloatingActions date={date} />
-      </div>
+      <Suspense fallback={<div className="py-4 sm:py-6"><DailyDetailRecordsSkeleton /></div>}>
+        <MyDailyDetailData date={date} />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/src/app/(post)/my/month/[month]/_components/MyMonthlyDetailData.tsx
+++ b/frontend/src/app/(post)/my/month/[month]/_components/MyMonthlyDetailData.tsx
@@ -1,0 +1,41 @@
+import MonthlyDetailRecords from '@/app/(post)/_components/MonthlyDetailRecords';
+import MonthlyDetailRecordsSkeleton from '@/app/(post)/_components/MonthlyDetailRecordsSkeleton';
+import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
+import ErrorFallback from '@/components/ErrorFallback';
+import { getMonthRange } from '@/lib/date';
+import { createMockDailyRecord } from '@/lib/mocks/mock';
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+import { myDailyRecordListOptions } from '@/lib/api/my';
+
+interface MyMonthlyDetailDataProps {
+  month: string;
+}
+
+export default async function MyMonthlyDetailData({ month }: MyMonthlyDetailDataProps) {
+  const queryClient = new QueryClient();
+
+  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
+    queryClient.setQueryData(['my', 'records', 'daily', month], createMockDailyRecord());
+  } else {
+    await queryClient.prefetchQuery(myDailyRecordListOptions(month));
+  }
+
+  const { startDate, endDate } = getMonthRange(month);
+
+  return (
+    <div className="py-4 sm:py-6 pb-28 sm:pb-40">
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <ErrorHandlingWrapper
+          fallbackComponent={ErrorFallback}
+          suspenseFallback={<MonthlyDetailRecordsSkeleton />}
+        >
+          <MonthlyDetailRecords
+            month={month}
+            routePath="/my/detail"
+            viewMapRoutePath={`/map?start=${startDate}&end=${endDate}`}
+          />
+        </ErrorHandlingWrapper>
+      </HydrationBoundary>
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/my/month/[month]/loading.tsx
+++ b/frontend/src/app/(post)/my/month/[month]/loading.tsx
@@ -1,0 +1,18 @@
+import MonthlyDetailRecordsSkeleton from '@/app/(post)/_components/MonthlyDetailRecordsSkeleton';
+
+export default function Loading() {
+  return (
+    <div className="-mt-4 sm:-mt-6 h-full transition-colors duration-300 dark:bg-[#121212] bg-[#FDFDFD]">
+      <div className="-mx-4 sm:-mx-6 py-3 px-4 sm:py-6 sm:px-6 sticky top-0 z-50 transition-colors duration-300 dark:bg-[#121212] bg-white">
+        <div className="flex items-center justify-between">
+          <div className="h-4 w-6 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+          <div className="h-5 w-24 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+          <div className="h-4 w-6 bg-gray-200 dark:bg-gray-700 rounded animate-pulse" />
+        </div>
+      </div>
+      <div className="py-4 sm:py-6 pb-28 sm:pb-40">
+        <MonthlyDetailRecordsSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/my/month/[month]/page.tsx
+++ b/frontend/src/app/(post)/my/month/[month]/page.tsx
@@ -1,16 +1,7 @@
 import MonthlyDetailHeaderActions from '@/app/(post)/_components/MonthlyDetailHeaderActions';
-import MonthlyDetailRecords from '@/app/(post)/_components/MonthlyDetailRecords';
 import MonthlyDetailRecordsSkeleton from '@/app/(post)/_components/MonthlyDetailRecordsSkeleton';
-import ErrorHandlingWrapper from '@/components/ErrorHandlingWrapper';
-import ErrorFallback from '@/components/ErrorFallback';
-import { getMonthRange } from '@/lib/date';
-import { createMockDailyRecord } from '@/lib/mocks/mock';
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
-import { myDailyRecordListOptions } from '@/lib/api/my';
+import { Suspense } from 'react';
+import MyMonthlyDetailData from './_components/MyMonthlyDetailData';
 
 interface MyMonthlyDetailPageProps {
   params: Promise<{ month: string }>;
@@ -20,15 +11,7 @@ export default async function MyMonthlyDetailPage({
   params,
 }: MyMonthlyDetailPageProps) {
   const { month } = await params;
-  const queryClient = new QueryClient();
 
-  if (process.env.NEXT_PUBLIC_MOCK === 'true') {
-    queryClient.setQueryData(['my', 'records', 'daily', month], createMockDailyRecord());
-  } else {
-    await queryClient.prefetchQuery(myDailyRecordListOptions(month));
-  }
-
-  const { startDate, endDate } = getMonthRange(month);
   return (
     <div className="-mt-4 sm:-mt-6 h-full transition-colors duration-300 dark:bg-[#121212] bg-[#FDFDFD]">
       <div className="-mx-4 sm:-mx-6 py-3 px-4 sm:py-6 sm:px-6 sticky top-0 z-50 transition-colors duration-300 dark:bg-[#121212] bg-white">
@@ -36,21 +19,9 @@ export default async function MyMonthlyDetailPage({
           <MonthlyDetailHeaderActions month={month} title="Memory archive" />
         </header>
       </div>
-
-      <div className="py-4 sm:py-6 pb-28 sm:pb-40">
-        <HydrationBoundary state={dehydrate(queryClient)}>
-          <ErrorHandlingWrapper
-            fallbackComponent={ErrorFallback}
-            suspenseFallback={<MonthlyDetailRecordsSkeleton />}
-          >
-            <MonthlyDetailRecords
-              month={month}
-              routePath="/my/detail"
-              viewMapRoutePath={`/map?start=${startDate}&end=${endDate}`}
-            />
-          </ErrorHandlingWrapper>
-        </HydrationBoundary>
-      </div>
+      <Suspense fallback={<div className="py-4 sm:py-6"><MonthlyDetailRecordsSkeleton /></div>}>
+        <MyMonthlyDetailData month={month} />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/src/app/(post)/record/[recordId]/loading.tsx
+++ b/frontend/src/app/(post)/record/[recordId]/loading.tsx
@@ -1,0 +1,25 @@
+function RecordDetailSkeleton() {
+  return (
+    <div className="space-y-6 animate-pulse">
+      {/* 제목 영역 */}
+      <div className="space-y-2">
+        <div className="h-6 w-3/4 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-4 w-1/3 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+
+      {/* 콘텐츠 블록들 */}
+      <div className="space-y-4">
+        <div className="h-4 w-full bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-4 w-5/6 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-4 w-4/6 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="aspect-video w-full bg-gray-200 dark:bg-gray-700 rounded-xl" />
+        <div className="h-4 w-full bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-4 w-3/4 bg-gray-200 dark:bg-gray-700 rounded" />
+      </div>
+    </div>
+  );
+}
+
+export default function Loading() {
+  return <RecordDetailSkeleton />;
+}

--- a/frontend/src/app/(post)/record/[recordId]/page.tsx
+++ b/frontend/src/app/(post)/record/[recordId]/page.tsx
@@ -1,15 +1,7 @@
 import type { Metadata } from 'next';
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
-import { notFound } from 'next/navigation';
 import { getCachedRecordDetail } from '@/lib/api/records';
 import RecordDetailContent from '../_components/RecordDetailContent';
-import type { ApiError } from '@/lib/utils/errorHandler';
 import {
-  RecordDetailResponse,
   ImageValue,
   TextValue,
 } from '@/lib/types/record';
@@ -90,25 +82,5 @@ export async function generateMetadata({
 export default async function RecordPage({ params }: RecordPageProps) {
   const { recordId } = await params;
 
-  const queryClient = new QueryClient();
-  let record: RecordDetailResponse;
-
-  try {
-    record = await getCachedRecordDetail(recordId);
-
-    // QueryClient에 직접 넣어서 HydrationBoundary로 클라이언트에 전달
-    queryClient.setQueryData(['record', recordId], record);
-  } catch (error) {
-    // 404 에러는 notFound 페이지로
-    const apiError = error as ApiError;
-    if (apiError.code === 'NOT_FOUND' || apiError.message?.includes('404')) {
-      notFound();
-    }
-  }
-
-  return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      <RecordDetailContent recordId={recordId} />
-    </HydrationBoundary>
-  );
+  return <RecordDetailContent recordId={recordId} />;
 }

--- a/frontend/src/app/(post)/shared/_components/SharedRecords.tsx
+++ b/frontend/src/app/(post)/shared/_components/SharedRecords.tsx
@@ -12,7 +12,7 @@ import {
   DrawerTitle,
 } from '@/components/ui/drawer';
 import { Users, X } from 'lucide-react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useSuspenseQuery, useQueryClient } from '@tanstack/react-query';
 import { groupListOptions } from '@/lib/api/group';
 import {
   GroupCoverUpdateResponse,
@@ -23,7 +23,6 @@ import { useApiPatch } from '@/hooks/useApi';
 
 interface SharedRecordProps {
   searchParams: string;
-  initialGroups?: GroupSummary[];
 }
 
 const sortGroups = (
@@ -45,15 +44,11 @@ const sortGroups = (
 
 export default function SharedRecords({
   searchParams,
-  initialGroups = [],
 }: SharedRecordProps) {
   const queryClient = useQueryClient();
   const sortBy = (searchParams as GroupSortOption) || 'latest';
 
-  const { data: groups = initialGroups } = useQuery({
-    ...groupListOptions(),
-    initialData: initialGroups,
-  });
+  const { data: groups } = useSuspenseQuery(groupListOptions());
 
   const sortedGroups = useMemo(() => {
     if (sortBy === 'latest') return groups;

--- a/frontend/src/app/(post)/shared/_components/SharedRecords.tsx
+++ b/frontend/src/app/(post)/shared/_components/SharedRecords.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import { RecordCard } from '@/components/ui/RecordCard';
 import GalleryDrawer from '@/app/(post)/_components/GalleryDrawer';
 import {
@@ -20,6 +20,52 @@ import {
 } from '@/lib/types/recordResponse';
 import { GroupSortOption } from './SharedHeaderActions';
 import { useApiPatch } from '@/hooks/useApi';
+
+// 개별 그룹 카드 컴포넌트 - 콜백 최적화
+const GroupCard = memo(function GroupCard({
+  group,
+  onNavigate,
+  onOpenGallery,
+}: {
+  group: GroupSummary;
+  onNavigate: (groupId: string) => void;
+  onOpenGallery: (groupId: string) => void;
+}) {
+  const isViewer = group.permission === 'VIEWER';
+
+  const handleClick = useCallback(() => {
+    onNavigate(group.groupId);
+  }, [onNavigate, group.groupId]);
+
+  const handleChangeCover = useCallback(() => {
+    onOpenGallery(group.groupId);
+  }, [onOpenGallery, group.groupId]);
+
+  const count = useMemo(
+    () => `${group.memberCount}명 • ${group.recordCount}기록`,
+    [group.memberCount, group.recordCount],
+  );
+
+  const createdAt = useMemo(
+    () => group.createdAt.split('T')[0],
+    [group.createdAt],
+  );
+
+  return (
+    <RecordCard
+      id={group.groupId}
+      name={group.name}
+      count={count}
+      latestTitle={group.latestPost?.title || '최신 기록이 없어요'}
+      latestLocation={group.latestPost?.placeName}
+      hasNotification={false}
+      cover={group.cover}
+      onClick={handleClick}
+      onChangeCover={isViewer ? undefined : handleChangeCover}
+      createdAt={createdAt}
+    />
+  );
+});
 
 interface SharedRecordProps {
   searchParams: string;
@@ -42,7 +88,7 @@ const sortGroups = (
   }
 };
 
-export default function SharedRecords({
+const SharedRecords = memo(function SharedRecords({
   searchParams,
 }: SharedRecordProps) {
   const queryClient = useQueryClient();
@@ -100,29 +146,39 @@ export default function SharedRecords({
     },
   );
 
-  const openGallery = (groupId: string) => {
+  const handleNavigate = useCallback(
+    (groupId: string) => {
+      router.push(`/group/${groupId}`);
+    },
+    [router],
+  );
+
+  const openGallery = useCallback((groupId: string) => {
     setActiveGroupId(groupId);
     setIsDrawerOpen(true);
-  };
+  }, []);
 
-  const handleCoverSelect = (assetId: string, recordId: string) => {
-    if (!activeGroupId) return;
+  const handleCoverSelect = useCallback(
+    (assetId: string, recordId: string) => {
+      if (!activeGroupId) return;
 
-    // 낙관적 업데이트: 캐시 직접 수정
-    queryClient.setQueryData<GroupSummary[]>(['shared'], (oldData) => {
-      if (!oldData) return oldData;
-      return oldData.map((group) =>
-        group.groupId === activeGroupId
-          ? {
-              ...group,
-              cover: group.cover ? { ...group.cover, assetId } : null,
-            }
-          : group,
-      );
-    });
+      // 낙관적 업데이트: 캐시 직접 수정
+      queryClient.setQueryData<GroupSummary[]>(['shared'], (oldData) => {
+        if (!oldData) return oldData;
+        return oldData.map((group) =>
+          group.groupId === activeGroupId
+            ? {
+                ...group,
+                cover: group.cover ? { ...group.cover, assetId } : null,
+              }
+            : group,
+        );
+      });
 
-    updateGroupCover({ assetId: assetId, sourcePostId: recordId });
-  };
+      updateGroupCover({ assetId: assetId, sourcePostId: recordId });
+    },
+    [activeGroupId, queryClient, updateGroupCover],
+  );
 
   if (sortedGroups.length === 0) {
     return (
@@ -147,26 +203,14 @@ export default function SharedRecords({
   return (
     <>
       <div className="grid grid-cols-2 gap-4 md:grid-cols-3 pb-16 sm:pb-32">
-        {sortedGroups.map((g) => {
-          const isViewer = g.permission === 'VIEWER';
-          return (
-            <RecordCard
-              key={g.groupId}
-              id={g.groupId}
-              name={g.name}
-              count={`${g.memberCount}명 • ${g.recordCount}기록`}
-              latestTitle={g.latestPost?.title || '최신 기록이 없어요'}
-              latestLocation={g.latestPost?.placeName}
-              hasNotification={false}
-              cover={g.cover}
-              onClick={() => router.push(`/group/${g.groupId}`)}
-              onChangeCover={
-                isViewer ? undefined : () => openGallery(g.groupId)
-              }
-              createdAt={g.createdAt.split('T')[0]}
-            />
-          );
-        })}
+        {sortedGroups.map((g) => (
+          <GroupCard
+            key={g.groupId}
+            group={g}
+            onNavigate={handleNavigate}
+            onOpenGallery={openGallery}
+          />
+        ))}
       </div>
 
       {/* 커버 변경 Drawer */}
@@ -204,4 +248,6 @@ export default function SharedRecords({
       </Drawer>
     </>
   );
-}
+});
+
+export default SharedRecords;

--- a/frontend/src/app/(post)/shared/_components/SharedRecordsSkeleton.tsx
+++ b/frontend/src/app/(post)/shared/_components/SharedRecordsSkeleton.tsx
@@ -1,0 +1,24 @@
+function RecordCardSkeleton() {
+  return (
+    <div className="h-42 sm:h-50 rounded-2xl bg-gray-200 dark:bg-gray-800 animate-pulse relative overflow-hidden">
+      <div className="absolute bottom-0 left-0 right-0 p-3 sm:p-4 space-y-1.5">
+        <div className="flex items-center justify-between gap-2">
+          <div className="h-3 w-2/3 bg-gray-300 dark:bg-gray-700 rounded" />
+          <div className="h-4 w-7 bg-gray-300 dark:bg-gray-700 rounded-lg" />
+        </div>
+        <div className="h-2.5 w-4/5 bg-gray-300 dark:bg-gray-700 rounded" />
+        <div className="h-2 w-1/3 bg-gray-300 dark:bg-gray-700 rounded" />
+      </div>
+    </div>
+  );
+}
+
+export default function SharedRecordsSkeleton() {
+  return (
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <RecordCardSkeleton key={i} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/(post)/shared/loading.tsx
+++ b/frontend/src/app/(post)/shared/loading.tsx
@@ -1,0 +1,5 @@
+import SharedRecordsSkeleton from './_components/SharedRecordsSkeleton';
+
+export default function Loading() {
+  return <SharedRecordsSkeleton />;
+}

--- a/frontend/src/components/BlockContent.tsx
+++ b/frontend/src/components/BlockContent.tsx
@@ -8,11 +8,11 @@ import ImageCarousel from './ImageCarousel';
 import ImageTileGrid from './ImageTileGrid';
 import { EMOTION_MAP } from '@/lib/constants/constants';
 import { useMediaResolveMulti } from '@/hooks/useMediaResolve';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, memo } from 'react';
 
 type ImageLayout = 'carousel' | 'tile' | 'responsive';
 
-export default function BlockContent({
+const BlockContent = memo(function BlockContent({
   block,
   imageLayout = 'carousel',
 }: {
@@ -190,13 +190,15 @@ export default function BlockContent({
     default:
       return null;
   }
-}
+});
+
+export default BlockContent;
 
 /**
  * 이미지 블록 처리하는 내부 컴포넌트
  * imageId를 통한 solve를 위해 분리
  */
-function ImageBlock({
+const ImageBlock = memo(function ImageBlock({
   value,
   layout = 'carousel',
 }: {
@@ -253,4 +255,4 @@ function ImageBlock({
       )}
     </div>
   );
-}
+});

--- a/frontend/src/components/BottomNavigation.tsx
+++ b/frontend/src/components/BottomNavigation.tsx
@@ -32,9 +32,13 @@ export default function BottomNavigation() {
   const effectiveGroupId =
     pathGroupId || (scope === 'group' ? searchParamsGroupId : null);
 
+  const isSharedPage = pathname === '/shared';
+  const isGroupDetail = /\/group\/[^/]+\/(post|draft)\//.test(pathname);
+
+  // /shared 페이지에서는 미리 데이터를 fetch하여 drawer 열림 지연 방지
   const { data: groups = [] } = useQuery({
     ...groupListOptions(),
-    enabled: isGroupSelectOpen,
+    enabled: isGroupSelectOpen || isSharedPage,
   });
 
   // 현재 그룹의 role 조회
@@ -42,9 +46,6 @@ export default function BottomNavigation() {
     ...groupMyRoleOptions(effectiveGroupId!),
     enabled: !!effectiveGroupId,
   });
-
-  const isSharedPage = pathname === '/shared';
-  const isGroupDetail = /\/group\/[^/]+\/(post|draft)\//.test(pathname);
 
   // VIEWER 권한 확인
   const isViewer = roleData?.role === 'VIEWER';

--- a/frontend/src/components/DailyDetailRecords.tsx
+++ b/frontend/src/components/DailyDetailRecords.tsx
@@ -2,27 +2,24 @@
 
 import { recordPreviewListOptions } from '@/lib/api/records';
 import DailyDetailRecordItem from './DailyDetailRecordItem';
-import { RecordPreview } from '@/lib/types/recordResponse';
-import { useQuery } from '@tanstack/react-query';
+
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { BookOpen } from 'lucide-react';
 
 interface DailyDetailRecordsProps {
-  memories?: RecordPreview[];
   date: string;
   scope: 'personal' | 'groups';
   groupId?: string;
 }
 
 export default function DailyDetailRecords({
-  memories,
   date,
   scope,
   groupId,
 }: DailyDetailRecordsProps) {
-  const { data: records = [] } = useQuery({
-    ...recordPreviewListOptions(date, scope, groupId),
-    ...(memories && { initialData: memories }),
-  });
+  const { data: records } = useSuspenseQuery(
+    recordPreviewListOptions(date, scope, groupId),
+  );
 
   return (
     <div className="relative border-l-[1.5px] space-y-6 transition-colors dark:border-white/10 border-gray-100">

--- a/frontend/src/components/DailyDetailRecordsSkeleton.tsx
+++ b/frontend/src/components/DailyDetailRecordsSkeleton.tsx
@@ -1,0 +1,43 @@
+function DailyDetailRecordItemSkeleton() {
+  return (
+    <div className="space-y-2">
+      {/* 시간 & 액션 행 */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <div className="w-3.5 h-3.5 rounded-full bg-gray-200 dark:bg-gray-800 animate-pulse" />
+          <div className="h-3 w-20 bg-gray-200 dark:bg-gray-800 rounded animate-pulse" />
+        </div>
+        <div className="w-6 h-6 rounded-full bg-gray-200 dark:bg-gray-800 animate-pulse" />
+      </div>
+
+      {/* 메인 카드 */}
+      <div className="rounded-lg p-5 border dark:bg-[#1E1E1E] dark:border-white/5 bg-white border-gray-100/60">
+        {/* 제목 & 아바타 행 */}
+        <div className="flex justify-between items-start gap-2 mb-4">
+          <div className="h-4 w-3/4 bg-gray-200 dark:bg-gray-800 rounded animate-pulse" />
+          <div className="w-8 h-8 rounded-full bg-gray-200 dark:bg-gray-800 animate-pulse shrink-0" />
+        </div>
+
+        {/* 블록 콘텐츠 */}
+        <div className="space-y-3">
+          <div className="h-3 w-full bg-gray-200 dark:bg-gray-800 rounded animate-pulse" />
+          <div className="h-3 w-5/6 bg-gray-200 dark:bg-gray-800 rounded animate-pulse" />
+          <div className="aspect-video w-full bg-gray-200 dark:bg-gray-800 rounded-lg animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function DailyDetailRecordsSkeleton() {
+  return (
+    <div className="relative border-l-[1.5px] space-y-6 dark:border-white/10 border-gray-100">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="relative pl-6">
+          <div className="absolute -left-[7.5px] top-1 w-3.5 h-3.5 rounded-full z-10 border-2 shadow-sm dark:bg-gray-800 dark:border-[#121212] bg-gray-200 border-white animate-pulse" />
+          <DailyDetailRecordItemSkeleton />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/RecordCard.tsx
+++ b/frontend/src/components/ui/RecordCard.tsx
@@ -5,6 +5,7 @@ import { PostCard } from './PostCard';
 import { useRouter } from 'next/navigation';
 import { GroupCover } from '@/lib/types/group';
 import { randomBaseImage } from '@/lib/image';
+import { memo } from 'react';
 
 /**
  * MonthRecordCard - 월별 기록 카드
@@ -24,7 +25,7 @@ export interface RecordCardProps {
   onChangeCover?: (id: string) => void;
 }
 
-export function RecordCard({
+export const RecordCard = memo(function RecordCard({
   id,
   name,
   count,
@@ -91,7 +92,7 @@ export function RecordCard({
       </PostCard.Overlay>
     </PostCard>
   );
-}
+});
 
 /**
  * DateRecordCard - 날짜 기록 카드
@@ -108,7 +109,7 @@ export interface DateRecordCardProps {
   icon?: React.ReactNode;
 }
 
-export function DateRecordCard({
+export const DateRecordCard = memo(function DateRecordCard({
   date,
   dayName,
   title,
@@ -164,7 +165,7 @@ export function DateRecordCard({
       </PostCard.Overlay>
     </PostCard>
   );
-}
+});
 
 /**
  * SimpleRecordCard - 간단한 기록 카드
@@ -179,7 +180,7 @@ export interface SimpleRecordCardProps {
   height?: string;
 }
 
-export function SimpleRecordCard({
+export const SimpleRecordCard = memo(function SimpleRecordCard({
   title,
   description,
   coverUrl,
@@ -205,4 +206,4 @@ export function SimpleRecordCard({
       </PostCard.Overlay>
     </PostCard>
   );
-}
+});

--- a/frontend/src/lib/date.ts
+++ b/frontend/src/lib/date.ts
@@ -71,6 +71,14 @@ export function formatRelativeTime(date: Date): string {
   return `${years}년 전`;
 }
 
+// Intl.DateTimeFormat 인스턴스를 재사용하여 성능 개선
+const isoFormatter = new Intl.DateTimeFormat('ko-KR', {
+  timeZone: 'Asia/Seoul',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
 /**
  * 날짜를 YYYY-MM-DD 형식으로 포맷팅합니다.
  * @param date - 포맷팅할 날짜 (기본값: 현재 날짜)
@@ -80,14 +88,7 @@ export function formatRelativeTime(date: Date): string {
  */
 export function formatDateISO(date: Date = new Date()): string {
   // TODO: 한국 시간으로 고정 상태. 해외 지원 시 수정
-  const formatter = new Intl.DateTimeFormat('ko-KR', {
-    timeZone: 'Asia/Seoul',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
-
-  const parts = formatter.formatToParts(date);
+  const parts = isoFormatter.formatToParts(date);
   const year = parts.find((p) => p.type === 'year')?.value;
   const month = parts.find((p) => p.type === 'month')?.value;
   const day = parts.find((p) => p.type === 'day')?.value;
@@ -162,15 +163,20 @@ export const getStartOfWeek = (date: Date) => {
 
 export const getWeekDays = (baseDate: Date = new Date()) => {
   const days = [];
+  // 루프 밖으로 이동하여 성능 개선
+  const startOfWeek = getStartOfWeek(baseDate);
+  const today = formatDateISO();
+
   for (let i = 0; i < 7; i++) {
-    const startOfWeek = getStartOfWeek(baseDate);
     const day = new Date(startOfWeek);
     day.setDate(startOfWeek.getDate() + i);
+    const dayStr = formatDateISO(day);
+
     days.push({
       date: day,
-      dateStr: formatDateISO(day),
+      dateStr: dayStr,
       dayName: ['일', '월', '화', '수', '목', '금', '토'][i],
-      isToday: formatDateISO(day) === formatDateISO(),
+      isToday: dayStr === today,
     });
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       '@googlemaps/markerclusterer':
         specifier: ^2.6.2
         version: 2.6.2
+      '@lhci/cli':
+        specifier: ^0.15.1
+        version: 0.15.1
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -1095,6 +1098,21 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@formatjs/ecma402-abstract@2.3.6':
+    resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
+
+  '@formatjs/fast-memoize@2.2.7':
+    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
+
+  '@formatjs/icu-messageformat-parser@2.11.4':
+    resolution: {integrity: sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==}
+
+  '@formatjs/icu-skeleton-parser@1.8.16':
+    resolution: {integrity: sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==}
+
+  '@formatjs/intl-localematcher@0.6.2':
+    resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
+
   '@googlemaps/markerclusterer@2.6.2':
     resolution: {integrity: sha512-U6uVhq8iWhiIckA89sgRu8OK35mjd6/3CuoZKWakKEf0QmRRWpatlsPb3kqXkoWSmbcZkopRiI4dnW6DQSd7bQ==}
 
@@ -1526,6 +1544,13 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@lhci/cli@0.15.1':
+    resolution: {integrity: sha512-yhC0oXnXqGHYy1xl4D8YqaydMZ/khFAnXGY/o2m/J3PqPa/D0nj3V6TLoH02oVMFeEF2AQim7UbmdXMiXx2tOw==}
+    hasBin: true
+
+  '@lhci/utils@0.15.1':
+    resolution: {integrity: sha512-WclJnUQJeOMY271JSuaOjCv/aA0pgvuHZS29NFNdIeI14id8eiFsjith85EGKYhljgoQhJ2SiW4PsVfFiakNNw==}
 
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
@@ -2096,6 +2121,9 @@ packages:
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
+  '@paulirish/trace_engine@0.0.53':
+    resolution: {integrity: sha512-PUl/vlfo08Oj804VI5nDPeSk9vyslnBlVzDDwFt8SUVxY8+KdGMkra/vrXjEEHe8gb7+RqVTfOIlGw0nyrEelA==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2111,6 +2139,11 @@ packages:
     resolution: {integrity: sha512-Rh9Z4x5kEj1OdARd7U18AtVrnL6rmLSI0qYShaB4W7Wx5BKbgzndWF+QnuzMb7GLfVdlT5aYCXoPQVYuYtVu0g==}
     peerDependencies:
       '@opentelemetry/api': ^1.8
+
+  '@puppeteer/browsers@2.13.0':
+    resolution: {integrity: sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -2528,6 +2561,10 @@ packages:
     resolution: {integrity: sha512-YWIkL6/dnaiQyFiZXJ/nN+NXGv/15z45ia86bE/TMq01CubX/DUOilgsFz0pk2v/pg3tp/U2MskLO9Hz0cnqeg==}
     engines: {node: '>=18'}
 
+  '@sentry-internal/tracing@7.120.4':
+    resolution: {integrity: sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==}
+    engines: {node: '>=8'}
+
   '@sentry/babel-plugin-component-annotate@4.9.0':
     resolution: {integrity: sha512-TJ7sVoa2Bf36lpJjBAzpNDC5Hg+evjsQnqUPeDx9Nz/YFw0u9rK1cwvi95gVWpx7PJSDCkljIv3aw0m4RatHpQ==}
     engines: {node: '>= 14'}
@@ -2596,6 +2633,14 @@ packages:
     resolution: {integrity: sha512-1pubWDZE5y5HZEPMAZERP4fVl2NH3Ihp1A+vMoVkb3Qc66Diqj1WierAnStlZP7tCx0TBa0dK85GTW/ZFYyB9g==}
     engines: {node: '>=18'}
 
+  '@sentry/core@7.120.4':
+    resolution: {integrity: sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==}
+    engines: {node: '>=8'}
+
+  '@sentry/integrations@7.120.4':
+    resolution: {integrity: sha512-kkBTLk053XlhDCg7OkBQTIMF4puqFibeRO3E3YiVc4PGLnocXMaVpOSCkMqAc1k1kZ09UgGi8DxfQhnFEjUkpA==}
+    engines: {node: '>=8'}
+
   '@sentry/nextjs@10.38.0':
     resolution: {integrity: sha512-MW2f6mK54jFyS/lmJxT7GWr5d12E+3qvIhR5EdjdyzMX8udSOCGyFJaFIwUfMyEMuggPEvNQVFFpjIrvWXCSGA==}
     engines: {node: '>=18'}
@@ -2618,6 +2663,10 @@ packages:
     resolution: {integrity: sha512-wriyDtWDAoatn8EhOj0U4PJR1WufiijTsCGALqakOHbFiadtBJANLe6aSkXoXT4tegw59cz1wY4NlzHjYksaPw==}
     engines: {node: '>=18'}
 
+  '@sentry/node@7.120.4':
+    resolution: {integrity: sha512-qq3wZAXXj2SRWhqErnGCSJKUhPSlZ+RGnCZjhfjHpP49KNpcd9YdPTIUsFMgeyjdh6Ew6aVCv23g1hTP0CHpYw==}
+    engines: {node: '>=8'}
+
   '@sentry/opentelemetry@10.38.0':
     resolution: {integrity: sha512-YPVhWfYmC7nD3EJqEHGtjp4fp5LwtAbE5rt9egQ4hqJlYFvr8YEz9sdoqSZxO0cZzgs2v97HFl/nmWAXe52G2Q==}
     engines: {node: '>=18'}
@@ -2633,6 +2682,14 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/types@7.120.4':
+    resolution: {integrity: sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q==}
+    engines: {node: '>=8'}
+
+  '@sentry/utils@7.120.4':
+    resolution: {integrity: sha512-zCKpyDIWKHwtervNK2ZlaK8mMV7gVUijAgFeJStH+CU/imcdquizV3pFLlSQYRswG+Lbyd6CT/LGRh3IbtkCFw==}
+    engines: {node: '>=8'}
 
   '@sentry/vercel-edge@10.38.0':
     resolution: {integrity: sha512-lElDFktj/PyRC/LDHejPFhQmHVMCB9Celj+IHi36aw96a/LekqF6/7vmp26hDtH58QtuiPO3h5voqEAMUOkSlw==}
@@ -3210,6 +3267,9 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
@@ -3456,6 +3516,9 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@8.49.0':
     resolution: {integrity: sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==}
@@ -3820,6 +3883,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -3856,6 +3923,10 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
+  ansi-escapes@3.2.0:
+    resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
+    engines: {node: '>=4'}
+
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -3864,6 +3935,14 @@ packages:
     resolution: {integrity: sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw==}
     engines: {node: '>=18'}
 
+  ansi-regex@3.0.1:
+    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
+    engines: {node: '>=4'}
+
+  ansi-regex@4.1.1:
+    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
+    engines: {node: '>=6'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -3871,6 +3950,10 @@ packages:
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
+
+  ansi-styles@3.2.1:
+    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
+    engines: {node: '>=4'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -3926,6 +4009,9 @@ packages:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
 
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
     engines: {node: '>= 0.4'}
@@ -3966,6 +4052,10 @@ packages:
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
+
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -4060,6 +4150,36 @@ packages:
       bare-abort-controller:
         optional: true
 
+  bare-fs@4.5.5:
+    resolution: {integrity: sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.7.0:
+    resolution: {integrity: sha512-64Rcwj8qlnTZU8Ps6JJEdSmxBEUGgI7g8l+lMtsJLl4IsfTcHMTfJ188u2iGV6P6YPRZrtv72B2kjn+hp+Yv3g==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.8.0:
+    resolution: {integrity: sha512-reUN0M2sHRqCdG4lUK3Fw8w98eeUIZHL5c3H7Mbhk2yVBL+oofgaIp0ieLfD5QXwPCypBpmEEKU2WZKzbAk8GA==}
+    peerDependencies:
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.3.2:
+    resolution: {integrity: sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -4075,6 +4195,10 @@ packages:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
 
+  basic-ftp@5.2.0:
+    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+    engines: {node: '>=10.0.0'}
+
   bin-version-check@5.1.0:
     resolution: {integrity: sha512-bYsvMqJ8yNGILLz1KP9zKLzQ6YpljV3ln1gqhuLkUtyfGi3qXKGuK2p+U4NAvjVFzDFiBBtOpCOSFNuYYEGZ5g==}
     engines: {node: '>=12'}
@@ -4089,6 +4213,10 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  body-parser@1.20.4:
+    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -4192,6 +4320,10 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@2.4.2:
+    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
+    engines: {node: '>=4'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -4199,6 +4331,9 @@ packages:
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
+
+  chardet@0.7.0:
+    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -4227,9 +4362,22 @@ packages:
       '@chromatic-com/playwright':
         optional: true
 
+  chrome-launcher@0.13.4:
+    resolution: {integrity: sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A==}
+
+  chrome-launcher@1.2.1:
+    resolution: {integrity: sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
+
+  chromium-bidi@14.0.0:
+    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
+    peerDependencies:
+      devtools-protocol: '*'
 
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
@@ -4257,6 +4405,10 @@ packages:
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
+  cli-cursor@2.1.0:
+    resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
+    engines: {node: '>=4'}
+
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
@@ -4277,12 +4429,18 @@ packages:
     resolution: {integrity: sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==}
     engines: {node: '>=20'}
 
+  cli-width@2.2.1:
+    resolution: {integrity: sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -4303,6 +4461,9 @@ packages:
   collect-v8-coverage@1.0.3:
     resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
 
+  color-convert@1.9.3:
+    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -4310,6 +4471,9 @@ packages:
   color-convert@3.1.3:
     resolution: {integrity: sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==}
     engines: {node: '>=14.6'}
+
+  color-name@1.1.3:
+    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -4362,12 +4526,24 @@ packages:
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
 
+  compressible@2.0.18:
+    resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
+    engines: {node: '>= 0.6'}
+
+  compression@1.8.1:
+    resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
+    engines: {node: '>= 0.8.0'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
+
+  configstore@5.0.1:
+    resolution: {integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==}
+    engines: {node: '>=8'}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -4446,6 +4622,13 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  crypto-random-string@2.0.0:
+    resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
+    engines: {node: '>=8'}
+
+  csp_evaluator@1.1.5:
+    resolution: {integrity: sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -4499,6 +4682,10 @@ packages:
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -4545,8 +4732,15 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -4594,6 +4788,10 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
 
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
@@ -4601,6 +4799,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -4614,6 +4816,10 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -4624,6 +4830,12 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  devtools-protocol@0.0.1467305:
+    resolution: {integrity: sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==}
+
+  devtools-protocol@0.0.1566079:
+    resolution: {integrity: sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -4649,6 +4861,10 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
 
   dotenv-expand@12.0.1:
     resolution: {integrity: sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==}
@@ -4706,6 +4922,9 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   engine.io-client@6.6.4:
     resolution: {integrity: sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==}
 
@@ -4720,6 +4939,10 @@ packages:
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
     engines: {node: '>=10.13.0'}
+
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -4778,6 +5001,10 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@1.0.5:
+    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
+    engines: {node: '>=0.8.0'}
+
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
@@ -4785,6 +5012,11 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   eslint-config-next@16.0.10:
     resolution: {integrity: sha512-BxouZUm0I45K4yjOOIzj24nTi0H2cGo0y7xUmk+Po/PYtJXFBYVDS1BguE7t28efXjKdcN0tmiLivxQy//SsZg==}
@@ -4980,6 +5212,10 @@ packages:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -4991,6 +5227,15 @@ packages:
   ext-name@5.0.0:
     resolution: {integrity: sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==}
     engines: {node: '>=4'}
+
+  external-editor@3.1.0:
+    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
+    engines: {node: '>=4'}
+
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -5031,6 +5276,9 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -5045,6 +5293,10 @@ packages:
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+
+  figures@2.0.0:
+    resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
+    engines: {node: '>=4'}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -5076,6 +5328,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -5151,6 +5407,10 @@ packages:
       react-dom:
         optional: true
 
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -5217,6 +5477,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
@@ -5227,6 +5491,10 @@ packages:
 
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -5299,6 +5567,10 @@ packages:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
 
+  has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -5341,6 +5613,14 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-link-header@1.1.3:
+    resolution: {integrity: sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==}
+    engines: {node: '>=6.0.0'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   http2-wrapper@2.2.1:
     resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
     engines: {node: '>=10.19.0'}
@@ -5348,6 +5628,10 @@ packages:
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -5357,6 +5641,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.1:
     resolution: {integrity: sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==}
@@ -5381,6 +5669,12 @@ packages:
     resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
     engines: {node: '>=16.x'}
     hasBin: true
+
+  image-ssim@0.2.0:
+    resolution: {integrity: sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
 
   immer@10.2.0:
     resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
@@ -5415,6 +5709,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inquirer@6.5.2:
+    resolution: {integrity: sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==}
+    engines: {node: '>=6.0.0'}
+
   inspect-with-kind@1.0.5:
     resolution: {integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==}
 
@@ -5425,6 +5723,13 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  intl-messageformat@10.7.18:
+    resolution: {integrity: sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -5472,6 +5777,11 @@ packages:
     resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -5484,6 +5794,10 @@ packages:
   is-finalizationregistry@1.1.1:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
+
+  is-fullwidth-code-point@2.0.0:
+    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
+    engines: {node: '>=4'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -5533,6 +5847,10 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
+
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
@@ -5571,6 +5889,9 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
+
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
@@ -5587,6 +5908,10 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
     engines: {node: '>=16'}
@@ -5596,6 +5921,9 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-fetch@3.0.0:
+    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -5796,9 +6124,16 @@ packages:
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
+
+  js-library-detector@6.7.0:
+    resolution: {integrity: sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==}
+    engines: {node: '>=12'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -5894,6 +6229,9 @@ packages:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
 
+  legacy-javascript@0.0.1:
+    resolution: {integrity: sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg==}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -5904,6 +6242,23 @@ packages:
 
   libphonenumber-js@1.12.33:
     resolution: {integrity: sha512-r9kw4OA6oDO4dPXkOrXTkArQAafIKAU71hChInV4FxZ69dxCfbwQGDPzqR5/vea94wU705/3AZroEbSoeVWrQw==}
+
+  lie@3.1.1:
+    resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
+
+  lighthouse-logger@1.2.0:
+    resolution: {integrity: sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==}
+
+  lighthouse-logger@2.0.2:
+    resolution: {integrity: sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==}
+
+  lighthouse-stack-packs@1.12.2:
+    resolution: {integrity: sha512-Ug8feS/A+92TMTCK6yHYLwaFMuelK/hAKRMdldYkMNwv+d9PtWxjXEg6rwKtsUXTADajhdrhXyuNCJ5/sfmPFw==}
+
+  lighthouse@12.6.1:
+    resolution: {integrity: sha512-85WDkjcXAVdlFem9Y6SSxqoKiz/89UsDZhLpeLJIsJ4LlHxw047XTZhlFJmjYCB7K5S1erSBAf5cYLcfyNbH3A==}
+    engines: {node: '>=18.20'}
+    hasBin: true
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -5995,6 +6350,9 @@ packages:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
     engines: {node: '>=6.11.5'}
 
+  localforage@1.10.0:
+    resolution: {integrity: sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -6002,6 +6360,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.17.23:
+    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -6045,6 +6406,9 @@ packages:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
 
+  lookup-closest-locale@6.2.0:
+    resolution: {integrity: sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -6065,6 +6429,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
 
   lucide-react@0.561.0:
     resolution: {integrity: sha512-Y59gMY38tl4/i0qewcqohPdEbieBy7SovpBL9IFebhc2mDd8x4PZSOsiFRkpPcOq6bj1r/mjH/Rk73gSlIJP2A==}
@@ -6096,6 +6464,10 @@ packages:
   magicast@0.5.1:
     resolution: {integrity: sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==}
 
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -6105,6 +6477,9 @@ packages:
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
+
+  marky@1.3.0:
+    resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -6122,6 +6497,9 @@ packages:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
 
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
@@ -6132,6 +6510,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  metaviewport-parser@0.3.0:
+    resolution: {integrity: sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -6157,10 +6538,19 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
     engines: {node: '>=4.0.0'}
     hasBin: true
+
+  mimic-fn@1.2.0:
+    resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
+    engines: {node: '>=4'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -6199,6 +6589,9 @@ packages:
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
@@ -6248,6 +6641,9 @@ packages:
     resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
     engines: {node: '>= 10.16.0'}
 
+  mute-stream@0.0.7:
+    resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
+
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -6273,6 +6669,10 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -6285,6 +6685,10 @@ packages:
     peerDependencies:
       '@nestjs/common': ^5.0.0 || ^6.6.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
       winston: ^3.0.0
+
+  netmask@2.0.2:
+    resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
+    engines: {node: '>= 0.4.0'}
 
   next-auth@5.0.0-beta.30:
     resolution: {integrity: sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==}
@@ -6414,11 +6818,19 @@ packages:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   one-time@1.0.0:
     resolution: {integrity: sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==}
+
+  onetime@2.0.1:
+    resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
+    engines: {node: '>=4'}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -6432,6 +6844,14 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
+  open@7.4.2:
+    resolution: {integrity: sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==}
+    engines: {node: '>=8'}
+
+  open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -6439,6 +6859,10 @@ packages:
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
+
+  os-tmpdir@1.0.2:
+    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
+    engines: {node: '>=0.10.0'}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -6471,12 +6895,23 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-cache-control@1.0.1:
+    resolution: {integrity: sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==}
 
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -6534,6 +6969,9 @@ packages:
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
+
+  path-to-regexp@0.1.12:
+    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -6726,12 +7164,23 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  puppeteer-core@24.37.5:
+    resolution: {integrity: sha512-ybL7iE78YPN4T6J+sPLO7r0lSByp/0NN6PvfBEql219cOnttoTFzCWKiBOjstXSqi/OKpwae623DWAsL7cn2MQ==}
+    engines: {node: '>=18'}
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
@@ -6753,6 +7202,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
 
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
@@ -6897,6 +7350,9 @@ packages:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
@@ -6935,6 +7391,10 @@ packages:
     resolution: {integrity: sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==}
     engines: {node: '>=14.16'}
 
+  restore-cursor@2.0.0:
+    resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
+    engines: {node: '>=4'}
+
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
@@ -6953,6 +7413,20 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rimraf@2.7.1:
+    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  robots-parser@3.0.1:
+    resolution: {integrity: sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==}
+    engines: {node: '>=10.0.0'}
+
   rollup@4.55.1:
     resolution: {integrity: sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -6966,8 +7440,16 @@ packages:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
 
+  run-async@2.4.1:
+    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
+    engines: {node: '>=0.12.0'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@6.6.7:
+    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
+    engines: {npm: '>=2.0.0'}
 
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
@@ -7020,6 +7502,10 @@ packages:
     resolution: {integrity: sha512-LJWA9kSvMolR51oDE6PN3kALBNaUdkxzAGcexw8gjMA8xr5zUqK0JiR3CgARSqanYF3Z1YHvsErb1KDgh+v7Rg==}
     engines: {node: '>=12'}
 
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -7029,6 +7515,15 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -7036,9 +7531,16 @@ packages:
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
+
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -7113,6 +7615,10 @@ packages:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   socket.io-adapter@2.5.6:
     resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
 
@@ -7127,6 +7633,14 @@ packages:
   socket.io@4.8.3:
     resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
     engines: {node: '>=10.2.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -7163,6 +7677,10 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  speedline-core@1.4.3:
+    resolution: {integrity: sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==}
+    engines: {node: '>=8.0'}
 
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
@@ -7230,6 +7748,10 @@ packages:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
 
+  string-width@2.1.1:
+    resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
+    engines: {node: '>=4'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -7271,6 +7793,14 @@ packages:
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@4.0.0:
+    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
+    engines: {node: '>=4'}
+
+  strip-ansi@5.2.0:
+    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
+    engines: {node: '>=6'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -7338,6 +7868,10 @@ packages:
     resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
     engines: {node: '>=14.18.0'}
 
+  supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -7384,8 +7918,14 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
+  tar-fs@3.1.1:
+    resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
+
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   terser-webpack-plugin@5.3.16:
     resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
@@ -7418,6 +7958,12 @@ packages:
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
+  third-party-web@0.26.7:
+    resolution: {integrity: sha512-buUzX4sXC4efFX6xg2bw6/eZsCUh8qQwSavC4D9HpONMFlRbcHhD8Je5qwYdCpViR6q0qla2wPP+t91a2vgolg==}
+
+  third-party-web@0.29.0:
+    resolution: {integrity: sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==}
+
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
@@ -7447,12 +7993,26 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
   tldts-core@7.0.19:
     resolution: {integrity: sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==}
+
+  tldts-icann@6.1.86:
+    resolution: {integrity: sha512-NFxmRT2lAEMcCOBgeZ0NuM0zsK/xgmNajnY6n4S1mwAKocft2s2ise1O3nQxrH3c+uY6hgHUV9GGNVp7tUE4Sg==}
 
   tldts@7.0.19:
     resolution: {integrity: sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==}
     hasBin: true
+
+  tmp@0.0.33:
+    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
+    engines: {node: '>=0.6.0'}
+
+  tmp@0.1.0:
+    resolution: {integrity: sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==}
+    engines: {node: '>=6'}
 
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
@@ -7483,6 +8043,10 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   triple-beam@1.4.1:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
@@ -7567,6 +8131,9 @@ packages:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -7620,6 +8187,12 @@ packages:
   typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
+
+  typed-query-selector@2.12.0:
+    resolution: {integrity: sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==}
+
+  typedarray-to-buffer@3.1.5:
+    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -7717,6 +8290,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unique-string@2.0.0:
+    resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
+    engines: {node: '>=8'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -7785,6 +8362,10 @@ packages:
 
   uuid@13.0.0:
     resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
 
   uuid@9.0.1:
@@ -7914,6 +8495,9 @@ packages:
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
 
+  webdriver-bidi-protocol@0.4.1:
+    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -7941,6 +8525,9 @@ packages:
       webpack-cli:
         optional: true
 
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -7955,6 +8542,9 @@ packages:
   which-collection@1.0.2:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
+
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
   which-typed-array@1.1.19:
     resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
@@ -8010,6 +8600,9 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  write-file-atomic@3.0.3:
+    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
+
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -8017,6 +8610,18 @@ packages:
   write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -8046,6 +8651,10 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xdg-basedir@4.0.0:
+    resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
+    engines: {node: '>=8'}
+
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
@@ -8053,6 +8662,9 @@ packages:
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -8066,13 +8678,27 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@13.1.2:
+    resolution: {integrity: sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==}
+
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
+
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yauzl@3.2.0:
     resolution: {integrity: sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==}
@@ -8095,6 +8721,9 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.1.13:
     resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
@@ -9140,6 +9769,32 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@formatjs/ecma402-abstract@2.3.6':
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/intl-localematcher': 0.6.2
+      decimal.js: 10.6.0
+      tslib: 2.8.1
+
+  '@formatjs/fast-memoize@2.2.7':
+    dependencies:
+      tslib: 2.8.1
+
+  '@formatjs/icu-messageformat-parser@2.11.4':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.6
+      '@formatjs/icu-skeleton-parser': 1.8.16
+      tslib: 2.8.1
+
+  '@formatjs/icu-skeleton-parser@1.8.16':
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.6
+      tslib: 2.8.1
+
+  '@formatjs/intl-localematcher@0.6.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@googlemaps/markerclusterer@2.6.2':
     dependencies:
       '@types/supercluster': 7.1.3
@@ -9490,7 +10145,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -9508,7 +10163,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -9683,6 +10338,48 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lhci/cli@0.15.1':
+    dependencies:
+      '@lhci/utils': 0.15.1
+      chrome-launcher: 0.13.4
+      compression: 1.8.1
+      debug: 4.4.3
+      express: 4.22.1
+      inquirer: 6.5.2
+      isomorphic-fetch: 3.0.0
+      lighthouse: 12.6.1
+      lighthouse-logger: 1.2.0
+      open: 7.4.2
+      proxy-agent: 6.5.0
+      tmp: 0.1.0
+      uuid: 8.3.2
+      yargs: 15.4.1
+      yargs-parser: 13.1.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - encoding
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  '@lhci/utils@0.15.1':
+    dependencies:
+      debug: 4.4.3
+      isomorphic-fetch: 3.0.0
+      js-yaml: 3.14.2
+      lighthouse: 12.6.1
+      tree-kill: 1.2.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - encoding
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
 
   '@lukeed/csprng@1.1.0': {}
 
@@ -10271,6 +10968,11 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
+  '@paulirish/trace_engine@0.0.53':
+    dependencies:
+      legacy-javascript: 0.0.1
+      third-party-web: 0.29.0
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -10283,6 +10985,21 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.0)
     transitivePeerDependencies:
+      - supports-color
+
+  '@puppeteer/browsers@2.13.0':
+    dependencies:
+      debug: 4.4.3
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.7.4
+      tar-fs: 3.1.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
       - supports-color
 
   '@radix-ui/primitive@1.1.3': {}
@@ -10630,6 +11347,12 @@ snapshots:
       '@sentry-internal/browser-utils': 10.38.0
       '@sentry/core': 10.38.0
 
+  '@sentry-internal/tracing@7.120.4':
+    dependencies:
+      '@sentry/core': 7.120.4
+      '@sentry/types': 7.120.4
+      '@sentry/utils': 7.120.4
+
   '@sentry/babel-plugin-component-annotate@4.9.0': {}
 
   '@sentry/browser@10.38.0':
@@ -10699,6 +11422,18 @@ snapshots:
       - supports-color
 
   '@sentry/core@10.38.0': {}
+
+  '@sentry/core@7.120.4':
+    dependencies:
+      '@sentry/types': 7.120.4
+      '@sentry/utils': 7.120.4
+
+  '@sentry/integrations@7.120.4':
+    dependencies:
+      '@sentry/core': 7.120.4
+      '@sentry/types': 7.120.4
+      '@sentry/utils': 7.120.4
+      localforage: 1.10.0
 
   '@sentry/nextjs@10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@16.0.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(webpack@5.103.0(esbuild@0.27.2))':
     dependencies:
@@ -10781,6 +11516,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@sentry/node@7.120.4':
+    dependencies:
+      '@sentry-internal/tracing': 7.120.4
+      '@sentry/core': 7.120.4
+      '@sentry/integrations': 7.120.4
+      '@sentry/types': 7.120.4
+      '@sentry/utils': 7.120.4
+
   '@sentry/opentelemetry@10.38.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.39.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -10795,6 +11538,12 @@ snapshots:
       '@sentry/browser': 10.38.0
       '@sentry/core': 10.38.0
       react: 19.2.1
+
+  '@sentry/types@7.120.4': {}
+
+  '@sentry/utils@7.120.4':
+    dependencies:
+      '@sentry/types': 7.120.4
 
   '@sentry/vercel-edge@10.38.0':
     dependencies:
@@ -11511,6 +12260,8 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
+
   '@tsconfig/node10@1.0.12': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -11630,7 +12381,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
 
   '@types/http-cache-semantics@4.0.4': {}
 
@@ -11674,7 +12425,7 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
 
   '@types/node@20.19.27':
     dependencies:
@@ -11687,7 +12438,6 @@ snapshots:
   '@types/node@22.19.7':
     dependencies:
       undici-types: 6.21.0
-    optional: true
 
   '@types/oauth@0.9.6':
     dependencies:
@@ -11730,7 +12480,7 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
@@ -11779,7 +12529,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
 
   '@types/triple-beam@1.3.5': {}
 
@@ -11792,6 +12542,11 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.19.7
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -12282,6 +13037,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
@@ -12315,6 +13072,8 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
+  ansi-escapes@3.2.0: {}
+
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -12323,9 +13082,17 @@ snapshots:
     dependencies:
       environment: 1.1.0
 
+  ansi-regex@3.0.1: {}
+
+  ansi-regex@4.1.1: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
+
+  ansi-styles@3.2.1:
+    dependencies:
+      color-convert: 1.9.3
 
   ansi-styles@4.3.0:
     dependencies:
@@ -12370,6 +13137,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
+
+  array-flatten@1.1.1: {}
 
   array-includes@3.1.9:
     dependencies:
@@ -12440,6 +13209,10 @@ snapshots:
   assertion-error@2.0.1: {}
 
   ast-types-flow@0.0.8: {}
+
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
 
   ast-types@0.16.1:
     dependencies:
@@ -12563,6 +13336,42 @@ snapshots:
 
   bare-events@2.8.2: {}
 
+  bare-fs@4.5.5:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.8.0(bare-events@2.8.2)
+      bare-url: 2.3.2
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  bare-os@3.7.0:
+    optional: true
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.7.0
+    optional: true
+
+  bare-stream@2.8.0(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.23.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  bare-url@2.3.2:
+    dependencies:
+      bare-path: 3.0.0
+    optional: true
+
   base64-js@1.5.1: {}
 
   base64id@2.0.0: {}
@@ -12570,6 +13379,8 @@ snapshots:
   base64url@3.0.1: {}
 
   baseline-browser-mapping@2.9.19: {}
+
+  basic-ftp@5.2.0: {}
 
   bin-version-check@5.1.0:
     dependencies:
@@ -12589,6 +13400,23 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  body-parser@1.20.4:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.14.1
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   body-parser@2.2.2:
     dependencies:
@@ -12710,12 +13538,20 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@2.4.2:
+    dependencies:
+      ansi-styles: 3.2.1
+      escape-string-regexp: 1.0.5
+      supports-color: 5.5.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   char-regex@1.0.2: {}
+
+  chardet@0.7.0: {}
 
   chardet@2.1.1: {}
 
@@ -12739,7 +13575,33 @@ snapshots:
 
   chromatic@13.3.5: {}
 
+  chrome-launcher@0.13.4:
+    dependencies:
+      '@types/node': 22.19.7
+      escape-string-regexp: 1.0.5
+      is-wsl: 2.2.0
+      lighthouse-logger: 1.2.0
+      mkdirp: 0.5.6
+      rimraf: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  chrome-launcher@1.2.1:
+    dependencies:
+      '@types/node': 22.19.7
+      escape-string-regexp: 4.0.0
+      is-wsl: 2.2.0
+      lighthouse-logger: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   chrome-trace-event@1.0.4: {}
+
+  chromium-bidi@14.0.0(devtools-protocol@0.0.1566079):
+    dependencies:
+      devtools-protocol: 0.0.1566079
+      mitt: 3.0.1
+      zod: 3.25.76
 
   ci-info@3.9.0: {}
 
@@ -12764,6 +13626,10 @@ snapshots:
 
   classnames@2.5.1: {}
 
+  cli-cursor@2.1.0:
+    dependencies:
+      restore-cursor: 2.0.0
+
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -12785,9 +13651,17 @@ snapshots:
       slice-ansi: 7.1.2
       string-width: 8.1.0
 
+  cli-width@2.2.1: {}
+
   cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
 
   cliui@8.0.1:
     dependencies:
@@ -12803,6 +13677,10 @@ snapshots:
 
   collect-v8-coverage@1.0.3: {}
 
+  color-convert@1.9.3:
+    dependencies:
+      color-name: 1.1.3
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -12810,6 +13688,8 @@ snapshots:
   color-convert@3.1.3:
     dependencies:
       color-name: 2.1.0
+
+  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -12850,6 +13730,22 @@ snapshots:
 
   component-emitter@1.3.1: {}
 
+  compressible@2.0.18:
+    dependencies:
+      mime-db: 1.54.0
+
+  compression@1.8.1:
+    dependencies:
+      bytes: 3.1.2
+      compressible: 2.0.18
+      debug: 2.6.9
+      negotiator: 0.6.4
+      on-headers: 1.1.0
+      safe-buffer: 5.2.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
@@ -12858,6 +13754,15 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       typedarray: 0.0.6
+
+  configstore@5.0.1:
+    dependencies:
+      dot-prop: 5.3.0
+      graceful-fs: 4.2.11
+      make-dir: 3.1.0
+      unique-string: 2.0.0
+      write-file-atomic: 3.0.3
+      xdg-basedir: 4.0.0
 
   consola@3.4.2: {}
 
@@ -12934,6 +13839,10 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  crypto-random-string@2.0.0: {}
+
+  csp_evaluator@1.1.5: {}
+
   css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
@@ -12978,6 +13887,8 @@ snapshots:
 
   damerau-levenshtein@1.0.8: {}
 
+  data-uri-to-buffer@6.0.2: {}
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -13014,7 +13925,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   decimal.js-light@2.5.1: {}
+
+  decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -13049,6 +13964,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  define-lazy-prop@2.0.0: {}
+
   define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
@@ -13057,17 +13974,29 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
+  destroy@1.2.0: {}
+
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
 
   detect-node-es@1.1.0: {}
+
+  devtools-protocol@0.0.1467305: {}
+
+  devtools-protocol@0.0.1566079: {}
 
   dezalgo@1.0.4:
     dependencies:
@@ -13089,6 +14018,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
 
   dotenv-expand@12.0.1:
     dependencies:
@@ -13130,6 +14063,10 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
   engine.io-client@6.6.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
@@ -13164,6 +14101,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
 
   environment@1.1.0: {}
 
@@ -13309,9 +14251,19 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@1.0.5: {}
+
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
 
   eslint-config-next@16.0.10(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -13589,6 +14541,42 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.4
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.12
+      proxy-addr: 2.0.7
+      qs: 6.14.1
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -13631,6 +14619,22 @@ snapshots:
       ext-list: 2.2.2
       sort-keys-length: 1.0.1
 
+  external-editor@3.1.0:
+    dependencies:
+      chardet: 0.7.0
+      iconv-lite: 0.4.24
+      tmp: 0.0.33
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
@@ -13667,6 +14671,10 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
@@ -13674,6 +14682,10 @@ snapshots:
   fecha@4.2.3: {}
 
   fflate@0.8.2: {}
+
+  figures@2.0.0:
+    dependencies:
+      escape-string-regexp: 1.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -13712,6 +14724,18 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   finalhandler@2.1.1:
     dependencies:
@@ -13802,6 +14826,8 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
+  fresh@0.5.2: {}
+
   fresh@2.0.0: {}
 
   fs-extra@10.1.0:
@@ -13863,6 +14889,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.3
+
   get-stream@6.0.1: {}
 
   get-symbol-description@1.1.0:
@@ -13874,6 +14904,14 @@ snapshots:
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.2.0
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   glob-parent@5.1.2:
     dependencies:
@@ -13962,6 +15000,8 @@ snapshots:
 
   has-bigints@1.1.0: {}
 
+  has-flag@3.0.0: {}
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -14002,6 +15042,15 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-link-header@1.1.3: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http2-wrapper@2.2.1:
     dependencies:
       quick-lru: 5.1.1
@@ -14014,9 +15063,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-signals@2.1.0: {}
 
   husky@9.1.7: {}
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.1:
     dependencies:
@@ -14033,6 +15093,10 @@ snapshots:
   ignore@7.0.5: {}
 
   image-size@2.0.2: {}
+
+  image-ssim@0.2.0: {}
+
+  immediate@3.0.6: {}
 
   immer@10.2.0: {}
 
@@ -14066,6 +15130,22 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inquirer@6.5.2:
+    dependencies:
+      ansi-escapes: 3.2.0
+      chalk: 2.4.2
+      cli-cursor: 2.1.0
+      cli-width: 2.2.1
+      external-editor: 3.1.0
+      figures: 2.0.0
+      lodash: 4.17.21
+      mute-stream: 0.0.7
+      run-async: 2.4.1
+      rxjs: 6.6.7
+      string-width: 2.1.1
+      strip-ansi: 5.2.0
+      through: 2.3.8
+
   inspect-with-kind@1.0.5:
     dependencies:
       kind-of: 6.0.3
@@ -14077,6 +15157,15 @@ snapshots:
       side-channel: 1.1.0
 
   internmap@2.0.3: {}
+
+  intl-messageformat@10.7.18:
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.6
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/icu-messageformat-parser': 2.11.4
+      tslib: 2.8.1
+
+  ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -14130,6 +15219,8 @@ snapshots:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
 
+  is-docker@2.2.1: {}
+
   is-docker@3.0.0: {}
 
   is-extglob@2.1.1: {}
@@ -14137,6 +15228,8 @@ snapshots:
   is-finalizationregistry@1.1.1:
     dependencies:
       call-bound: 1.0.4
+
+  is-fullwidth-code-point@2.0.0: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -14177,6 +15270,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-obj@2.0.0: {}
+
   is-plain-obj@1.1.0: {}
 
   is-promise@4.0.0: {}
@@ -14215,6 +15310,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.19
 
+  is-typedarray@1.0.0: {}
+
   is-unicode-supported@0.1.0: {}
 
   is-weakmap@2.0.2: {}
@@ -14228,6 +15325,10 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
+
   is-wsl@3.1.0:
     dependencies:
       is-inside-container: 1.0.0
@@ -14235,6 +15336,13 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isomorphic-fetch@3.0.0:
+    dependencies:
+      node-fetch: 2.7.0
+      whatwg-fetch: 3.6.20
+    transitivePeerDependencies:
+      - encoding
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -14318,7 +15426,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.0
@@ -14412,7 +15520,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -14477,7 +15585,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -14627,13 +15735,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.19.27
+      '@types/node': 22.19.7
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -14663,7 +15771,11 @@ snapshots:
 
   jose@6.1.3: {}
 
+  jpeg-js@0.4.4: {}
+
   js-cookie@3.0.5: {}
+
+  js-library-detector@6.7.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -14763,6 +15875,8 @@ snapshots:
     dependencies:
       language-subtag-registry: 0.3.23
 
+  legacy-javascript@0.0.1: {}
+
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -14771,6 +15885,64 @@ snapshots:
       type-check: 0.4.0
 
   libphonenumber-js@1.12.33: {}
+
+  lie@3.1.1:
+    dependencies:
+      immediate: 3.0.6
+
+  lighthouse-logger@1.2.0:
+    dependencies:
+      debug: 2.6.9
+      marky: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  lighthouse-logger@2.0.2:
+    dependencies:
+      debug: 4.4.3
+      marky: 1.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  lighthouse-stack-packs@1.12.2: {}
+
+  lighthouse@12.6.1:
+    dependencies:
+      '@paulirish/trace_engine': 0.0.53
+      '@sentry/node': 7.120.4
+      axe-core: 4.11.0
+      chrome-launcher: 1.2.1
+      configstore: 5.0.1
+      csp_evaluator: 1.1.5
+      devtools-protocol: 0.0.1467305
+      enquirer: 2.4.1
+      http-link-header: 1.1.3
+      intl-messageformat: 10.7.18
+      jpeg-js: 0.4.4
+      js-library-detector: 6.7.0
+      lighthouse-logger: 2.0.2
+      lighthouse-stack-packs: 1.12.2
+      lodash-es: 4.17.23
+      lookup-closest-locale: 6.2.0
+      metaviewport-parser: 0.3.0
+      open: 8.4.2
+      parse-cache-control: 1.0.1
+      puppeteer-core: 24.37.5
+      robots-parser: 3.0.1
+      semver: 5.7.2
+      speedline-core: 1.4.3
+      third-party-web: 0.26.7
+      tldts-icann: 6.1.86
+      ws: 7.5.10
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -14846,6 +16018,10 @@ snapshots:
 
   loader-runner@4.3.1: {}
 
+  localforage@1.10.0:
+    dependencies:
+      lie: 3.1.1
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -14853,6 +16029,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.17.23: {}
 
   lodash.includes@4.3.0: {}
 
@@ -14896,6 +16074,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
 
+  lookup-closest-locale@6.2.0: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -14911,6 +16091,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru-cache@7.18.3: {}
 
   lucide-react@0.561.0(react@19.2.1):
     dependencies:
@@ -14940,6 +16122,10 @@ snapshots:
       '@babel/types': 7.28.5
       source-map-js: 1.2.1
 
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
+
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
@@ -14949,6 +16135,8 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
+
+  marky@1.3.0: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -14960,11 +16148,15 @@ snapshots:
     dependencies:
       fs-monkey: 1.1.0
 
+  merge-descriptors@1.0.3: {}
+
   merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  metaviewport-parser@0.3.0: {}
 
   methods@1.1.2: {}
 
@@ -14985,7 +16177,11 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@1.6.0: {}
+
   mime@2.6.0: {}
+
+  mimic-fn@1.2.0: {}
 
   mimic-fn@2.1.0: {}
 
@@ -15012,6 +16208,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  mitt@3.0.1: {}
 
   mkdirp@0.5.6:
     dependencies:
@@ -15075,6 +16273,8 @@ snapshots:
       type-is: 1.6.18
       xtend: 4.0.2
 
+  mute-stream@0.0.7: {}
+
   mute-stream@2.0.0: {}
 
   nano-spawn@2.0.0: {}
@@ -15087,6 +16287,8 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  negotiator@0.6.4: {}
+
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
@@ -15096,6 +16298,8 @@ snapshots:
       '@nestjs/common': 11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       fast-safe-stringify: 2.1.1
       winston: 3.19.0
+
+  netmask@2.0.2: {}
 
   next-auth@5.0.0-beta.30(next@16.0.11(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1):
     dependencies:
@@ -15210,6 +16414,8 @@ snapshots:
     dependencies:
       ee-first: 1.1.1
 
+  on-headers@1.1.0: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -15217,6 +16423,10 @@ snapshots:
   one-time@1.0.0:
     dependencies:
       fn.name: 1.1.0
+
+  onetime@2.0.1:
+    dependencies:
+      mimic-fn: 1.2.0
 
   onetime@5.1.2:
     dependencies:
@@ -15232,6 +16442,17 @@ snapshots:
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
+
+  open@7.4.2:
+    dependencies:
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+
+  open@8.4.2:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
 
   optionator@0.9.4:
     dependencies:
@@ -15253,6 +16474,8 @@ snapshots:
       log-symbols: 4.1.0
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
+
+  os-tmpdir@1.0.2: {}
 
   outvariant@1.4.3: {}
 
@@ -15282,11 +16505,31 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.0.2
+
   package-json-from-dist@1.0.1: {}
 
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-cache-control@1.0.1: {}
 
   parse-json@5.2.0:
     dependencies:
@@ -15350,6 +16593,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.4
       minipass: 7.1.2
+
+  path-to-regexp@0.1.12: {}
 
   path-to-regexp@6.3.0: {}
 
@@ -15510,9 +16755,44 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   proxy-from-env@1.1.0: {}
 
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
+
+  puppeteer-core@24.37.5:
+    dependencies:
+      '@puppeteer/browsers': 2.13.0
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1566079)
+      debug: 4.4.3
+      devtools-protocol: 0.0.1566079
+      typed-query-selector: 2.12.0
+      webdriver-bidi-protocol: 0.4.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
 
   pure-rand@6.1.0: {}
 
@@ -15529,6 +16809,13 @@ snapshots:
       safe-buffer: 5.2.1
 
   range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
 
   raw-body@3.0.2:
     dependencies:
@@ -15704,6 +16991,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  require-main-filename@2.0.0: {}
+
   reselect@5.1.1: {}
 
   resolve-alpn@1.2.1: {}
@@ -15736,6 +17025,11 @@ snapshots:
     dependencies:
       lowercase-keys: 3.0.0
 
+  restore-cursor@2.0.0:
+    dependencies:
+      onetime: 2.0.1
+      signal-exit: 3.0.7
+
   restore-cursor@3.1.0:
     dependencies:
       onetime: 5.1.2
@@ -15751,6 +17045,16 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rimraf@2.7.1:
+    dependencies:
+      glob: 7.2.3
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+
+  robots-parser@3.0.1: {}
 
   rollup@4.55.1:
     dependencies:
@@ -15795,9 +17099,15 @@ snapshots:
 
   run-applescript@7.1.0: {}
 
+  run-async@2.4.1: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@6.6.7:
+    dependencies:
+      tslib: 1.14.1
 
   rxjs@7.8.1:
     dependencies:
@@ -15857,9 +17167,31 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
+  semver@5.7.2: {}
+
   semver@6.3.1: {}
 
   semver@7.7.3: {}
+
+  semver@7.7.4: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   send@1.2.1:
     dependencies:
@@ -15881,6 +17213,15 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
   serve-static@2.2.1:
     dependencies:
       encodeurl: 2.0.0
@@ -15889,6 +17230,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-blocking@2.0.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -16006,6 +17349,8 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  smart-buffer@4.2.0: {}
+
   socket.io-adapter@2.5.6:
     dependencies:
       debug: 4.4.3
@@ -16047,6 +17392,19 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
+
   sonner@2.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       react: 19.2.1
@@ -16077,6 +17435,12 @@ snapshots:
   source-map@0.7.4: {}
 
   source-map@0.7.6: {}
+
+  speedline-core@1.4.3:
+    dependencies:
+      '@types/node': 22.19.7
+      image-ssim: 0.2.0
+      jpeg-js: 0.4.4
 
   split2@4.2.0: {}
 
@@ -16149,6 +17513,11 @@ snapshots:
     dependencies:
       char-regex: 1.0.2
       strip-ansi: 6.0.1
+
+  string-width@2.1.1:
+    dependencies:
+      is-fullwidth-code-point: 2.0.0
+      strip-ansi: 4.0.0
 
   string-width@4.2.3:
     dependencies:
@@ -16227,6 +17596,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  strip-ansi@4.0.0:
+    dependencies:
+      ansi-regex: 3.0.1
+
+  strip-ansi@5.2.0:
+    dependencies:
+      ansi-regex: 4.1.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -16293,6 +17670,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  supports-color@5.5.0:
+    dependencies:
+      has-flag: 3.0.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -16330,6 +17711,18 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  tar-fs@3.1.1:
+    dependencies:
+      pump: 3.0.3
+      tar-stream: 3.1.7
+    optionalDependencies:
+      bare-fs: 4.5.5
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar-stream@3.1.7:
     dependencies:
       b4a: 1.7.3
@@ -16338,6 +17731,14 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.23.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
 
   terser-webpack-plugin@5.3.16(@swc/core@1.15.4)(webpack@5.103.0(@swc/core@1.15.4)):
     dependencies:
@@ -16382,6 +17783,10 @@ snapshots:
 
   text-hex@1.0.0: {}
 
+  third-party-web@0.26.7: {}
+
+  third-party-web@0.29.0: {}
+
   through@2.3.8: {}
 
   tiny-invariant@1.3.3: {}
@@ -16401,11 +17806,25 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
   tldts-core@7.0.19: {}
+
+  tldts-icann@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
 
   tldts@7.0.19:
     dependencies:
       tldts-core: 7.0.19
+
+  tmp@0.0.33:
+    dependencies:
+      os-tmpdir: 1.0.2
+
+  tmp@0.1.0:
+    dependencies:
+      rimraf: 2.7.1
 
   tmpl@1.0.5: {}
 
@@ -16434,6 +17853,8 @@ snapshots:
       tldts: 7.0.19
 
   tr46@0.0.3: {}
+
+  tree-kill@1.2.2: {}
 
   triple-beam@1.4.1: {}
 
@@ -16517,6 +17938,8 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
 
   tw-animate-css@1.4.0: {}
@@ -16581,6 +18004,12 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
+  typed-query-selector@2.12.0: {}
+
+  typedarray-to-buffer@3.1.5:
+    dependencies:
+      is-typedarray: 1.0.0
+
   typedarray@0.0.6: {}
 
   typeorm@0.3.28(pg@8.16.3)(ts-node@10.9.2(@swc/core@1.15.4)(@types/node@22.19.2)(typescript@5.9.3)):
@@ -16644,6 +18073,10 @@ snapshots:
       through: 2.3.8
 
   undici-types@6.21.0: {}
+
+  unique-string@2.0.0:
+    dependencies:
+      crypto-random-string: 2.0.0
 
   universalify@2.0.1: {}
 
@@ -16725,6 +18158,8 @@ snapshots:
   uuid@11.1.0: {}
 
   uuid@13.0.0: {}
+
+  uuid@8.3.2: {}
 
   uuid@9.0.1: {}
 
@@ -16860,6 +18295,8 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
+  webdriver-bidi-protocol@0.4.1: {}
+
   webidl-conversions@3.0.1: {}
 
   webpack-node-externals@3.0.0: {}
@@ -16934,6 +18371,8 @@ snapshots:
       - esbuild
       - uglify-js
 
+  whatwg-fetch@3.6.20: {}
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -16969,6 +18408,8 @@ snapshots:
       is-set: 2.0.3
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
+
+  which-module@2.0.1: {}
 
   which-typed-array@1.1.19:
     dependencies:
@@ -17047,6 +18488,13 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  write-file-atomic@3.0.3:
+    dependencies:
+      imurmurhash: 0.1.4
+      is-typedarray: 1.0.0
+      signal-exit: 3.0.7
+      typedarray-to-buffer: 3.1.5
+
   write-file-atomic@4.0.2:
     dependencies:
       imurmurhash: 0.1.4
@@ -17058,6 +18506,8 @@ snapshots:
       signal-exit: 4.1.0
     optional: true
 
+  ws@7.5.10: {}
+
   ws@8.18.3: {}
 
   ws@8.19.0: {}
@@ -17066,9 +18516,13 @@ snapshots:
     dependencies:
       is-wsl: 3.1.0
 
+  xdg-basedir@4.0.0: {}
+
   xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
+
+  y18n@4.0.3: {}
 
   y18n@5.0.8: {}
 
@@ -17076,7 +18530,31 @@ snapshots:
 
   yaml@2.8.2: {}
 
+  yargs-parser@13.1.2:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@17.7.2:
     dependencies:
@@ -17087,6 +18565,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yauzl@3.2.0:
     dependencies:
@@ -17102,6 +18585,8 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.1.13):
     dependencies:
       zod: 4.1.13
+
+  zod@3.25.76: {}
 
   zod@4.1.13: {}
 


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- #242 

## 작업 내용 + 스크린샷

피드백 중 가장 큰 비중을 차지했던 "페이지 라우팅 지연" 문제를 해결하기 위해 sentry 대시보드와 브라우저 performance 도구를 활용해 원인을 분석하고 최적화를 진행

<img width="2048" height="985" alt="image" src="https://github.com/user-attachments/assets/b15d8ace-7b12-416b-80d7-e9440a5f84c3" />

일단 많은 유저가 접하게 될 루트 경로인 `/`를 확인했을 때 아래 사진과 같습니다.

<img width="2048" height="1058" alt="image" src="https://github.com/user-attachments/assets/7f09e252-924a-4fc0-b92c-5feb68078a57" />

613.99ms나 걸리는 `/`경로 GET 요청을 분석했을 때,
서버 컴포넌트와 라우팅 지연이 next.js app 라우터 구조에서 깊은 연관이 있다는걸 알게 되었어요.

- 일반적인 react 프로젝트(CSR)에서는 클릭하면 즉시 페이지가 바뀌게 돼요.
  그 다음, 페이지 내부에서 API를 호출하게 되기 때문에 데이터 로드에 대한 유저 피드백을 고려하게 돼요.
- 하지만 Next.js 서버 컴포넌트에서는 서버에서 데이터를 다 가져온 뒤에 완성된 결과물인 RSC payload를 브라우저로 보내요.
  즉, 서버 컴포넌트에서의 api 패칭 처리와 같은 데이터 로드가 끝날 때까지 서버는 브라우저에 응답을 주지 않아요.
이때 유저는 클릭했지만 아무 변화가 없으니, 라우팅 자체가 안되고 지연되고 있다고 느끼게 되는 것이죠.

이를 `Suspense`를 통한 스트리밍 도입으로 해결하고자 했어요.
서버 컴포넌트에서 `hydration` 처리만 해주고 `suspense`를 적용하지 않았었어요.
그래서 데이터 패칭이 완료될 때까지 페이지 이동 없이 지연되고 있던 문제였거든요.

`Suspense` 를 사용해서 레이아웃을 먼저 보여주고, 데이터가 필요한 부분만 로딩 상태를 보여주는 방식으로 UX를 개선할 수 있을 것 같았어요.

또한, 서버 컴포넌트에서 데이터를 클라이언트로 내려주겠다고 `queryClient.setQueryData` 를 해주고 있었어요.
tanstack query의 장점을 살리려면 `prefetchQuery` 를 사용해서 서버에서 미리 캐싱하는게 정석적일 것 같아서, 이 부분도 수정해줬습니다.

`setQueryData` 는 캐시에 데이터를 강제 주입하는거라 Tanstack Query가 이 데이터가 언제 패칭됐는지, 아직 유효한지 알 수 없다는 단점이 있어요.

  | setQueryData | prefetchQuery
-- | -- | --
dateUpdatedAt 타임스탬프 | 없음 | 올바르게 설정
staleTime 존중 | 무시 | 만료 여부 추적
클라이언트에서 즉시 재요청 가능성 | 높음 | stale 판단 후 결정
에러 처리 | 직접 해야 함 | 내장

<br />

### 1. 라우팅 구조 및 데이터 패칭 최적화

- 문제: Nextjs app router 환경에서 서버 컴포넌트의 `await` 처리가 끝날 떄까지 브라우저 응답이 차단되어 유저가 클릭 후 무반응을 경험함 (인터렉션 반응 지연)

이를
- `suspense`를 동비해 레이아웃을 즉시 렌더링하고, 무거운 데이터는 스트리밍 방식으로 처리
- `setQueryData` 대신 `prefetchQuery`를 사용해 Tanstack Query의 캐시 무결성 보장

<br />

### 2. 메인 스레드 블로킹 (long task) 및 렌더링 최적화

- 기록 리스트: 매번 수행되던 복잡한 블록 레이아웃 계산(Map 생성, 정렬 등)을 `useMemo`로 최적화하고 컴포넌트를 분리해 `React.memo` 활용
- 날짜 파라미터: 클라이언트 `useEffect` 내부의 `router.replace` 없애 이중 렌더링 제거
- 조건부 렌더링: css로 숨겨져 있어 항상 실행되던 마이페이지의 차트/대시보드 컴포넌트를 조건부 렌더링으로 불필요한 `useEffect` 실행 방지 (차트/대시보드 실행 방지)
- 인라인 함수 제거: 렌더링마다 생성되던 인라인 함수들을 외부로 분리하거나 `useCallback`으로 감싸 자식 컴포넌트의 불필요한 리렌더링 차단 (컴포넌트 호출시 전달하는 함수가 인라인으로 작성되어 있던 문제)

<br />

### 3. 기록 추가할 그룹 선택 drawer 인터렉션 지연 개선

GroupSelectDrawer(함께 기록함 페이지의 하단 + 버튼 클릭시 뜨는 drawer) 클릭 시점에 데이터를 패칭하던 방식에서, `/shared` 페이지 진입 시미리 데이터를 `prefetch`하도록 수정해 drawer 오픈 속도 개선

<br />

### 성능 지표

- 메인 페이지 microtasks: 175.7ms -> 134.9ms (23% 개선)
  개선 전

<img width="70%"  alt="image" src="https://github.com/user-attachments/assets/53dd4e8a-242b-43eb-82c9-d1c3e3396cf3" />

  개선 후
  
<img width="70%" alt="image" src="https://github.com/user-attachments/assets/54c71a4d-b01c-484b-a92b-2dccdfdf9d59" />

- drawer 이벤트 처리: 265.6ms -> 102.0ms (61% 개선)
  개선 전

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/bf758f80-5f6e-4447-accc-286df7396700" />

  개선 후

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/d9f96677-e887-49db-829f-d0cf6f0b072d" />

- 그룹 페이지 Timer fired: 163.3 -> 65.8ms (60% 개선)
  개선 전

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/7a386024-b3d2-4550-a673-e84f91a3ac1c" />


개선 후

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/0355c0b3-7d66-4ae0-a1df-9e7067141529" />

- 그룹 페이지 fored reflow: 375.7ms -> 171.3ms (54% 개선)
  개선 전

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/db61f63c-2afe-4450-95c9-38b8e29f6764" />

  개선 후

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/e5ed6995-d62a-4ab0-aa31-a06d30a0378b" />

- 작성 페이지 layout 작업: 173.9ms -> 31.7ms (81% 개선)
  개선 전

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/822a3f65-45da-4438-a8bb-dd41d211eadf" />

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/7be91a50-9c8b-4f14-9ef8-bfe49b064eee" />

  개선 후

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/78cf608e-9bd9-4d94-ba49-a81060e4f0d4" />

  long task가 사라졌습니다.

## 실제 걸린 시간

3day

## 작업하며 고민했던 점

sentry로 라우팅 지연을 파악한 것 처럼 개선 후도 sentry로 파악하고자 하지만,
- 아직 배포 전
- 개선 후 데이터가 쌓이지 않은 상태

로 인해 실제로 얼마나 라우팅 지연이 개선되었는지는 조금 더 경과를 지켜봐야할 것 같아요.
위에 적은 것들은 라우팅 지연에 영향을 줄 수 있을만한 것들을 분석해서 개선한 내용들이에요.

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [x] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항

비슷한 작업들을 여러 페이지에서 동일하게 해줘야 했기에 변경된 파일 개수가 많아요.
커밋 단위로 일부 파일들만 보시는걸 추천드립니다. (어차피 작업 내용은 비슷해요.)

## 시각 자료(이미지/영상, 있다면)(선택)
