### PR TITLE
Android APK 빌드 GitHub Actions 수정

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -22,20 +22,22 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
 
-      - name: Install frontend dependencies
-        working-directory: frontend
-        run: npm ci
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
 
-      - name: Install mobile-app dependencies
-        working-directory: mobile-app
-        run: npm ci
+      - name: Install dependencies
+        run: pnpm install --filter mobile-app
 
       - name: Sync Capacitor
         working-directory: mobile-app
-        run: npx cap sync android
+        run: pnpm exec cap sync android
+
+      - name: Create local.properties
+        working-directory: mobile-app/android
+        run: echo "sdk.dir=/usr/local/lib/android/sdk" > local.properties
 
       - name: Grant execute permission for gradlew
         working-directory: mobile-app/android


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- 빌드된 `app-debug.apk`를 Artifacts로 7일간 보관
- pnpm workspace 모노레포 구조 반영

## 작업 내용 + 스크린샷

## 실제 걸린 시간

## 작업하며 고민했던 점(선택)

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
