### PR TITLE
API 중복 호출 최적화 및 fetch 타임아웃 AbortController 적용

### DIFF
--- a/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
+++ b/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
@@ -470,9 +470,7 @@ export default function PostEditor({
       await refreshGroupData(groupId);
       queryClient.invalidateQueries({ queryKey: ['group', groupId] });
       return;
-    }
-
-    if (groupId) {
+    } else if (groupId) {
       await refreshGroupData(groupId);
       queryClient.invalidateQueries({ queryKey: ['group', groupId] });
     }
@@ -866,7 +864,9 @@ export default function PostEditor({
               handleFieldCommit={handleFieldCommit}
               removeBlock={removeBlock}
               onOpenDrawer={handleOpenDrawerWrapper}
-              contentBlockCount={blocks.filter((b) => b.type === 'content').length}
+              contentBlockCount={
+                blocks.filter((b) => b.type === 'content').length
+              }
               handlePointerDown={handlePointerDown}
               handlePointerMove={handlePointerMove}
               handleDragEnd={handleDragEnd}

--- a/frontend/src/app/(post)/record/_components/RecordDetailHeaderActions.tsx
+++ b/frontend/src/app/(post)/record/_components/RecordDetailHeaderActions.tsx
@@ -26,6 +26,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { groupMyRoleOptions } from '@/lib/api/group';
+import { refreshSharedData } from '@/lib/actions/revalidate';
 
 interface RecordDetailHeaderActionsProps {
   record: RecordDetailResponse;
@@ -74,13 +75,23 @@ export default function RecordDetailHeaderActions({
 
   const queryClient = useQueryClient();
   const { mutate: deleteRecord } = useApiDelete(`/api/posts/${record.id}`, {
-    onSuccess: () => {
+    onSuccess: async () => {
       toast.success('기록이 삭제되었습니다.');
-      queryClient.invalidateQueries({ queryKey: ['records'] });
+      queryClient.invalidateQueries({ queryKey: ['my', 'records'] });
 
-      setTimeout(() => {
-        router.back();
-      }, 1000);
+      if (record.groupId) {
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: ['group', record.groupId, 'records'],
+          }),
+          queryClient.invalidateQueries({
+            queryKey: ['shared'],
+          }),
+          refreshSharedData(),
+        ]);
+      }
+
+      router.back();
     },
     onError: (error: ApiError) => {
       if (error.code && error.code === 'NOT_FOUND') {

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -8,7 +8,7 @@ import {
 } from '@tanstack/react-query';
 import { useState } from 'react';
 import { Toaster, toast } from 'sonner';
-import { getErrorMessage } from '@/lib/utils/errorHandler';
+import { getErrorMessage, type ApiError } from '@/lib/utils/errorHandler';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   // 렌더마다 새 QueryClient 생성 방지 (중요)
@@ -18,7 +18,12 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         queryCache: new QueryCache({
           onError: (error, query) => {
             if (query.meta?.silent) return;
-            // 쿼리 에러 시 토스트 표시
+            if ((error as ApiError)?.code === 'TIMEOUT') {
+              toast.error('요청 시간이 초과되었습니다.', {
+                description: '네트워크 연결을 확인하고 다시 시도해 주세요.',
+              });
+              return;
+            }
             const message = getErrorMessage(error);
             toast.error(message);
           },
@@ -26,7 +31,12 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         mutationCache: new MutationCache({
           onError: (error, variables, context, mutation) => {
             if (mutation.meta?.silent) return;
-            // mutation 에러 시 토스트 표시
+            if ((error as ApiError)?.code === 'TIMEOUT') {
+              toast.error('요청 시간이 초과되었습니다.', {
+                description: '네트워크 연결을 확인하고 다시 시도해 주세요.',
+              });
+              return;
+            }
             const message = getErrorMessage(error);
             toast.error(message);
           },

--- a/frontend/src/components/ProfileEditHeaderActions.tsx
+++ b/frontend/src/components/ProfileEditHeaderActions.tsx
@@ -37,12 +37,18 @@ export default function ProfileEditHeaderActions({
       <h2 className="text-[13px] sm:text-sm font-bold dark:text-white text-itta-black">
         {title}
       </h2>
-      <button
-        onClick={handleSave}
-        className="cursor-pointer font-bold text-[13px] sm:text-sm active:scale-95 transition-all min-w-8"
-      >
-        {isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : '저장'}
-      </button>
+      <div className="relative flex items-center justify-end min-w-8">
+        {isPending ? (
+          <Loader2 className="w-5 h-5 animate-spin" />
+        ) : (
+          <button
+            onClick={handleSave}
+            className="cursor-pointer font-bold text-[13px] sm:text-sm active:scale-95 transition-all"
+          >
+            저장
+          </button>
+        )}
+      </div>
     </header>
   );
 }

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -4,6 +4,7 @@ import {
   useQueryClient,
   type UseQueryOptions,
   type UseMutationOptions,
+  type UseMutationResult,
   type QueryKey,
 } from '@tanstack/react-query';
 import { get, post, put, del, patch } from '@/lib/api/api';
@@ -11,6 +12,22 @@ import type { ApiResponse } from '@/lib/types/response';
 import { createApiError } from '@/lib/utils/errorHandler';
 
 type FetchParams = Record<string, string | number | boolean>;
+
+/**
+ * isPending 중 중복 호출을 방지하는 mutate 가드
+ * 버튼 더블 클릭 등으로 인한 중복 API 요청 방지
+ */
+function withPendingGuard<TData, TError, TVariables, TContext>(
+  mutation: UseMutationResult<TData, TError, TVariables, TContext>,
+) {
+  return {
+    ...mutation,
+    mutate: (...args: Parameters<typeof mutation.mutate>) => {
+      if (mutation.isPending) return;
+      mutation.mutate(...args);
+    },
+  };
+}
 
 interface UseApiQueryOptions<TData, TError = Error> extends Omit<
   UseQueryOptions<ApiResponse<TData>, TError, TData, QueryKey>,
@@ -79,32 +96,34 @@ export function useApiPost<
 ) {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: async (variables: TVariables) => {
-      const response = await post<TData>(
-        endpoint,
-        variables as Record<string, unknown>,
-        { headers },
-        sendCookie,
-      );
+  return withPendingGuard(
+    useMutation({
+      mutationFn: async (variables: TVariables) => {
+        const response = await post<TData>(
+          endpoint,
+          variables as Record<string, unknown>,
+          { headers },
+          sendCookie,
+        );
 
-      // 에러 응답 처리 (토큰 재발급은 fetchApi에서 자동 처리됨)
-      if (!response.success) {
-        throw createApiError(response);
-      }
+        // 에러 응답 처리 (토큰 재발급은 fetchApi에서 자동 처리됨)
+        if (!response.success) {
+          throw createApiError(response);
+        }
 
-      return response;
-    },
-    onSuccess: (data, variables, context, mutationContext) => {
-      if (options?.invalidateKeys) {
-        options.invalidateKeys.forEach((key) => {
-          queryClient.invalidateQueries({ queryKey: key });
-        });
-      }
-      options?.onSuccess?.(data, variables, context, mutationContext);
-    },
-    ...options,
-  });
+        return response;
+      },
+      onSuccess: (data, variables, context, mutationContext) => {
+        if (options?.invalidateKeys) {
+          options.invalidateKeys.forEach((key) => {
+            queryClient.invalidateQueries({ queryKey: key });
+          });
+        }
+        options?.onSuccess?.(data, variables, context, mutationContext);
+      },
+      ...options,
+    }),
+  );
 }
 
 /**
@@ -124,30 +143,32 @@ export function useApiPut<
 ) {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: async (variables: TVariables) => {
-      const response = await put<TData>(
-        endpoint,
-        variables as Record<string, unknown>,
-      );
+  return withPendingGuard(
+    useMutation({
+      mutationFn: async (variables: TVariables) => {
+        const response = await put<TData>(
+          endpoint,
+          variables as Record<string, unknown>,
+        );
 
-      // 에러 응답 처리 (토큰 재발급은 fetchApi에서 자동 처리됨)
-      if (!response.success) {
-        throw createApiError(response);
-      }
+        // 에러 응답 처리 (토큰 재발급은 fetchApi에서 자동 처리됨)
+        if (!response.success) {
+          throw createApiError(response);
+        }
 
-      return response;
-    },
-    onSuccess: (data, variables, context, mutationContext) => {
-      if (options?.invalidateKeys) {
-        options.invalidateKeys.forEach((key) => {
-          queryClient.invalidateQueries({ queryKey: key });
-        });
-      }
-      options?.onSuccess?.(data, variables, context, mutationContext);
-    },
-    ...options,
-  });
+        return response;
+      },
+      onSuccess: (data, variables, context, mutationContext) => {
+        if (options?.invalidateKeys) {
+          options.invalidateKeys.forEach((key) => {
+            queryClient.invalidateQueries({ queryKey: key });
+          });
+        }
+        options?.onSuccess?.(data, variables, context, mutationContext);
+      },
+      ...options,
+    }),
+  );
 }
 
 /**
@@ -164,29 +185,31 @@ export function useApiDelete<TData = unknown, TVariables = unknown>(
 ) {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: async (variables: TVariables) => {
-      const url =
-        typeof endpoint === 'function' ? endpoint(variables) : endpoint;
-      const response = await del<TData>(url);
+  return withPendingGuard(
+    useMutation({
+      mutationFn: async (variables: TVariables) => {
+        const url =
+          typeof endpoint === 'function' ? endpoint(variables) : endpoint;
+        const response = await del<TData>(url);
 
-      // 에러 응답 처리 (토큰 재발급은 fetchApi에서 자동 처리됨)
-      if (!response.success) {
-        throw createApiError(response);
-      }
+        // 에러 응답 처리 (토큰 재발급은 fetchApi에서 자동 처리됨)
+        if (!response.success) {
+          throw createApiError(response);
+        }
 
-      return response;
-    },
-    onSuccess: (data, variables, context, mutationContext) => {
-      if (options?.invalidateKeys) {
-        options.invalidateKeys.forEach((key) => {
-          queryClient.invalidateQueries({ queryKey: key });
-        });
-      }
-      options?.onSuccess?.(data, variables, context, mutationContext);
-    },
-    ...options,
-  });
+        return response;
+      },
+      onSuccess: (data, variables, context, mutationContext) => {
+        if (options?.invalidateKeys) {
+          options.invalidateKeys.forEach((key) => {
+            queryClient.invalidateQueries({ queryKey: key });
+          });
+        }
+        options?.onSuccess?.(data, variables, context, mutationContext);
+      },
+      ...options,
+    }),
+  );
 }
 
 /**
@@ -206,28 +229,30 @@ export function useApiPatch<
 ) {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: async (variables: TVariables) => {
-      const response = await patch<TData>(
-        endpoint,
-        variables as Record<string, unknown>,
-      );
+  return withPendingGuard(
+    useMutation({
+      mutationFn: async (variables: TVariables) => {
+        const response = await patch<TData>(
+          endpoint,
+          variables as Record<string, unknown>,
+        );
 
-      // 에러 응답 처리 (토큰 재발급은 fetchApi에서 자동 처리됨)
-      if (!response.success) {
-        throw createApiError(response);
-      }
+        // 에러 응답 처리 (토큰 재발급은 fetchApi에서 자동 처리됨)
+        if (!response.success) {
+          throw createApiError(response);
+        }
 
-      return response;
-    },
-    onSuccess: (data, variables, context, mutationContext) => {
-      if (options?.invalidateKeys) {
-        options.invalidateKeys.forEach((key) => {
-          queryClient.invalidateQueries({ queryKey: key });
-        });
-      }
-      options?.onSuccess?.(data, variables, context, mutationContext);
-    },
-    ...options,
-  });
+        return response;
+      },
+      onSuccess: (data, variables, context, mutationContext) => {
+        if (options?.invalidateKeys) {
+          options.invalidateKeys.forEach((key) => {
+            queryClient.invalidateQueries({ queryKey: key });
+          });
+        }
+        options?.onSuccess?.(data, variables, context, mutationContext);
+      },
+      ...options,
+    }),
+  );
 }

--- a/frontend/src/hooks/useCreateRecord.ts
+++ b/frontend/src/hooks/useCreateRecord.ts
@@ -7,10 +7,8 @@ import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 import { ApiResponse } from '@/lib/types/response';
 import {
-  refreshGroupData,
-  refreshHomeData,
-  refreshRecordData,
-  refreshSharedData,
+  refreshRecordAndHomeData,
+  refreshRecordGroupAndSharedData,
 } from '@/lib/actions/revalidate';
 import { ApiError } from '@/lib/utils/errorHandler';
 import { handlePublishError } from '@/lib/utils/error/publishHandler';
@@ -37,7 +35,7 @@ export const useCreateRecord = (
   const { userId } = useAuthStore();
 
   const invalidateQuery = async (groupId?: string) => {
-    await Promise.all([refreshRecordData(), refreshHomeData()]);
+    await refreshRecordAndHomeData();
 
     const invalidations = [
       queryClient.invalidateQueries({ queryKey: ['my', 'records'] }),
@@ -54,8 +52,7 @@ export const useCreateRecord = (
         queryClient.invalidateQueries({
           queryKey: ['shared'],
         }),
-        refreshGroupData(groupId),
-        refreshSharedData(),
+        refreshRecordGroupAndSharedData(groupId),
       );
     }
 

--- a/frontend/src/hooks/useMediaUpload.ts
+++ b/frontend/src/hooks/useMediaUpload.ts
@@ -7,6 +7,8 @@ import { getImageDimensions } from '@/lib/utils/image';
 import { useState } from 'react';
 import * as Sentry from '@sentry/nextjs';
 import { logger } from '@/lib/utils/logger';
+import { toast } from 'sonner';
+import type { ApiError } from '@/lib/utils/errorHandler';
 
 export const useMediaUpload = () => {
   const [isUploading, setIsUploading] = useState(false);
@@ -45,6 +47,12 @@ export const useMediaUpload = () => {
 
       return successIds; // 최종적으로 전달할 mediaId 배열 반환
     } catch (error) {
+      if ((error as ApiError)?.code === 'TIMEOUT') {
+        toast.error('이미지 업로드 시간이 초과되었습니다.', {
+          description: '네트워크 연결을 확인하고 다시 시도해 주세요.',
+        });
+      }
+
       Sentry.captureException(error, {
         tags: {
           context: 'media',

--- a/frontend/src/lib/actions/revalidate.ts
+++ b/frontend/src/lib/actions/revalidate.ts
@@ -10,6 +10,16 @@ export async function refreshRecordData() {
   revalidatePath('/my', 'layout');
 }
 
+export async function refreshRecordAndHomeData() {
+  revalidatePath('/', 'page');
+  revalidatePath('/my', 'layout');
+}
+
+export async function refreshRecordGroupAndSharedData(groupId: string) {
+  revalidatePath(`/group/${groupId}`, 'layout');
+  revalidatePath('/shared');
+}
+
 export async function refreshGroupData(groupId: string) {
   revalidatePath(`/group/${groupId}`, 'layout');
 }

--- a/frontend/src/lib/api/api.ts
+++ b/frontend/src/lib/api/api.ts
@@ -33,6 +33,7 @@ interface FetchOptions extends RequestInit {
   maxRetries?: number; // 최대 재시도 횟수
   retryDelay?: number; // 초기 재시도 지연 시간 ms
   skipAuth?: boolean; // 인증 헤더 제외 (로그인, 회원가입 등)
+  timeout?: number; // 타임아웃 ms (0이면 비활성, 기본값 10000)
 }
 
 /**
@@ -69,9 +70,20 @@ async function fetchWithRetry<T>(
   maxRetries: number,
   retryDelay: number,
   skipAuth: boolean,
+  timeout: number,
 ) {
+  const controller = timeout > 0 ? new AbortController() : undefined;
+  const timeoutId = controller
+    ? setTimeout(() => controller.abort(), timeout)
+    : undefined;
+
   try {
-    const response = await fetch(url, fetchOptions);
+    const response = await fetch(url, {
+      ...fetchOptions,
+      signal: controller?.signal,
+    });
+
+    clearTimeout(timeoutId);
 
     if (response.status === 204) {
       return {
@@ -182,6 +194,7 @@ async function fetchWithRetry<T>(
         maxRetries,
         retryDelay,
         skipAuth,
+        timeout,
       );
     }
 
@@ -190,7 +203,22 @@ async function fetchWithRetry<T>(
       headers: response.headers,
     };
   } catch (error) {
+    clearTimeout(timeoutId);
+
     const err = error instanceof Error ? error : new Error('unknown error');
+
+    // 타임아웃(AbortError) - 재시도 없이 즉시 반환
+    if (err.name === 'AbortError') {
+      return {
+        success: false,
+        data: null,
+        error: {
+          code: 'TIMEOUT',
+          message: '요청 시간이 초과되었습니다.',
+          details: {},
+        },
+      };
+    }
 
     // JSON 파싱 에러는 재시도하지 않음
     if (
@@ -260,6 +288,7 @@ async function fetchWithRetry<T>(
       maxRetries,
       retryDelay,
       skipAuth,
+      timeout,
     );
   }
 }
@@ -280,6 +309,7 @@ export async function fetchApi<T>(
     maxRetries = 3,
     retryDelay = 1000,
     skipAuth = false,
+    timeout = 10000,
     ...fetchOptions
   } = options;
 
@@ -332,6 +362,7 @@ export async function fetchApi<T>(
     maxRetries,
     retryDelay,
     skipAuth,
+    timeout,
   );
 }
 

--- a/frontend/src/lib/api/presignMedia.ts
+++ b/frontend/src/lib/api/presignMedia.ts
@@ -1,4 +1,5 @@
 import { post } from './api';
+import { createApiError } from '@/lib/utils/errorHandler';
 
 export interface PresignRequestFile {
   contentType: string;
@@ -18,7 +19,7 @@ export const postMediaPresign = async (files: PresignRequestFile[]) => {
       files: files.map((f) => ({ contentType: f.contentType, size: f.size })),
     },
   );
-  if (!response.success) throw new Error('Presign URL 발급 실패');
+  if (!response.success) throw createApiError(response);
   return response.data.items;
 };
 
@@ -44,6 +45,6 @@ export const postMediaComplete = async (mediaIds: string[]) => {
   const response = await post<{ successIds: string[] }>('/api/media/complete', {
     mediaIds,
   });
-  if (!response.success) throw new Error('미디어 완료 확정 실패');
+  if (!response.success) throw createApiError(response);
   return response.data.successIds;
 };


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- #243 
- Close #243

## 작업 내용 + 스크린샷

### 1. API 요청 타임아웃 추가

fetch 요청에 대해 기본 10초 타임아웃을 적용했어요.

- `FetchOptions` 에 `timeout` 옵션 추가 (기본값 10초)
- `AbortController`로 타임아웃 초과 시 요청 중단
- 타임아웃은 재시도 없이 즉시 `TIMEOUT` 에러 코드 반환

물론 개별 요청에서 타임아웃 시간을 조정할 수 있어요.
```typescript
post('/api/endpoint', body, { timeout: 30000 }) // 30초
post('/api/endpoint', body, { timeout: 0 })     // 타임아웃 없음
```

### 2. 타임아웃 발생 시 사용자 안내

타임아웃 에러 발생시 자동으로 toast 안내가 표시되도록 했어요.
tanstack query의 전역 에러 핸들러에서 타임아웃 에러를 감지하도록 수정해줬어요.

- `provider.tsx`의 `QueryCache.onError`, `MutationCache.onError`에서 `TIMEOUT` 에러 감지
- "요청 시간이 초과되었습니다. 네트워크 연결을 확인하고 다시 시도해 주세요."로 안내
- 이미지 업로드는 타임아웃시 "이미지 업로드 시간이 초과되었습니다" 별도 안내

### 3. mutation 중복 호출 방지

버튼 연속 클릭으로 인한 중복 API 요청을 차단하도록 수정했어요.
기존에는 post/patch/delete와 같은 api 요청시에 연속해서 버튼을 클릭하면 클릭한 횟수만큼 fetch 요청이 실행되었어요.

https://github.com/user-attachments/assets/af182737-4df5-4cf0-ab3c-586bcb75ac50

이를 공통 유틸 함수인 `useApiPost`, `useApiPut`, `useApiPatch`, `useApiDelete` 모두에 `withPendingGuard`로 요청이 진행중일 경우(`isPending`) 이후 요청을 무시하도록 수정해줬어요.

https://github.com/user-attachments/assets/e2bebb5b-6a4c-4829-84d9-c29e24aed841

여기서 `add POST` 요청이 중복되어 발생하는걸 발견했고, 캐시 무효화를 위한 server action이 2번 호출되어 발생하는 문제라는걸 파악했어요.

next.js server action은 현재 페이지 url로 POST 요청을 보내기 때문에 동시 호출시에 중복 네트워크 요청이 발생하는거에요.
그래서 한 번의 server action으로 원하는 로직이 실행되도록 수정해줬어요. (캐시 무효화 한번에 실행시키기)

https://github.com/user-attachments/assets/456e591d-46bf-47bf-9899-afca9449c763

## 실제 걸린 시간

- 6h

## 작업하며 고민했던 점(선택)

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [x] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
