### PR TITLE
안드로이드 모바일 테스트를 위한 빌드 actions 파일 추가

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,53 @@
+name: Android APK Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  android:
+    runs-on: ubuntu-latest
+    name: Build Android Debug APK
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Install mobile-app dependencies
+        working-directory: mobile-app
+        run: npm ci
+
+      - name: Sync Capacitor
+        working-directory: mobile-app
+        run: npx cap sync android
+
+      - name: Grant execute permission for gradlew
+        working-directory: mobile-app/android
+        run: chmod +x gradlew
+
+      - name: Build Debug APK
+        working-directory: mobile-app/android
+        run: ./gradlew assembleDebug --no-daemon
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: mobile-app/android/app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 7


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- 안드로이드 스튜디오의 용량이 커 현재 노트북에서 실행할 수 없음
- 안드로이드 환경에서의 서비스 상태를 확인하기 위해 빌드 후 핸드폰에서 다운 받을 수 있도록 함

<br />

- 빌드 시간이 꽤 걸릴 것을 고려해 수동 actions 실행 설정
- android apk 빌드 후 핸드폰으로 다운받아 확인할 수 있도록 함

## 작업 내용 + 스크린샷

## 실제 걸린 시간

0.5h

## 작업하며 고민했던 점(선택)

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
