### PR TITLE
커버 기본값 복귀용 DELETE API 추가 및 e2e 테스트 작성

### DIFF
--- a/backend/src/modules/group/controller/group-management.controller.ts
+++ b/backend/src/modules/group/controller/group-management.controller.ts
@@ -122,6 +122,27 @@ export class GroupManagementController {
   }
 
   @UseGuards(GroupRoleGuard)
+  @GroupRoles(GroupRoleEnum.EDITOR)
+  @Delete(':groupId/cover')
+  @ApiOperation({
+    summary: '그룹 커버 이미지 초기화',
+    description: '그룹의 커버 이미지를 기본값으로 되돌립니다.',
+  })
+  @ApiParam({ name: 'groupId', description: '그룹 ID' })
+  @ApiWrappedOkResponse({ type: Object })
+  async resetGroupCover(
+    @User() user: MyJwtPayload,
+    @Param('groupId') groupId: string,
+  ) {
+    return {
+      data: await this.groupManagementService.resetGroupCover(
+        user.sub,
+        groupId,
+      ),
+    };
+  }
+
+  @UseGuards(GroupRoleGuard)
   @GroupRoles(GroupRoleEnum.VIEWER)
   @Get(':groupId/settings')
   @ApiOperation({

--- a/backend/src/modules/group/controller/group-record.controller.ts
+++ b/backend/src/modules/group/controller/group-record.controller.ts
@@ -1,7 +1,8 @@
 import {
   Controller,
-  Patch,
+  Delete,
   Get,
+  Patch,
   Param,
   Body,
   Query,
@@ -74,6 +75,37 @@ export class GroupRecordController {
       month,
       body.assetId,
       body.sourcePostId,
+    );
+
+    return { data: result };
+  }
+
+  /**
+   * 그룹 월별 커버 초기화
+   */
+  @UseGuards(GroupRoleGuard)
+  @GroupRoles(GroupRoleEnum.EDITOR)
+  @Delete(':groupId/archives/months/:yyyy_mm/cover')
+  @ApiOperation({
+    summary: '그룹 월별 커버 초기화',
+    description:
+      '특정 월의 카드 커버를 기본값으로 되돌립니다. EDITOR 이상의 권한이 필요합니다.',
+  })
+  @ApiParam({ name: 'groupId', description: '그룹 ID' })
+  @ApiParam({ name: 'yyyy_mm', description: '연-월 (예: 2026-01)' })
+  @ApiWrappedOkResponse({ type: Object })
+  async resetMonthCover(
+    @User() user: MyJwtPayload,
+    @Param('groupId') groupId: string,
+    @Param('yyyy_mm') yyyy_mm: string,
+  ) {
+    const { year, month } = parseYearMonth(yyyy_mm);
+
+    const result = await this.groupRecordService.resetMonthCover(
+      user.sub,
+      groupId,
+      year,
+      month,
     );
 
     return { data: result };

--- a/backend/src/modules/group/group.module.ts
+++ b/backend/src/modules/group/group.module.ts
@@ -16,6 +16,7 @@ import { GroupRecordService } from './service/group-record.service';
 import { GroupInviteService } from './service/group-invite.service';
 import { GroupManagementService } from './service/group-management.service';
 import { GroupActivityService } from './service/group-activity.service';
+import { GroupRoleGuard } from './guards/group-roles.guard';
 
 import { User } from '../user/entity/user.entity';
 import { Post } from '../post/entity/post.entity';
@@ -51,6 +52,7 @@ import { AuthModule } from '../auth/auth.module';
     GroupInviteService,
     GroupManagementService,
     GroupActivityService,
+    GroupRoleGuard,
   ],
   controllers: [
     GroupController,
@@ -59,6 +61,6 @@ import { AuthModule } from '../auth/auth.module';
     GroupInviteController,
     GroupActivityController,
   ],
-  exports: [GroupService, GroupActivityService], // GroupRoleGuard에서 사용
+  exports: [GroupService, GroupActivityService, GroupRoleGuard],
 })
 export class GroupModule {}

--- a/backend/src/modules/group/guards/group-roles.guard.ts
+++ b/backend/src/modules/group/guards/group-roles.guard.ts
@@ -1,13 +1,17 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { GROUP_ROLE_KEY } from './group-roles.decorator';
-import { GroupService } from '../service/group.service';
 import { GroupRoleEnum } from '@/enums/group-role.enum';
+import { GroupMember } from '../entity/group_member.entity';
+import { GroupService } from '../service/group.service';
 
 import type { Request } from 'express';
 import type { MyJwtPayload } from '../../auth/auth.type';
 
-type RequestWithUser = Request & { user?: MyJwtPayload };
+type RequestWithUser = Request & {
+  user?: MyJwtPayload;
+  groupMember?: Pick<GroupMember, 'id' | 'groupId' | 'userId' | 'role'>;
+};
 
 // 역할 우선순위 정의
 const rolePriority: Record<GroupRoleEnum, number> = {
@@ -38,8 +42,15 @@ export class GroupRoleGuard implements CanActivate {
     const userId = user.sub;
     const groupId = request.params.groupId;
 
-    const member = await this.groupService.findMember(userId, groupId);
-    if (!member) return false;
+    const member = await this.groupService.ensureMember(userId, groupId, {
+      select: {
+        id: true,
+        groupId: true,
+        userId: true,
+        role: true,
+      },
+    });
+    request.groupMember = member;
 
     // 최소 요구되는 역할 중 하나라도 만족하면 true
     return requiredRoles.some(

--- a/backend/src/modules/group/service/group-management.service.ts
+++ b/backend/src/modules/group/service/group-management.service.ts
@@ -316,6 +316,47 @@ export class GroupManagementService {
     };
   }
 
+  async resetGroupCover(
+    userId: string,
+    groupId: string,
+  ): Promise<{
+    groupId: string;
+    cover: null;
+    updatedAt: Date;
+  }> {
+    const member = await this.groupMemberRepo.findOne({
+      where: { groupId, userId },
+    });
+
+    if (!member) {
+      const groupExists = await this.groupRepo.exists({
+        where: { id: groupId },
+      });
+      if (!groupExists) {
+        throw new NotFoundException('존재하지 않는 그룹입니다.');
+      }
+      throw new ForbiddenException('그룹 멤버가 아닙니다.');
+    }
+
+    await this.groupRepo.update(groupId, {
+      coverMediaId: null,
+      coverSourcePostId: null,
+    });
+
+    await this.groupActivityService.recordActivity({
+      groupId,
+      type: GroupActivityType.GROUP_COVER_UPDATE,
+      actorIds: [userId],
+      meta: { reset: true },
+    });
+
+    return {
+      groupId,
+      cover: null,
+      updatedAt: new Date(),
+    };
+  }
+
   /** 그룹 설정 정보 조회 */
   async getGroupSettings(
     userId: string,

--- a/backend/src/modules/group/service/group-management.service.ts
+++ b/backend/src/modules/group/service/group-management.service.ts
@@ -31,6 +31,7 @@ import {
   CoverCandidateItemDto,
 } from '../dto/get-group-cover-candidates.dto';
 import { GroupActivityService } from './group-activity.service';
+import { GroupService } from './group.service';
 
 import {
   resolveGroupNickname,
@@ -60,6 +61,7 @@ export class GroupManagementService {
     @InjectRepository(MediaAsset)
     private readonly mediaAssetRepo: Repository<MediaAsset>,
     private readonly groupActivityService: GroupActivityService,
+    private readonly groupService: GroupService,
   ) {}
 
   /** 멤버 초대 (ADMIN만 가능하도록 Controller/Guard에서 제한) */
@@ -92,14 +94,6 @@ export class GroupManagementService {
     groupId: string,
     targetUserId: string,
   ) {
-    const requesterMember = await this.groupMemberRepo.findOne({
-      where: { groupId, userId: requesterId },
-    });
-
-    if (!requesterMember || requesterMember.role !== GroupRoleEnum.ADMIN) {
-      throw new ForbiddenException('추방 권한이 없습니다.');
-    }
-
     // 대상이 방장인지 확인 (방장은 추방 불가)
     const group = await this.groupRepo.findOne({
       where: { id: groupId },
@@ -245,23 +239,7 @@ export class GroupManagementService {
     assetId: string,
     sourcePostId: string,
   ): Promise<UpdateGroupCoverResponseDto> {
-    // 1. 그룹 존재 확인 및 멤버 여부 확인
-    const member = await this.groupMemberRepo.findOne({
-      where: { groupId, userId },
-      relations: ['group'],
-    });
-
-    if (!member) {
-      const groupExists = await this.groupRepo.exists({
-        where: { id: groupId },
-      });
-      if (!groupExists) {
-        throw new NotFoundException('존재하지 않는 그룹입니다.');
-      }
-      throw new ForbiddenException('그룹 멤버가 아닙니다.');
-    }
-
-    // 2. 게시글 존재 및 그룹 소속 확인
+    // 1. 게시글 존재 및 그룹 소속 확인
     const post = await this.postRepo.findOne({
       where: { id: sourcePostId },
     });
@@ -274,7 +252,7 @@ export class GroupManagementService {
       throw new BadRequestException('해당 그룹의 게시글이 아닙니다.');
     }
 
-    // 3. Asset 존재 및 게시글 내 포함 여부 확인 (Block 이미지인지)
+    // 2. Asset 존재 및 게시글 내 포함 여부 확인 (Block 이미지인지)
     const postMedia = await this.postMediaRepo.findOne({
       where: {
         postId: sourcePostId,
@@ -290,7 +268,7 @@ export class GroupManagementService {
       );
     }
 
-    // 4. 그룹 정보 업데이트
+    // 3. 그룹 정보 업데이트
     await this.groupRepo.update(groupId, {
       coverMediaId: assetId,
       coverSourcePostId: sourcePostId,
@@ -303,7 +281,7 @@ export class GroupManagementService {
       meta: null,
     });
 
-    // 5. 응답 반환
+    // 4. 응답 반환
     return {
       groupId,
       cover: {
@@ -324,20 +302,6 @@ export class GroupManagementService {
     cover: null;
     updatedAt: Date;
   }> {
-    const member = await this.groupMemberRepo.findOne({
-      where: { groupId, userId },
-    });
-
-    if (!member) {
-      const groupExists = await this.groupRepo.exists({
-        where: { id: groupId },
-      });
-      if (!groupExists) {
-        throw new NotFoundException('존재하지 않는 그룹입니다.');
-      }
-      throw new ForbiddenException('그룹 멤버가 아닙니다.');
-    }
-
     await this.groupRepo.update(groupId, {
       coverMediaId: null,
       coverSourcePostId: null,
@@ -362,22 +326,7 @@ export class GroupManagementService {
     userId: string,
     groupId: string,
   ): Promise<GetGroupSettingsResponseDto> {
-    // 1. 그룹 존재 및 멤버 권한 확인
-    const requesterMember = await this.groupMemberRepo.findOne({
-      where: { groupId, userId },
-    });
-
-    if (!requesterMember) {
-      const groupExists = await this.groupRepo.exists({
-        where: { id: groupId },
-      });
-      if (!groupExists) {
-        throw new NotFoundException('존재하지 않는 그룹입니다.');
-      }
-      throw new ForbiddenException('그룹 멤버가 아닙니다.');
-    }
-
-    // 2. 그룹 정보 조회 (커버 이미지 및 owner 포함)
+    // 1. 그룹 정보 조회 (커버 이미지 및 owner 포함)
     const group = await this.groupRepo.findOne({
       where: { id: groupId },
       relations: ['coverMedia', 'owner'],
@@ -385,7 +334,7 @@ export class GroupManagementService {
 
     if (!group) throw new NotFoundException('존재하지 않는 그룹입니다.');
 
-    // 3. 전체 멤버 조회 (유저 정보 및 프로필 이미지 포함)
+    // 2. 전체 멤버 조회 (유저 정보 및 프로필 이미지 포함)
     const members = await this.groupMemberRepo.find({
       where: { groupId },
       relations: ['user', 'profileMedia'],
@@ -396,7 +345,7 @@ export class GroupManagementService {
       (member): member is GroupMember & { user: User } => Boolean(member.user),
     );
 
-    // 4. 응답 구성
+    // 3. 응답 구성
     const meMember = activeMembers.find((m) => m.userId === userId);
     if (!meMember) throw new ForbiddenException('그룹 멤버가 아닙니다.');
 
@@ -451,24 +400,10 @@ export class GroupManagementService {
     userId: string,
     groupId: string,
   ): Promise<GetGroupMemberMeResponseDto> {
-    // 1. 멤버 조회 (유저 및 프로필 미디어 포함)
-    const member = await this.groupMemberRepo.findOne({
-      where: { groupId, userId },
+    const member = await this.groupService.ensureMember(userId, groupId, {
       relations: ['user', 'profileMedia'],
     });
 
-    // 2. 멤버가 없는 경우 예외 처리
-    if (!member || !member.user) {
-      const groupExists = await this.groupRepo.exists({
-        where: { id: groupId },
-      });
-      if (!groupExists) {
-        throw new NotFoundException('존재하지 않는 그룹입니다.');
-      }
-      throw new ForbiddenException('그룹 멤버가 아닙니다.');
-    }
-
-    // 3. 응답 DTO 반환
     return {
       groupId: member.groupId,
       userId: member.userId,
@@ -489,19 +424,9 @@ export class GroupManagementService {
     userId: string,
     groupId: string,
   ): Promise<GetGroupPermissionResponseDto> {
-    const member = await this.groupMemberRepo.findOne({
-      where: { groupId, userId },
+    const member = await this.groupService.ensureMember(userId, groupId, {
       select: { role: true },
     });
-    if (!member) {
-      const groupExists = await this.groupRepo.exists({
-        where: { id: groupId },
-      });
-      if (!groupExists) {
-        throw new NotFoundException('존재하지 않는 그룹입니다.');
-      }
-      throw new ForbiddenException('그룹 멤버가 아닙니다.');
-    }
     return { role: member.role };
   }
 
@@ -519,20 +444,9 @@ export class GroupManagementService {
     }
 
     // 2. 멤버 조회 (유저 포함)
-    const member = await this.groupMemberRepo.findOne({
-      where: { groupId, userId },
+    const member = await this.groupService.ensureMember(userId, groupId, {
       relations: ['user'],
     });
-
-    if (!member || !member.user) {
-      const groupExists = await this.groupRepo.exists({
-        where: { id: groupId },
-      });
-      if (!groupExists) {
-        throw new NotFoundException('존재하지 않는 그룹입니다.');
-      }
-      throw new ForbiddenException('그룹 멤버가 아닙니다.');
-    }
 
     const beforeNickname = member.nicknameInGroup ?? null;
 
@@ -587,21 +501,13 @@ export class GroupManagementService {
 
   /** 그룹 커버 후보 조회 (월 단위, 커서 페이지네이션) */
   async getGroupCoverCandidates(
-    userId: string,
+    _userId: string,
     groupId: string,
     query: GetGroupCoverCandidatesQueryDto,
   ): Promise<GetGroupCoverCandidatesResponseDto> {
     const { month, cursor, limit = 20 } = query;
 
-    // 1. 그룹 멤버십 확인
-    const member = await this.groupMemberRepo.findOne({
-      where: { groupId, userId },
-    });
-    if (!member) {
-      throw new ForbiddenException('그룹 멤버가 아닙니다.');
-    }
-
-    // 2. 날짜 범위 계산 (UTC 기준)
+    // 1. 날짜 범위 계산 (UTC 기준)
     // month string: "YYYY-MM"
     const [yearStr, monthStr] = month.split('-');
     const year = parseInt(yearStr, 10);
@@ -610,7 +516,7 @@ export class GroupManagementService {
     const startOfMonth = new Date(Date.UTC(year, m - 1, 1, 0, 0, 0));
     const endOfMonth = new Date(Date.UTC(year, m, 0, 23, 59, 59, 999));
 
-    // 3. 커서 디코딩
+    // 2. 커서 디코딩
     // Cursor format: Base64(timestamp__id)
     let cursorTime: Date | null = null;
     let cursorId: string | null = null;
@@ -629,7 +535,7 @@ export class GroupManagementService {
       }
     }
 
-    // 4. Query Builder 생성
+    // 3. Query Builder 생성
     const qb = this.postRepo.createQueryBuilder('post');
 
     qb.leftJoinAndSelect('post.group', 'group')

--- a/backend/src/modules/group/service/group-record.service.ts
+++ b/backend/src/modules/group/service/group-record.service.ts
@@ -133,6 +133,31 @@ export class GroupRecordService {
     return { coverAssetId, sourcePostId };
   }
 
+  async resetMonthCover(
+    userId: string,
+    groupId: string,
+    year: number,
+    month: number,
+  ) {
+    const group = await this.groupRepo.findOne({
+      where: { id: groupId },
+    });
+    if (!group) {
+      throw new NotFoundException('그룹을 찾을 수 없습니다.');
+    }
+
+    await this.groupMonthCoverRepo.delete({ groupId, year, month });
+
+    await this.groupActivityService.recordActivity({
+      groupId,
+      type: GroupActivityType.GROUP_MONTH_COVER_UPDATE,
+      actorIds: [userId],
+      meta: { year, month, reset: true },
+    });
+
+    return { coverAssetId: null, sourcePostId: null };
+  }
+
   /**
    * 그룹 월별 아카이브 조회
    */

--- a/backend/src/modules/group/service/group.service.ts
+++ b/backend/src/modules/group/service/group.service.ts
@@ -8,7 +8,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, DataSource } from 'typeorm';
+import { FindOneOptions, Repository, DataSource } from 'typeorm';
 import { Group } from '../entity/group.entity';
 import { GroupMember } from '../entity/group_member.entity';
 import { GroupRoleEnum } from '@/enums/group-role.enum';
@@ -24,6 +24,8 @@ import { GetGroupsResponseDto, GroupItemDto } from '../dto/get-groups.dto';
 import { GroupActivityService } from './group-activity.service';
 
 import { resolveGroupNickname } from '../utils/group-nickname';
+
+type GroupMemberLookupOptions = Omit<FindOneOptions<GroupMember>, 'where'>;
 
 @Injectable()
 export class GroupService {
@@ -100,20 +102,35 @@ export class GroupService {
     return savedGroup;
   }
 
-  /** 그룹 멤버 조회 (Guard 핵심) */
   async findMember(
     userId: string,
     groupId: string,
+    options: GroupMemberLookupOptions = {},
   ): Promise<GroupMember | null> {
-    const member = await this.groupMemberRepo.findOne({
-      where: {
-        userId,
-        groupId,
-      },
-      relations: ['group', 'user'],
+    return this.groupMemberRepo.findOne({
+      ...options,
+      where: { userId, groupId },
     });
-    if (!member || !member.user) return null;
-    return member;
+  }
+
+  async ensureMember(
+    userId: string,
+    groupId: string,
+    options: GroupMemberLookupOptions = {},
+  ): Promise<GroupMember> {
+    const member = await this.findMember(userId, groupId, options);
+    if (member) {
+      return member;
+    }
+
+    const groupExists = await this.groupRepo.exists({
+      where: { id: groupId },
+    });
+    if (!groupExists) {
+      throw new NotFoundException('존재하지 않는 그룹입니다.');
+    }
+
+    throw new ForbiddenException('그룹 멤버가 아닙니다.');
   }
 
   /** 그룹 삭제 (방장만 가능) */

--- a/backend/src/modules/user/user.controller.ts
+++ b/backend/src/modules/user/user.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Patch,
   Param,
@@ -86,6 +87,28 @@ export class UserController {
 
     await this.userService.updateMonthCover(userId, year, month, body.assetId);
     return { data: { assetId: body.assetId } };
+  }
+
+  @Delete('archives/months/:yyyy_mm/cover')
+  @ApiOperation({
+    summary: '사용자 월별 커버 초기화',
+    description: '특정 월의 카드 커버를 기본값으로 되돌립니다.',
+  })
+  @ApiParam({ name: 'yyyy_mm', description: '연-월 (예: 2026-01)' })
+  @ApiWrappedOkResponse({ type: Object })
+  async resetMonthCover(
+    @User() user: MyJwtPayload,
+    @Param('yyyy_mm') yyyy_mm: string,
+  ) {
+    const userId = user?.sub;
+    if (!userId) {
+      throw new UnauthorizedException('Access token is required.');
+    }
+
+    const { year, month } = parseYearMonth(yyyy_mm);
+    await this.userService.resetMonthCover(userId, year, month);
+
+    return { data: { coverAssetId: null } };
   }
 
   @Get('archives/days')

--- a/backend/src/modules/user/user.service.ts
+++ b/backend/src/modules/user/user.service.ts
@@ -438,6 +438,10 @@ export class UserService {
     }
   }
 
+  async resetMonthCover(userId: string, year: number, month: number) {
+    await this.userMonthCoverRepo.delete({ userId, year, month });
+  }
+
   private cleanupStaleUserMonthCovers(userId: string) {
     void this.userMonthCoverRepo
       .createQueryBuilder()

--- a/backend/test/cover.e2e-spec.ts
+++ b/backend/test/cover.e2e-spec.ts
@@ -1,0 +1,165 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import type { Repository } from 'typeorm';
+
+import { AppModule } from '../src/app.module';
+import { GoogleStrategy } from '../src/modules/auth/strategies/google.strategy';
+import { KakaoStrategy } from '../src/modules/auth/strategies/kakao.strategy';
+import { User } from '../src/modules/user/entity/user.entity';
+import { Group } from '../src/modules/group/entity/group.entity';
+import { GroupMember } from '../src/modules/group/entity/group_member.entity';
+import { UserMonthCover } from '../src/modules/user/entity/user-month-cover.entity';
+import { GroupMonthCover } from '../src/modules/group/entity/group-month-cover.entity';
+import { GroupRoleEnum } from '../src/enums/group-role.enum';
+
+describe('Cover Reset API (e2e)', () => {
+  let app: INestApplication<App>;
+  let userRepository: Repository<User>;
+  let groupRepository: Repository<Group>;
+  let groupMemberRepository: Repository<GroupMember>;
+  let userMonthCoverRepository: Repository<UserMonthCover>;
+  let groupMonthCoverRepository: Repository<GroupMonthCover>;
+  let user: User;
+  let group: Group;
+  let accessToken: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(GoogleStrategy)
+      .useValue({})
+      .overrideProvider(KakaoStrategy)
+      .useValue({})
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+
+    userRepository = app.get(getRepositoryToken(User));
+    groupRepository = app.get(getRepositoryToken(Group));
+    groupMemberRepository = app.get(getRepositoryToken(GroupMember));
+    userMonthCoverRepository = app.get(getRepositoryToken(UserMonthCover));
+    groupMonthCoverRepository = app.get(getRepositoryToken(GroupMonthCover));
+    const jwtService = app.get(JwtService);
+
+    user = await userRepository.save(
+      userRepository.create({
+        email: 'cover-reset-owner@example.com',
+        nickname: 'cover-owner',
+        provider: 'kakao',
+        providerId: `cover-owner-${Date.now()}`,
+      }),
+    );
+    accessToken = jwtService.sign({ sub: user.id });
+
+    group = await groupRepository.save(
+      groupRepository.create({
+        name: 'cover-reset-group',
+        owner: { id: user.id } as User,
+      }),
+    );
+
+    await groupMemberRepository.save(
+      groupMemberRepository.create({
+        groupId: group.id,
+        userId: user.id,
+        role: GroupRoleEnum.ADMIN,
+        nicknameInGroup: user.nickname,
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    if (group?.id) {
+      await groupMonthCoverRepository.delete({ groupId: group.id });
+      await groupMemberRepository.delete({ groupId: group.id });
+      await groupRepository.delete({ id: group.id });
+    }
+    if (user?.id) {
+      await userMonthCoverRepository.delete({ userId: user.id });
+      await userRepository.delete({ id: user.id });
+    }
+    if (app) await app.close();
+  });
+
+  it('DELETE /user/archives/months/:yyyy_mm/cover should clear custom user month cover', async () => {
+    await userMonthCoverRepository.save(
+      userMonthCoverRepository.create({
+        userId: user.id,
+        year: 2026,
+        month: 3,
+        coverAssetId: null,
+      }),
+    );
+
+    const response = await request(app.getHttpServer())
+      .delete('/user/archives/months/2026-03/cover')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      data: { coverAssetId: null },
+    });
+
+    const cover = await userMonthCoverRepository.findOne({
+      where: { userId: user.id, year: 2026, month: 3 },
+    });
+    expect(cover).toBeNull();
+  });
+
+  it('DELETE /groups/:groupId/archives/months/:yyyy_mm/cover should clear custom group month cover', async () => {
+    await groupMonthCoverRepository.save(
+      groupMonthCoverRepository.create({
+        groupId: group.id,
+        year: 2026,
+        month: 3,
+        coverAssetId: null,
+        sourcePostId: null,
+      }),
+    );
+
+    const response = await request(app.getHttpServer())
+      .delete(`/groups/${group.id}/archives/months/2026-03/cover`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      data: { coverAssetId: null, sourcePostId: null },
+    });
+
+    const cover = await groupMonthCoverRepository.findOne({
+      where: { groupId: group.id, year: 2026, month: 3 },
+    });
+    expect(cover).toBeNull();
+  });
+
+  it('DELETE /groups/:groupId/cover should reset group cover to default', async () => {
+    const response = await request(app.getHttpServer())
+      .delete(`/groups/${group.id}/cover`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      data: { groupId: group.id, cover: null },
+    });
+
+    const updatedGroup = await groupRepository.findOne({
+      where: { id: group.id },
+    });
+    expect(updatedGroup).not.toBeNull();
+    expect(updatedGroup?.coverMediaId ?? null).toBeNull();
+    expect(updatedGroup?.coverSourcePostId ?? null).toBeNull();
+  });
+});


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)
- 커버를 기본값으로 되돌리는 전용 `DELETE` API를 추가했습니다.
- 기존 `PATCH`는 “특정 이미지로 설정”, 신규 `DELETE`는 “기본값 복귀”로 역할을 분리했습니다.
- 연관 이슈: #이슈번호

## 작업 내용 + 스크린샷
- 사용자 월별 커버 초기화 API 추가
- 그룹 월별 커버 초기화 API 추가
- 그룹 대표 커버 초기화 API 추가
- 각 서비스에 커버 초기화(커스텀 커버 제거) 로직 추가
- `cover.e2e-spec.ts` 테스트 파일 추가 (신규 DELETE API 3종 검증)
- 스크린샷: 없음

## 실제 걸린 시간
- 약 2시간 30분

## 작업하며 고민했던 점(선택)
- `PATCH + null` 허용 vs `DELETE` 분리를 비교했고, API 의도 명확성과 유지보수성을 위해 `DELETE` 분리로 결정했습니다.
- 권한 검증은 Guard, 도메인 규칙 검증은 Service로 분리하는 방향을 유지했습니다.

## 테스트 실행 여부

- [x] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)
- 추가된 엔드포인트
- `DELETE /user/archives/months/:yyyy_mm/cover`
- `DELETE /groups/:groupId/archives/months/:yyyy_mm/cover`
- `DELETE /groups/:groupId/cover`
- 로컬에서는 `backend build` 통과 확인했습니다.
- e2e는 테스트 DB 연결 상태에서 `pnpm test:be:e2e`로 최종 확인 부탁드립니다.

## 시각 자료(이미지/영상, 있다면)(선택)
- 없음
