### PR TITLE
안드로이드 모바일로 테스트하며 발견한 버그 수정

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
 
       - name: Set up Node.js

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -22,20 +22,22 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
 
-      - name: Install frontend dependencies
-        working-directory: frontend
-        run: npm ci
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
 
-      - name: Install mobile-app dependencies
-        working-directory: mobile-app
-        run: npm ci
+      - name: Install dependencies
+        run: pnpm install --filter mobile-app
 
       - name: Sync Capacitor
         working-directory: mobile-app
-        run: npx cap sync android
+        run: pnpm exec cap sync android
+
+      - name: Create local.properties
+        working-directory: mobile-app/android
+        run: echo "sdk.dir=/usr/local/lib/android/sdk" > local.properties
 
       - name: Grant execute permission for gradlew
         working-directory: mobile-app/android

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -2,6 +2,11 @@ name: Android APK Build
 
 on:
   workflow_dispatch:
+    inputs:
+      server_url:
+        description: '앱이 로드할 서버 URL (비워두면 프로덕션 https://ittda.vercel.app 사용)'
+        required: false
+        default: ''
 
 jobs:
   android:
@@ -33,6 +38,8 @@ jobs:
 
       - name: Sync Capacitor
         working-directory: mobile-app
+        env:
+          CAPACITOR_SERVER_URL: ${{ github.event.inputs.server_url }}
         run: pnpm exec cap sync android
 
       - name: Create local.properties

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -83,9 +83,13 @@ export class AuthController {
 
     // 3. FE로 리다이렉트 (모바일 앱은 커스텀 스킴으로)
     const isMobile = req.cookies?.oauth_mobile === '1';
+    const isAndroid = req.cookies?.oauth_android === '1';
     res.clearCookie('oauth_mobile', { path: '/' });
+    res.clearCookie('oauth_android', { path: '/' });
     const redirectUrl = isMobile
-      ? `ittda://oauth/callback?code=${code}`
+      ? isAndroid
+        ? `intent://oauth/callback?code=${code}#Intent;scheme=ittda;package=com.ittda.app;end`
+        : `ittda://oauth/callback?code=${code}`
       : `${this.FRONTEND_URL}/oauth/callback?code=${code}`;
     return res.redirect(302, redirectUrl);
   }
@@ -117,9 +121,13 @@ export class AuthController {
     });
 
     const isMobile = req.cookies?.oauth_mobile === '1';
+    const isAndroid = req.cookies?.oauth_android === '1';
     res.clearCookie('oauth_mobile', { path: '/' });
+    res.clearCookie('oauth_android', { path: '/' });
     const redirectUrl = isMobile
-      ? `ittda://oauth/callback?code=${code}`
+      ? isAndroid
+        ? `intent://oauth/callback?code=${code}#Intent;scheme=ittda;package=com.ittda.app;end`
+        : `ittda://oauth/callback?code=${code}`
       : `${this.FRONTEND_URL}/oauth/callback?code=${code}`;
     return res.redirect(302, redirectUrl);
   }

--- a/backend/src/modules/auth/guards/google-auth.guard.ts
+++ b/backend/src/modules/auth/guards/google-auth.guard.ts
@@ -12,9 +12,19 @@ export class GoogleAuthGuard extends AuthGuard('google') {
     const response = context.switchToHttp().getResponse();
     const prompt = request.query.prompt;
     const mobile = request.query.mobile;
+    const android = request.query.android;
 
     if (mobile === 'true') {
       response.cookie('oauth_mobile', '1', {
+        maxAge: 5 * 60 * 1000,
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        path: '/',
+      });
+    }
+    if (android === 'true') {
+      response.cookie('oauth_android', '1', {
         maxAge: 5 * 60 * 1000,
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',

--- a/backend/src/modules/auth/guards/kakao-auth.guard.ts
+++ b/backend/src/modules/auth/guards/kakao-auth.guard.ts
@@ -12,9 +12,19 @@ export class KakaoAuthGuard extends AuthGuard('kakao') {
     const response = context.switchToHttp().getResponse();
     const prompt = request.query.prompt;
     const mobile = request.query.mobile;
+    const android = request.query.android;
 
     if (mobile === 'true') {
       response.cookie('oauth_mobile', '1', {
+        maxAge: 5 * 60 * 1000,
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        path: '/',
+      });
+    }
+    if (android === 'true') {
+      response.cookie('oauth_android', '1', {
         maxAge: 5 * 60 * 1000,
         httpOnly: true,
         secure: process.env.NODE_ENV === 'production',

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -31,6 +31,7 @@ import type { PresignFileRequestDto } from './dto/presign-media.dto';
 @Injectable()
 export class MediaService {
   private readonly s3Client: S3Client;
+  private readonly s3PresignClient: S3Client;
   private readonly bucket: string;
   private readonly s3ConfigValid: boolean;
   private readonly logger = new Logger(MediaService.name);
@@ -64,6 +65,8 @@ export class MediaService {
     private readonly userRepository: Repository<User>,
   ) {
     const endpoint = this.configService.get<string>('S3_ENDPOINT');
+    const publicEndpoint =
+      this.configService.get<string>('S3_PUBLIC_ENDPOINT') ?? endpoint;
     const region = this.configService.get<string>('S3_REGION') ?? 'us-east-1';
     const accessKeyId = this.configService.get<string>('S3_ACCESS_KEY');
     const secretAccessKey = this.configService.get<string>('S3_SECRET_KEY');
@@ -75,14 +78,25 @@ export class MediaService {
       endpoint && accessKeyId && secretAccessKey && this.bucket,
     );
 
+    const credentials =
+      accessKeyId && secretAccessKey
+        ? { accessKeyId, secretAccessKey }
+        : undefined;
+
     this.s3Client = new S3Client({
       region,
       endpoint,
       forcePathStyle,
-      credentials:
-        accessKeyId && secretAccessKey
-          ? { accessKeyId, secretAccessKey }
-          : undefined,
+      credentials,
+    });
+
+    // Presigned URL 생성 전용 클라이언트: 외부에서 접근 가능한 public endpoint 사용
+    // S3_PUBLIC_ENDPOINT가 없으면 s3Client와 동일하게 동작
+    this.s3PresignClient = new S3Client({
+      region,
+      endpoint: publicEndpoint,
+      forcePathStyle,
+      credentials,
     });
   }
 
@@ -148,7 +162,7 @@ export class MediaService {
         });
         let uploadUrl: string;
         try {
-          uploadUrl = await getSignedUrl(this.s3Client, command, {
+          uploadUrl = await getSignedUrl(this.s3PresignClient, command, {
             expiresIn: this.presignTtlSeconds,
           });
         } catch (err) {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@capacitor/app": "^7.0.0",
     "@capacitor/browser": "^7.0.0",
+    "@capacitor/clipboard": "^7.0.4",
     "@capacitor/core": "^7.0.0",
     "@capacitor/network": "^8.0.1",
     "@capacitor/share": "^7.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@capacitor/core": "^7.0.0",
     "@capacitor/network": "^8.0.1",
     "@capacitor/splash-screen": "^7.0.5",
+    "@capacitor/status-bar": "^7.0.6",
     "@googlemaps/markerclusterer": "^2.6.2",
     "@lhci/cli": "^0.15.1",
     "@next/third-parties": "^16.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@capacitor/browser": "^7.0.0",
     "@capacitor/core": "^7.0.0",
     "@capacitor/network": "^8.0.1",
+    "@capacitor/share": "^7.0.4",
     "@capacitor/splash-screen": "^7.0.5",
     "@capacitor/status-bar": "^7.0.6",
     "@googlemaps/markerclusterer": "^2.6.2",

--- a/frontend/src/app/(login)/login/_components/LoginContent.tsx
+++ b/frontend/src/app/(login)/login/_components/LoginContent.tsx
@@ -23,6 +23,11 @@ const isNativePlatform = () =>
     window as unknown as { Capacitor?: { isNativePlatform?: () => boolean } }
   ).Capacitor?.isNativePlatform?.();
 
+const isAndroidPlatform = () =>
+  typeof window !== 'undefined' &&
+  (window as unknown as { Capacitor?: { getPlatform?: () => string } })
+    .Capacitor?.getPlatform?.() === 'android';
+
 const ERROR_MESSAGES: Record<string, string> = {
   invalid_callback: '잘못된 로그인 요청입니다.',
   token_not_found: '인증 토큰을 받지 못했습니다.',
@@ -241,6 +246,7 @@ export default function LoginContent({
             callback,
             forceAccountSelect,
             mobile: true,
+            android: isAndroidPlatform(),
           }),
         });
         return;

--- a/frontend/src/app/(main)/inquiry/page.tsx
+++ b/frontend/src/app/(main)/inquiry/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useIMEInput } from '@/hooks/useIMEInput';
 import { useRouter } from 'next/navigation';
 import Back from '@/components/Back';
 import { useApiPost } from '@/hooks/useApi';
@@ -18,6 +19,9 @@ export default function InquiryPage() {
   const [otherText, setOtherText] = useState('');
   const [content, setContent] = useState('');
   const [email, setEmail] = useState('');
+  const otherTextImeProps = useIMEInput(setOtherText);
+  const contentImeProps = useIMEInput(setContent);
+  const emailImeProps = useIMEInput(setEmail);
 
   const { mutate: submit, isPending } = useApiPost('/api/inquiries', {
     onSuccess: () => {
@@ -97,7 +101,7 @@ export default function InquiryPage() {
                   {cat === '기타' && category === '기타' && (
                     <input
                       value={otherText}
-                      onChange={(e) => setOtherText(e.target.value)}
+                      {...otherTextImeProps}
                       placeholder="직접 입력"
                       maxLength={80}
                       className="flex-1 h-8 px-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-[#1E1E1E] text-sm text-gray-900 dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-gray-600"
@@ -118,7 +122,7 @@ export default function InquiryPage() {
             </p>
             <textarea
               value={content}
-              onChange={(e) => setContent(e.target.value)}
+              {...contentImeProps}
               placeholder="내 답변"
               rows={6}
               maxLength={2000}
@@ -141,7 +145,7 @@ export default function InquiryPage() {
             <input
               type="text"
               value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              {...emailImeProps}
               placeholder="내 답변"
               className={`w-full h-11 px-4 rounded-xl border bg-gray-50 dark:bg-[#1E1E1E] text-sm text-gray-900 dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 transition-colors ${
                 emailError

--- a/frontend/src/app/(map)/_components/RecordMapContent.tsx
+++ b/frontend/src/app/(map)/_components/RecordMapContent.tsx
@@ -232,7 +232,7 @@ export default function RecordMapContent({
 
   return (
     // fixed inset-0: 전체 화면 커버 (status bar 영역 포함) + 문서 스크롤 이슈 방지
-    <div className="fixed inset-0 overflow-hidden bg-white">
+    <div className="fixed top-0 bottom-0 left-0 right-0 max-w-4xl mx-auto overflow-hidden bg-white">
       <APIProvider apiKey={apiKey!}>
         {/* GoogleMap: vaul-drawer-wrapper 밖 → filter drawer transform 영향 안 받음 */}
         <div className="absolute inset-0">

--- a/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
+++ b/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
@@ -537,59 +537,64 @@ export default function PostEditor({
 
     setIsSaving(true);
 
-    if (groupId) {
-      await refreshGroupData(groupId);
-      queryClient.invalidateQueries({ queryKey: ['group', groupId] });
-    }
-
-    // 개인용 게시글 이미지 -> id 변환 로직
-    const finalizedBlocks = await Promise.all(
-      filteredBlocks.map(async (block) => {
-        if (block.type === 'photos') {
-          const tempUrls = block.value.tempUrls || [];
-          const filesToUpload: File[] = [];
-
-          // Ref에서 실제 파일 매칭
-          tempUrls.forEach((url) => {
-            const file = pendingFilesRef.current.get(url);
-            if (file) filesToUpload.push(file);
-          });
-
-          if (filesToUpload.length > 0) {
-            const newMediaIds = await uploadMultipleMedia(filesToUpload);
-            const updatedValue = {
-              mediaIds: [...(block.value.mediaIds || []), ...newMediaIds],
-              tempUrls: [], // 업로드 완료 후 비움
-            };
-
-            return { ...block, value: updatedValue };
-          }
-        }
-        return block;
-      }),
-    );
-
-    // 빈 photos 블록 필터링 (mediaIds와 tempUrls가 모두 비어있는 경우 제거)
-    const validBlocks = finalizedBlocks.filter((block) => {
-      if (block.type === 'photos') {
-        const mediaIds = block.value.mediaIds || [];
-        const tempUrls = block.value.tempUrls || [];
-        return mediaIds.length > 0 || tempUrls.length > 0;
+    try {
+      if (groupId) {
+        await refreshGroupData(groupId);
+        queryClient.invalidateQueries({ queryKey: ['group', groupId] });
       }
-      return true;
-    });
 
-    const postPayload: CreateRecordRequest = {
-      title,
-      blocks: mapBlocksToPayload(validBlocks, isDraft),
-      ...(groupId ? { groupId } : {}),
-      ...(!postId ? { scope } : {}),
-    };
+      // 개인용 게시글 이미지 -> id 변환 로직
+      const finalizedBlocks = await Promise.all(
+        filteredBlocks.map(async (block) => {
+          if (block.type === 'photos') {
+            const tempUrls = block.value.tempUrls || [];
+            const filesToUpload: File[] = [];
 
-    queryClient.invalidateQueries({ queryKey: ['my', 'records'] });
-    execute({
-      payload: postPayload,
-    });
+            // Ref에서 실제 파일 매칭
+            tempUrls.forEach((url) => {
+              const file = pendingFilesRef.current.get(url);
+              if (file) filesToUpload.push(file);
+            });
+
+            if (filesToUpload.length > 0) {
+              const newMediaIds = await uploadMultipleMedia(filesToUpload);
+              const updatedValue = {
+                mediaIds: [...(block.value.mediaIds || []), ...newMediaIds],
+                tempUrls: [], // 업로드 완료 후 비움
+              };
+
+              return { ...block, value: updatedValue };
+            }
+          }
+          return block;
+        }),
+      );
+
+      // 빈 photos 블록 필터링 (mediaIds와 tempUrls가 모두 비어있는 경우 제거)
+      const validBlocks = finalizedBlocks.filter((block) => {
+        if (block.type === 'photos') {
+          const mediaIds = block.value.mediaIds || [];
+          const tempUrls = block.value.tempUrls || [];
+          return mediaIds.length > 0 || tempUrls.length > 0;
+        }
+        return true;
+      });
+
+      const postPayload: CreateRecordRequest = {
+        title,
+        blocks: mapBlocksToPayload(validBlocks, isDraft),
+        ...(groupId ? { groupId } : {}),
+        ...(!postId ? { scope } : {}),
+      };
+
+      queryClient.invalidateQueries({ queryKey: ['my', 'records'] });
+      execute({
+        payload: postPayload,
+      });
+    } catch {
+      toast.error('사진 업로드에 실패했습니다. 다시 시도해 주세요.');
+      setIsSaving(false);
+    }
   };
 
   const { throttled: throttledEmitStream, flush: flushEmitStream } =

--- a/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
+++ b/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
@@ -151,10 +151,10 @@ const BlockItem = memo(function BlockItem({
       data-block-id={block.id}
       onPointerUp={handleDragEnd}
       onPointerCancel={handleDragEnd}
-      className={`cursor-grab touch-none relative group/field ${block.layout.span === 1 ? 'col-span-1' : 'col-span-2'} ${isDraggingId === block.id ? 'opacity-20 scale-95' : 'opacity-100'} ${!isDraggingId ? 'transition-all duration-300' : ''}`}
+      className={`cursor-grab relative group/field ${isDraggingId ? 'touch-none' : 'touch-auto'} ${block.layout.span === 1 ? 'col-span-1' : 'col-span-2'} ${isDraggingId === block.id ? 'opacity-20 scale-95' : 'opacity-100'} ${!isDraggingId ? 'transition-all duration-300' : ''}`}
     >
       <div
-        className={`relative w-full flex flex-row gap-2 items-center touch-none ${
+        className={`relative w-full flex flex-row gap-2 items-center ${isDraggingId ? 'touch-none' : 'touch-auto'} ${
           block.layout.col === 1 ? 'justify-start' : 'justify-end'
         }`}
       >
@@ -220,12 +220,17 @@ export default function PostEditor({
 
   // LOCK_DENIED 수신 시 열려있는 drawer가 해당 블록이면 강제 닫기
   // (usePostEditorBlocks보다 먼저 선언되므로 ref 패턴으로 최신 setActiveDrawer 참조)
-  const onLockDeniedRef = useRef<((lockKey: string) => void) | undefined>(undefined);
+  const onLockDeniedRef = useRef<((lockKey: string) => void) | undefined>(
+    undefined,
+  );
   const stableOnLockDenied = useCallback((lockKey: string) => {
     onLockDeniedRef.current?.(lockKey);
   }, []);
 
-  const { requestLock, releaseLock, acquireExclusiveLock } = useLockManager(draftId, stableOnLockDenied);
+  const { requestLock, releaseLock, acquireExclusiveLock } = useLockManager(
+    draftId,
+    stableOnLockDenied,
+  );
   const { uploadMultipleMedia } = useMediaUpload();
   const { data: group } = useQuery({
     ...groupDetailOptions(groupId!),
@@ -357,13 +362,21 @@ export default function PostEditor({
     };
   }, [draftId, initialPost, groupId, isPublishing]);
 
-  const { members } = useDraftPresence(draftId, groupId, isPublishing, initialPost?.version ?? 0);
+  const { members } = useDraftPresence(
+    draftId,
+    groupId,
+    isPublishing,
+    initialPost?.version ?? 0,
+  );
 
   // 서버의 LOCK_CHANGED 브로드캐스트 수신
   useEffect(() => {
     if (!socket) return;
 
-    const handleLockChanged = ({ lockKey, ownerSessionId }: LockResponsePayload) => {
+    const handleLockChanged = ({
+      lockKey,
+      ownerSessionId,
+    }: LockResponsePayload) => {
       setLocks((prev) => {
         const newLocks = { ...prev };
         if (ownerSessionId) {
@@ -381,7 +394,11 @@ export default function PostEditor({
     // 주의: socket.off(event) (콜백 없음)는 ALL 핸들러를 제거하므로
     // useDraftPresence가 등록한 PRESENCE_SNAPSHOT 핸들러까지 삭제되는 버그를 방지하기 위해
     // 반드시 콜백 참조를 저장하고 socket.off(event, handler)로 제거해야 함.
-    const handlePresenceSnapshot = ({ locks: snapshotLocks }: { locks?: Record<string, string> }) => {
+    const handlePresenceSnapshot = ({
+      locks: snapshotLocks,
+    }: {
+      locks?: Record<string, string>;
+    }) => {
       if (snapshotLocks && Object.keys(snapshotLocks).length > 0) {
         setLocks(snapshotLocks);
       }
@@ -389,9 +406,17 @@ export default function PostEditor({
 
     // 소켓 재연결 시 새 sessionId가 부여되면 locks에 남아있는 이전 sessionId를 갱신.
     // 갱신하지 않으면 자신의 락이 isLockedByOther=true로 보여 "다른 사용자 편집 중" 오표시됨.
-    const handlePresenceReplaced = ({ previousSessionId, sessionId }: { previousSessionId: string; sessionId: string }) => {
+    const handlePresenceReplaced = ({
+      previousSessionId,
+      sessionId,
+    }: {
+      previousSessionId: string;
+      sessionId: string;
+    }) => {
       setLocks((prev) => {
-        const hasStale = Object.values(prev).some((v) => v === previousSessionId);
+        const hasStale = Object.values(prev).some(
+          (v) => v === previousSessionId,
+        );
         if (!hasStale) return prev;
         const updated: Record<string, string> = {};
         Object.entries(prev).forEach(([key, val]) => {
@@ -591,7 +616,8 @@ export default function PostEditor({
       execute({
         payload: postPayload,
       });
-    } catch {
+    } catch (e) {
+      console.log(e);
       toast.error('사진 업로드에 실패했습니다. 다시 시도해 주세요.');
       setIsSaving(false);
     }
@@ -910,7 +936,11 @@ export default function PostEditor({
           mySessionId={mySessionId}
           members={members}
           applyPatch={applyPatch}
-          lockManager={{ locks, requestLock: acquireExclusiveLock, releaseLock }}
+          lockManager={{
+            locks,
+            requestLock: acquireExclusiveLock,
+            releaseLock,
+          }}
         />
         <div
           ref={gridRef}

--- a/frontend/src/app/(post)/_components/editor/RecordTitleInput.tsx
+++ b/frontend/src/app/(post)/_components/editor/RecordTitleInput.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useIMEInput } from '@/hooks/useIMEInput';
 import Image from 'next/image';
 import { PresenceMember } from '@/hooks/useDraftPresence';
 import { PatchApplyPayload } from '@/lib/types/recordCollaboration';
@@ -101,14 +102,13 @@ export default function RecordTitleInput({
     3000,
   );
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newVal = e.target.value;
+  const handleChangeValue = (newVal: string) => {
     setTitle(newVal);
-
     if (isMyLock) {
       throttledApplyPatch(newVal);
     }
   };
+  const imeProps = useIMEInput(handleChangeValue);
 
   const handleBlur = () => {
     if (!draftId) return;
@@ -218,7 +218,7 @@ export default function RecordTitleInput({
         type="text"
         placeholder="제목을 입력하세요"
         value={title}
-        onChange={handleChange}
+        {...imeProps}
         onFocus={handleFocus}
         onBlur={handleBlur}
         disabled={isLockedByOther}

--- a/frontend/src/app/(post)/_components/editor/Toolbar.tsx
+++ b/frontend/src/app/(post)/_components/editor/Toolbar.tsx
@@ -57,7 +57,7 @@ export default function Toolbar({ onAddBlock, onOpenDrawer }: ToolbarProps) {
 
       <div
         className="w-full bg-white dark:bg-[#2A2A2A] border-t border-gray-100 dark:border-white/5 px-2 pt-4 sm:px-4 sm:pt-3 flex justify-around items-center"
-        style={{ paddingBottom: 'calc(1.5rem + env(safe-area-inset-bottom))' }}
+        style={{ paddingBottom: 'calc(1rem + env(safe-area-inset-bottom))' }}
       >
         {TOOL_ITEMS.map(({ id, Icon }) => (
           <button

--- a/frontend/src/app/(post)/_components/editor/Toolbar.tsx
+++ b/frontend/src/app/(post)/_components/editor/Toolbar.tsx
@@ -57,7 +57,7 @@ export default function Toolbar({ onAddBlock, onOpenDrawer }: ToolbarProps) {
 
       <div
         className="w-full bg-white dark:bg-[#2A2A2A] border-t border-gray-100 dark:border-white/5 px-2 pt-4 sm:px-4 sm:pt-3 flex justify-around items-center"
-        style={{ paddingBottom: 'calc(1rem + env(safe-area-inset-bottom))' }}
+        style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom))' }}
       >
         {TOOL_ITEMS.map(({ id, Icon }) => (
           <button

--- a/frontend/src/app/(post)/_components/editor/core/CoreField.tsx
+++ b/frontend/src/app/(post)/_components/editor/core/CoreField.tsx
@@ -113,13 +113,28 @@ export const ContentField = ({
 
   const adjustHeight = useCallback(() => {
     const target = textareaRef.current;
-    // 현재 텍스트 크기에 맞게 높이 조절
-    if (target) {
-      requestAnimationFrame(() => {
+    if (!target) return;
+    // height: auto 로 먼저 줄이면 스크롤 컨테이너가 위로 점프하는 문제가 발생.
+    // scrollHeight는 overflow:hidden 상태에서도 콘텐츠 전체 높이를 반환하므로
+    // 현재 높이보다 커질 때만 늘리고, 줄어들 때는 height: auto 후 재측정.
+    requestAnimationFrame(() => {
+      const newHeight = target.scrollHeight;
+      if (newHeight > target.offsetHeight) {
+        // 콘텐츠가 늘어난 경우: 높이만 확장 후 커서가 보이도록 스크롤
+        target.style.height = `${newHeight}px`;
+        // 커서 위치를 뷰포트 안으로 부드럽게 스크롤
+        target.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      } else {
+        // 콘텐츠가 줄어든 경우: 스크롤 위치 저장 후 복원
+        const scrollEl = target.closest('[data-radix-scroll-area-viewport]') ??
+          target.parentElement?.closest('[style*="overflow"]') ??
+          document.scrollingElement;
+        const savedScroll = scrollEl?.scrollTop ?? 0;
         target.style.height = 'auto';
         target.style.height = `${target.scrollHeight}px`;
-      });
-    }
+        if (scrollEl) scrollEl.scrollTop = savedScroll;
+      }
+    });
   }, []);
 
   // value 변경될 때 높이 조절

--- a/frontend/src/app/(post)/_components/editor/core/CoreField.tsx
+++ b/frontend/src/app/(post)/_components/editor/core/CoreField.tsx
@@ -9,6 +9,7 @@ import { Calendar, ChevronDown, Clock } from 'lucide-react';
 import { FieldDeleteButton } from './FieldDeleteButton';
 import { cn } from '@/lib/utils';
 import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import { useIMEInput } from '@/hooks/useIMEInput';
 import { DateValue, TextValue, TimeValue } from '@/lib/types/record';
 
 interface DateProps {
@@ -86,6 +87,7 @@ export const ContentField = ({
   onLockedClick,
 }: ContentProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const imeProps = useIMEInput(onChange);
   const isInternalFocus = useRef(false);
 
   useEffect(() => {
@@ -174,7 +176,7 @@ export const ContentField = ({
           disabled={isLocked}
           onFocus={handleFocusWrapper}
           onBlur={handleBlur}
-          onChange={(e) => onChange(e.target.value)}
+          {...imeProps}
           className="w-full h-auto border-none focus:ring-0 outline-none text-base leading-relaxed tracking-tight resize-none p-1 overflow-hidden bg-transparent text-itta-black dark:text-gray-300 placeholder-gray-300 dark:placeholder-gray-500"
         />
       </div>

--- a/frontend/src/app/(post)/_components/editor/core/SaveTemplateDrawer.tsx
+++ b/frontend/src/app/(post)/_components/editor/core/SaveTemplateDrawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useIMEInput } from '@/hooks/useIMEInput';
 import { CheckCircle2 } from 'lucide-react';
 import {
   Drawer,
@@ -23,6 +24,8 @@ export default function SaveTemplateDrawer({
 }: SaveTemplateDrawerProps) {
   const [name, setName] = useState('');
   const [desc, setDesc] = useState('');
+  const nameImeProps = useIMEInput(setName);
+  const descImeProps = useIMEInput(setDesc);
 
   const isValid = name.trim().length > 0;
 
@@ -48,7 +51,7 @@ export default function SaveTemplateDrawer({
                 autoFocus
                 type="text"
                 value={name}
-                onChange={(e) => setName(e.target.value)}
+                {...nameImeProps}
                 placeholder="예: 나의 데일리 기록"
                 className="w-full border-b-2 bg-transparent py-3 text-lg font-bold transition-all outline-none dark:border-white/5 dark:focus:border-[#10B981] dark:text-white border-gray-100 focus:border-[#10B981] text-[#333333]"
               />
@@ -60,7 +63,7 @@ export default function SaveTemplateDrawer({
               <input
                 type="text"
                 value={desc}
-                onChange={(e) => setDesc(e.target.value)}
+                {...descImeProps}
                 placeholder="어떤 구성을 위한 템플릿인가요?"
                 className="w-full border-b bg-transparent py-2 text-base font-medium transition-all outline-none dark:border-white/5 dark:focus:border-[#10B981] dark:text-gray-400 border-gray-100 focus:border-[#10B981] text-gray-600"
               />

--- a/frontend/src/app/(post)/_components/editor/media/MediaDrawer.tsx
+++ b/frontend/src/app/(post)/_components/editor/media/MediaDrawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useIMEInput } from '@/hooks/useIMEInput';
 import {
   Drawer,
   DrawerContent,
@@ -40,6 +41,7 @@ const CATEGORIES = [
 export default function MediaDrawer({ onClose, onSelect }: MediaDrawerProps) {
   const [isManualInput, setIsManualInput] = useState(false);
   const [query, setQuery] = useState('');
+  const queryImeProps = useIMEInput(setQuery);
   const [results, setResults] = useState<MediaValue[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -126,7 +128,7 @@ export default function MediaDrawer({ onClose, onSelect }: MediaDrawerProps) {
                       type="text"
                       placeholder="이름을 입력하세요"
                       value={query}
-                      onChange={(e) => setQuery(e.target.value)}
+                      {...queryImeProps}
                       className="w-full bg-[#F4F4F4] dark:bg-white/5 border-none rounded-lg sm:rounded-xl px-10 sm:px-12 py-3 sm:py-4 mobile-input font-medium focus:ring-1 focus:ring-[#10B981] transition-all outline-none text-itta-black dark:text-white"
                     />
                     <Search className="absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 w-3.5 sm:w-4 h-3.5 sm:h-4 text-gray-400" />

--- a/frontend/src/app/(post)/_components/editor/media/MediaManualInput.tsx
+++ b/frontend/src/app/(post)/_components/editor/media/MediaManualInput.tsx
@@ -6,6 +6,7 @@ import {
   LucideMusic4,
 } from 'lucide-react';
 import { CategoryChip } from './MediaCategoryChip';
+import { useIMEInput } from '@/hooks/useIMEInput';
 
 interface ManualInputProps {
   manualType: string;
@@ -30,6 +31,8 @@ export const MediaManualInput = ({
   manualYear,
   setManualYear,
 }: ManualInputProps) => {
+  const titleImeProps = useIMEInput(setManualTitle);
+  const yearImeProps = useIMEInput(setManualYear);
   return (
     <div className="px-4 sm:px-8 py-1.5 sm:py-2 space-y-6 sm:space-y-8 animate-in fade-in slide-in-from-bottom-2 duration-300">
       {/* 카테고리 섹션 */}
@@ -70,7 +73,7 @@ export const MediaManualInput = ({
           type="text"
           placeholder="직접 입력해 주세요"
           value={manualTitle}
-          onChange={(e) => setManualTitle(e.target.value)}
+          {...titleImeProps}
           className="w-full bg-transparent border-b border-gray-100 dark:border-white/10 py-2.5 sm:py-3 mobile-input font-bold text-[#333] dark:text-white outline-none focus:border-itta-point transition-colors"
         />
       </section>
@@ -90,7 +93,7 @@ export const MediaManualInput = ({
             type="text"
             inputMode="numeric"
             value={manualYear}
-            onChange={(e) => setManualYear(e.target.value)}
+            {...yearImeProps}
             className="w-full bg-transparent text-lg sm:text-xl font-bold text-[#333] dark:text-white outline-none scrollbar-hide"
           />
           <div className="absolute right-0 top-1/2 -translate-y-1/2 flex flex-col text-itta-gray3 gap-0.5 sm:gap-1">

--- a/frontend/src/app/(post)/_components/editor/table/TableField.tsx
+++ b/frontend/src/app/(post)/_components/editor/table/TableField.tsx
@@ -4,6 +4,35 @@ import { TableValue } from '@/lib/types/recordField';
 import { cn } from '@/lib/utils';
 import { Plus, MinusCircle, X } from 'lucide-react';
 import { useEffect, useRef } from 'react';
+import { useIMEInput } from '@/hooks/useIMEInput';
+
+interface TableCellInputProps {
+  value: string;
+  onChange: (val: string) => void;
+  disabled?: boolean;
+  onFocus?: () => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  inputRef?: React.Ref<HTMLInputElement>;
+  placeholder?: string;
+  className?: string;
+}
+
+function TableCellInput({ value, onChange, disabled, onFocus, onBlur, inputRef, placeholder, className }: TableCellInputProps) {
+  const imeProps = useIMEInput(onChange);
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      value={value}
+      {...imeProps}
+      disabled={disabled}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      placeholder={placeholder}
+      className={className}
+    />
+  );
+}
 
 interface TableFieldProps {
   data: TableValue | null;
@@ -183,11 +212,10 @@ export const TableField = ({
                       key={cIdx}
                       className="p-0 border-r border-gray-100/50 dark:border-white/5 last:border-none overflow-hidden"
                     >
-                      <input
-                        ref={rIdx === 0 && cIdx === 0 ? firstInputRef : null}
-                        type="text"
+                      <TableCellInput
+                        inputRef={rIdx === 0 && cIdx === 0 ? firstInputRef : null}
                         value={cell}
-                        onChange={(e) => updateCell(rIdx, cIdx, e.target.value)}
+                        onChange={(val) => updateCell(rIdx, cIdx, val)}
                         disabled={isLocked && !isMyLock}
                         onFocus={handleFocusWrapper}
                         onBlur={handleBlurWrapper}

--- a/frontend/src/app/(post)/_components/editor/tag/TagDrawer.tsx
+++ b/frontend/src/app/(post)/_components/editor/tag/TagDrawer.tsx
@@ -128,144 +128,143 @@ export default function TagDrawer({
     <Drawer open={true} onOpenChange={(open) => !open && onClose()}>
       <DrawerContent className="h-[85%]">
         <div className="w-full flex flex-col h-full overflow-hidden">
-        <div className="flex-1 overflow-y-auto p-6 sm:p-8">
-          <DrawerHeader className="px-0 items-start text-left">
-            <div className="flex flex-col text-left">
-              <span className="text-[10px] sm:text-[11px] font-bold text-[#10B981] uppercase tracking-[0.2em] sm:tracking-widest leading-none mb-1">
-                SELECT TAGS
-              </span>
-              <DrawerTitle className="text-base sm:text-lg font-bold">
-                태그 추가하기
-              </DrawerTitle>
-            </div>
-          </DrawerHeader>
-
-          {/* 현재 선택된 태그 리스트 */}
-          {prevTags.length !== 0 && (
-            <div className="flex flex-wrap gap-1.5 sm:gap-2 mb-2 sm:mb-3 min-h-7 sm:min-h-8">
-              {prevTags.map((tag) => (
-                <span
-                  key={tag}
-                  className="flex items-center gap-1 sm:gap-1.5 px-2.5 sm:px-3 py-1 sm:py-1.5 rounded-lg bg-itta-point/10 text-itta-point text-[11px] sm:text-xs font-bold animate-in fade-in zoom-in-95"
-                >
-                  #{tag}
-                  <X
-                    size={12}
-                    className="cursor-pointer hover:text-rose-500 transition-colors sm:hidden"
-                    onClick={() => removeTag(tag)}
-                  />
-                  <X
-                    size={14}
-                    className="cursor-pointer hover:text-rose-500 transition-colors hidden sm:block"
-                    onClick={() => removeTag(tag)}
-                  />
+          <div className="flex-1 overflow-y-auto p-6 sm:p-8">
+            <DrawerHeader className="px-0 items-start text-left">
+              <div className="flex flex-col text-left">
+                <span className="text-[10px] sm:text-[11px] font-bold text-[#10B981] uppercase tracking-[0.2em] sm:tracking-widest leading-none mb-1">
+                  SELECT TAGS
                 </span>
-              ))}
-            </div>
-          )}
-
-          {/* 태그 입력창 */}
-          <div className="flex justify-between items-center gap-1.5 sm:gap-2 mb-5 sm:mb-6">
-            <div className="flex flex-1 justify-center items-center">
-              <div className="flex-1 relative">
-                <span
-                  className={`absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 font-bold transition-colors pointer-events-none z-10 ${isLimitReached ? 'text-itta-gray3' : 'text-itta-point'}`}
-                >
-                  #
-                </span>
-                <input
-                  value={inputValue}
-                  {...imeProps}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.preventDefault();
-                      addTag(e);
-                    }
-                  }}
-                  className="w-full pl-7 sm:pl-8 pr-3 sm:pr-4 py-2.5 sm:py-3 rounded-lg bg-gray-50 dark:bg-white/5 outline-none focus:ring-1 focus:ring-itta-point mobile-input dark:text-white"
-                  placeholder={
-                    isLimitReached ? '최대 개수 4개 도달' : '새 태그 입력'
-                  }
-                />
+                <DrawerTitle className="text-base sm:text-lg font-bold">
+                  태그 추가하기
+                </DrawerTitle>
               </div>
-            </div>
-            <button
-              onClick={addTag}
-              className="p-2.5 sm:p-3 rounded-xl sm:rounded-2xl bg-itta-point text-white shadow-lg shadow-itta-point/20 active:scale-90 transition-transform"
-            >
-              <Plus size={18} className="sm:hidden" />
-              <Plus size={20} className="hidden sm:block" />
-            </button>
-          </div>
+            </DrawerHeader>
 
-          {/* 이전 사용 태그 섹션 */}
-
-          <div className="space-y-3 sm:space-y-4">
-            <p className="text-[9px] sm:text-[10px] font-bold text-itta-gray3">
-              이전에 사용한 태그
-            </p>
-            {isPending && (
-              <div className="flex-1 flex items-center justify-center">
-                <Loader2 className="w-8 h-8 animate-spin text-itta-point" />
+            {/* 현재 선택된 태그 리스트 */}
+            {prevTags.length !== 0 && (
+              <div className="flex flex-wrap gap-1.5 sm:gap-2 mb-2 sm:mb-3 min-h-7 sm:min-h-8">
+                {prevTags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="flex items-center gap-1 sm:gap-1.5 px-2.5 sm:px-3 py-1 sm:py-1.5 rounded-lg bg-itta-point/10 text-itta-point text-[11px] sm:text-xs font-bold animate-in fade-in zoom-in-95"
+                  >
+                    #{tag}
+                    <X
+                      size={12}
+                      className="cursor-pointer hover:text-rose-500 transition-colors sm:hidden"
+                      onClick={() => removeTag(tag)}
+                    />
+                    <X
+                      size={14}
+                      className="cursor-pointer hover:text-rose-500 transition-colors hidden sm:block"
+                      onClick={() => removeTag(tag)}
+                    />
+                  </span>
+                ))}
               </div>
             )}
-            {suggestedTags.length > 0 && (
-              <div className="flex flex-wrap gap-1.5 sm:gap-2">
-                {suggestedTags.map((tag) => {
-                  const isSelected = prevTags.includes(tag);
-                  return (
-                    <button
-                      key={tag}
-                      onClick={() => togglePreviousTag(tag)}
-                      className={`px-2.5 sm:px-3 py-1.5 sm:py-2 rounded-lg text-[11px] sm:text-xs font-bold border transition-all active:scale-95
+
+            {/* 태그 입력창 */}
+            <div className="flex justify-between items-center gap-1.5 sm:gap-2 mb-5 sm:mb-6">
+              <div className="flex flex-1 justify-center items-center">
+                <div className="flex-1 relative">
+                  <span
+                    className={`absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 font-bold transition-colors pointer-events-none z-10 ${isLimitReached ? 'text-itta-gray3' : 'text-itta-point'}`}
+                  >
+                    #
+                  </span>
+                  <input
+                    value={inputValue}
+                    {...imeProps}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        addTag(e);
+                      }
+                    }}
+                    className="w-full pl-7 sm:pl-8 pr-3 sm:pr-4 py-2.5 sm:py-3 rounded-lg bg-gray-50 dark:bg-white/5 outline-none focus:ring-1 focus:ring-itta-point mobile-input dark:text-white"
+                    placeholder={
+                      isLimitReached ? '최대 개수 4개 도달' : '새 태그 입력'
+                    }
+                  />
+                </div>
+              </div>
+              <button
+                onClick={addTag}
+                className="p-2.5 sm:p-3 rounded-xl sm:rounded-2xl bg-itta-point text-white shadow-lg shadow-itta-point/20 active:scale-90 transition-transform"
+              >
+                <Plus size={18} className="sm:hidden" />
+                <Plus size={20} className="hidden sm:block" />
+              </button>
+            </div>
+
+            {/* 이전 사용 태그 섹션 */}
+
+            <div className="space-y-3 sm:space-y-4">
+              <p className="text-[9px] sm:text-[10px] font-bold text-itta-gray3">
+                이전에 사용한 태그
+              </p>
+              {isPending && (
+                <div className="flex-1 flex items-center justify-center">
+                  <Loader2 className="w-8 h-8 animate-spin text-itta-point" />
+                </div>
+              )}
+              {suggestedTags.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 sm:gap-2">
+                  {suggestedTags.map((tag) => {
+                    const isSelected = prevTags.includes(tag);
+                    return (
+                      <button
+                        key={tag}
+                        onClick={() => togglePreviousTag(tag)}
+                        className={`px-2.5 sm:px-3 py-1.5 sm:py-2 rounded-lg text-[11px] sm:text-xs font-bold border transition-all active:scale-95
                         ${
                           isSelected
                             ? 'bg-itta-point text-white border-itta-point'
                             : 'border-gray-100 text-itta-gray3 hover:border-itta-point dark:border-white/10'
                         }`}
-                    >
-                      #{tag}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-            {!isPending && suggestedTags.length === 0 && (
-              <div className="flex items-center justify-center h-full">
-                <div className="w-full py-4 flex flex-col items-center justify-center gap-2">
-                  <div className="w-10 sm:w-12 h-10 sm:h-12 rounded-full flex items-center justify-center dark:bg-[#10B981]/10 bg-[#10B981]/10">
-                    <TagIcon className="w-4 sm:w-5 h-4 sm:h-5 text-[#10B981]" />
-                  </div>
-                  <div className="space-y-0.5 sm:space-y-1 text-center">
-                    <p className="text-xs sm:text-sm font-bold dark:text-gray-200 text-gray-700">
-                      아직 사용한 태그가 없어요
-                    </p>
-                    <p className="text-[11px] sm:text-xs text-gray-400">
-                      태그를 추가하여 기록을 분류해보세요
-                    </p>
+                      >
+                        #{tag}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+              {!isPending && suggestedTags.length === 0 && (
+                <div className="flex items-center justify-center h-full">
+                  <div className="w-full py-4 flex flex-col items-center justify-center gap-2">
+                    <div className="w-10 sm:w-12 h-10 sm:h-12 rounded-full flex items-center justify-center dark:bg-[#10B981]/10 bg-[#10B981]/10">
+                      <TagIcon className="w-4 sm:w-5 h-4 sm:h-5 text-[#10B981]" />
+                    </div>
+                    <div className="space-y-0.5 sm:space-y-1 text-center">
+                      <p className="text-xs sm:text-sm font-bold dark:text-gray-200 text-gray-700">
+                        아직 사용한 태그가 없어요
+                      </p>
+                      <p className="text-[11px] sm:text-xs text-gray-400">
+                        태그를 추가하여 기록을 분류해보세요
+                      </p>
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
+              )}
+            </div>
           </div>
 
-        </div>
+          {/* 고정 푸터 */}
+          <div className="px-6 sm:px-8 pb-6 sm:pb-8 pt-2">
+            {/* 경고 메시지 영역 (이후 토스트로 변경?)*/}
+            <div className="h-5 sm:h-6 mb-1.5 sm:mb-2 flex justify-center items-center">
+              {showWarning && (
+                <p className="text-rose-500 text-[11px] sm:text-[13px] font-semibold animate-in fade-in slide-in-from-bottom-2 duration-300">
+                  태그는 최대 {MAX_TAGS}개까지 추가할 수 있습니다.
+                </p>
+              )}
+            </div>
 
-        {/* 고정 푸터 */}
-        <div className="px-6 sm:px-8 pb-6 sm:pb-8 pt-2">
-          {/* 경고 메시지 영역 (이후 토스트로 변경?)*/}
-          <div className="h-5 sm:h-6 mb-1.5 sm:mb-2 flex justify-center items-center">
-            {showWarning && (
-              <p className="text-rose-500 text-[11px] sm:text-[13px] font-semibold animate-in fade-in slide-in-from-bottom-2 duration-300">
-                태그는 최대 {MAX_TAGS}개까지 추가할 수 있습니다.
-              </p>
-            )}
+            <DrawerClose className="w-full py-3 sm:py-4 rounded-xl sm:rounded-2xl text-xs sm:text-sm font-bold bg-itta-black text-white active:scale-95 transition-all shadow-lg shadow-black/10 dark:bg-white dark:text-black">
+              확인
+            </DrawerClose>
           </div>
-
-          <DrawerClose className="w-full py-3 sm:py-4 rounded-xl sm:rounded-2xl text-xs sm:text-sm font-bold bg-itta-black text-white active:scale-95 transition-all shadow-lg shadow-black/10 dark:bg-white dark:text-black">
-            확인
-          </DrawerClose>
-        </div>
         </div>
       </DrawerContent>
     </Drawer>

--- a/frontend/src/app/(post)/_components/editor/tag/TagDrawer.tsx
+++ b/frontend/src/app/(post)/_components/editor/tag/TagDrawer.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { X, Plus, Tag as TagIcon, Loader2 } from 'lucide-react';
+import { useIMEInput } from '@/hooks/useIMEInput';
 import {
   Drawer,
   DrawerClose,
@@ -27,6 +28,7 @@ export default function TagDrawer({
   onUpdateTags,
 }: TagDrawerProps) {
   const [inputValue, setInputValue] = useState('');
+  const imeProps = useIMEInput(setInputValue);
   const [showWarning, setShowWarning] = useState(false); // 경고 메시지
   const [suggestedTags, setSuggestedTags] = useState<string[]>([]);
   const [isPending, setIsPending] = useState(true);
@@ -34,6 +36,21 @@ export default function TagDrawer({
   const prevTags = tags.tags;
   const MAX_TAGS = 4;
   const isLimitReached = prevTags.length >= MAX_TAGS;
+
+  // 키보드 닫힘 감지 → vaul이 safe-area 포함한 레이아웃을 재계산하도록 resize 이벤트 발생
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+    let prevHeight = vv.height;
+    const onResize = () => {
+      if (vv.height > prevHeight) {
+        window.dispatchEvent(new Event('resize'));
+      }
+      prevHeight = vv.height;
+    };
+    vv.addEventListener('resize', onResize);
+    return () => vv.removeEventListener('resize', onResize);
+  }, []);
 
   useEffect(() => {
     async function fetchTags() {
@@ -172,7 +189,7 @@ export default function TagDrawer({
                 </span>
                 <input
                   value={inputValue}
-                  onChange={(e) => setInputValue(e.target.value)}
+                  {...imeProps}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter') {
                       e.preventDefault();

--- a/frontend/src/app/(post)/_components/editor/tag/TagDrawer.tsx
+++ b/frontend/src/app/(post)/_components/editor/tag/TagDrawer.tsx
@@ -37,21 +37,6 @@ export default function TagDrawer({
   const MAX_TAGS = 4;
   const isLimitReached = prevTags.length >= MAX_TAGS;
 
-  // 키보드 닫힘 감지 → vaul이 safe-area 포함한 레이아웃을 재계산하도록 resize 이벤트 발생
-  useEffect(() => {
-    const vv = window.visualViewport;
-    if (!vv) return;
-    let prevHeight = vv.height;
-    const onResize = () => {
-      if (vv.height > prevHeight) {
-        window.dispatchEvent(new Event('resize'));
-      }
-      prevHeight = vv.height;
-    };
-    vv.addEventListener('resize', onResize);
-    return () => vv.removeEventListener('resize', onResize);
-  }, []);
-
   useEffect(() => {
     async function fetchTags() {
       try {
@@ -141,8 +126,9 @@ export default function TagDrawer({
 
   return (
     <Drawer open={true} onOpenChange={(open) => !open && onClose()}>
-      <DrawerContent>
-        <div className="w-full p-6 sm:p-8 pb-10 sm:pb-12">
+      <DrawerContent className="h-[85%]">
+        <div className="w-full flex flex-col h-full overflow-hidden">
+        <div className="flex-1 overflow-y-auto p-6 sm:p-8">
           <DrawerHeader className="px-0 items-start text-left">
             <div className="flex flex-col text-left">
               <span className="text-[10px] sm:text-[11px] font-bold text-[#10B981] uppercase tracking-[0.2em] sm:tracking-widest leading-none mb-1">
@@ -214,7 +200,7 @@ export default function TagDrawer({
 
           {/* 이전 사용 태그 섹션 */}
 
-          <div className="space-y-3 sm:space-y-4 mb-8 sm:mb-10">
+          <div className="space-y-3 sm:space-y-4">
             <p className="text-[9px] sm:text-[10px] font-bold text-itta-gray3">
               이전에 사용한 태그
             </p>
@@ -263,6 +249,10 @@ export default function TagDrawer({
             )}
           </div>
 
+        </div>
+
+        {/* 고정 푸터 */}
+        <div className="px-6 sm:px-8 pb-6 sm:pb-8 pt-2">
           {/* 경고 메시지 영역 (이후 토스트로 변경?)*/}
           <div className="h-5 sm:h-6 mb-1.5 sm:mb-2 flex justify-center items-center">
             {showWarning && (
@@ -275,6 +265,7 @@ export default function TagDrawer({
           <DrawerClose className="w-full py-3 sm:py-4 rounded-xl sm:rounded-2xl text-xs sm:text-sm font-bold bg-itta-black text-white active:scale-95 transition-all shadow-lg shadow-black/10 dark:bg-white dark:text-black">
             확인
           </DrawerClose>
+        </div>
         </div>
       </DrawerContent>
     </Drawer>

--- a/frontend/src/app/(post)/_hooks/useRecordEditorDnD.ts
+++ b/frontend/src/app/(post)/_hooks/useRecordEditorDnD.ts
@@ -4,7 +4,8 @@ import { FieldType } from '@/lib/types/record';
 import { normalizeLayout } from '../_utils/recordLayoutHelper';
 import { PatchApplyPayload } from '@/lib/types/recordCollaboration';
 
-const DRAG_THRESHOLD = 8;
+const LONG_PRESS_DURATION = 300; // ms — 이 시간 이상 누르고 있어야 드래그 시작
+const SCROLL_CANCEL_THRESHOLD = 6; // px — 롱프레스 대기 중 이 이상 움직이면 스크롤로 판단해 취소
 
 export const useRecordEditorDnD = (
   blocks: RecordBlock[],
@@ -21,20 +22,22 @@ export const useRecordEditorDnD = (
   const pointerIdRef = useRef<number | null>(null);
   const capturedElementRef = useRef<HTMLElement | null>(null);
 
-  // pointer 이벤트 기반 드래그 대기 (non-textarea/input)
+  // pointer 이벤트 기반 롱프레스 대기 (non-textarea/input)
   const pendingDragRef = useRef<{
     pointerId: number;
     blockId: string;
     startX: number;
     startY: number;
+    timer: ReturnType<typeof setTimeout>;
   } | null>(null);
 
-  // touch 이벤트 기반 드래그 대기 (textarea/input — iOS pointercancel 우회)
+  // touch 이벤트 기반 롱프레스 대기 (textarea/input — iOS pointercancel 우회)
   const pendingTouchDragRef = useRef<{
     touchId: number;
     blockId: string;
     startX: number;
     startY: number;
+    timer: ReturnType<typeof setTimeout>;
   } | null>(null);
 
   // blocks를 ref로 미러링 — 전역 listener에서 항상 최신 값 참조
@@ -57,17 +60,42 @@ export const useRecordEditorDnD = (
       const blockId = blockEl.getAttribute('data-block-id');
       if (!blockId) return;
 
+      const timer = setTimeout(() => {
+        if (pendingDragRef.current?.blockId === blockId) {
+          // 롱프레스 완료 → 드래그 활성화
+          const blockEl = document.querySelector(
+            `[data-block-id="${blockId}"]`,
+          ) as HTMLElement | null;
+          if (blockEl) {
+            try {
+              blockEl.setPointerCapture(e.pointerId);
+            } catch {}
+            pointerIdRef.current = e.pointerId;
+            capturedElementRef.current = blockEl;
+          }
+          isPointerDraggingRef.current = true;
+          isDraggingIdRef.current = blockId;
+          setIsDraggingId(blockId);
+          pendingDragRef.current = null;
+        }
+      }, LONG_PRESS_DURATION);
+
       pendingDragRef.current = {
         pointerId: e.pointerId,
         blockId,
         startX: e.clientX,
         startY: e.clientY,
+        timer,
       };
     };
 
-    document.addEventListener('pointerdown', handleGlobalDown, { capture: true });
+    document.addEventListener('pointerdown', handleGlobalDown, {
+      capture: true,
+    });
     return () => {
-      document.removeEventListener('pointerdown', handleGlobalDown, { capture: true });
+      document.removeEventListener('pointerdown', handleGlobalDown, {
+        capture: true,
+      });
     };
   }, []);
 
@@ -87,11 +115,22 @@ export const useRecordEditorDnD = (
       const touch = e.changedTouches[0];
       if (!touch) return;
 
+      const timer = setTimeout(() => {
+        if (pendingTouchDragRef.current?.blockId === blockId) {
+          // 롱프레스 완료 → 드래그 활성화
+          isPointerDraggingRef.current = true;
+          isDraggingIdRef.current = blockId;
+          setIsDraggingId(blockId);
+          pendingTouchDragRef.current = null;
+        }
+      }, LONG_PRESS_DURATION);
+
       pendingTouchDragRef.current = {
         touchId: touch.identifier,
         blockId,
         startX: touch.clientX,
         startY: touch.clientY,
+        timer,
       };
     };
 
@@ -100,7 +139,9 @@ export const useRecordEditorDnD = (
       capture: true,
     });
     return () => {
-      document.removeEventListener('touchstart', handleGlobalTouchStart, { capture: true });
+      document.removeEventListener('touchstart', handleGlobalTouchStart, {
+        capture: true,
+      });
     };
   }, []);
 
@@ -120,7 +161,9 @@ export const useRecordEditorDnD = (
       lastUpdateRef.current = now;
 
       const currentBlocks = blocksRef.current;
-      const dragIdx = currentBlocks.findIndex((b) => b.id === currentDraggingId);
+      const dragIdx = currentBlocks.findIndex(
+        (b) => b.id === currentDraggingId,
+      );
       const hoverIdx = currentBlocks.findIndex((b) => b.id === targetId);
       if (dragIdx === -1 || hoverIdx === -1) return;
 
@@ -158,7 +201,10 @@ export const useRecordEditorDnD = (
         draggingBlock.layout.span !== nextSpan ||
         hoverNextSpan !== hoverBlock.layout.span
       ) {
-        const newBlocks = currentBlocks.map((b) => ({ ...b, layout: { ...b.layout } }));
+        const newBlocks = currentBlocks.map((b) => ({
+          ...b,
+          layout: { ...b.layout },
+        }));
         newBlocks[dragIdx].layout.span = nextSpan;
         if (hoverNextSpan !== hoverBlock.layout.span) {
           newBlocks[hoverIdx].layout.span = hoverNextSpan;
@@ -208,28 +254,21 @@ export const useRecordEditorDnD = (
 
     // pointer 이벤트 기반 drag (non-textarea/input)
     const handleGlobalMove = (e: PointerEvent) => {
-      if (pendingDragRef.current && e.pointerId === pendingDragRef.current.pointerId) {
+      if (
+        pendingDragRef.current &&
+        e.pointerId === pendingDragRef.current.pointerId
+      ) {
         const dx = e.clientX - pendingDragRef.current.startX;
         const dy = e.clientY - pendingDragRef.current.startY;
-        if (dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) {
-          const { pointerId, blockId } = pendingDragRef.current;
-          const blockEl = document.querySelector(
-            `[data-block-id="${blockId}"]`,
-          ) as HTMLElement | null;
-          if (blockEl) {
-            try {
-              blockEl.setPointerCapture(pointerId);
-            } catch {}
-            pointerIdRef.current = pointerId;
-            capturedElementRef.current = blockEl;
-          }
-          isPointerDraggingRef.current = true;
-          isDraggingIdRef.current = blockId;
-          setIsDraggingId(blockId);
+        // 롱프레스 대기 중 스크롤 의도 감지 → 타이머 취소
+        if (
+          dx * dx + dy * dy >
+          SCROLL_CANCEL_THRESHOLD * SCROLL_CANCEL_THRESHOLD
+        ) {
+          clearTimeout(pendingDragRef.current.timer);
           pendingDragRef.current = null;
-        } else {
-          return;
         }
+        return;
       }
 
       processDragOver(e.clientX, e.clientY);
@@ -237,28 +276,30 @@ export const useRecordEditorDnD = (
 
     // touch 이벤트 기반 drag (textarea/input — iOS pointercancel 우회)
     const handleGlobalTouchMove = (e: TouchEvent) => {
-      const touch = Array.from(e.changedTouches).find(
-        (t) =>
+      const touch =
+        Array.from(e.changedTouches).find((t) =>
           pendingTouchDragRef.current
             ? t.identifier === pendingTouchDragRef.current.touchId
             : false,
-      ) ?? (isPointerDraggingRef.current ? e.touches[0] : null);
+        ) ?? (isPointerDraggingRef.current ? e.touches[0] : null);
 
       if (!touch) return;
 
-      if (pendingTouchDragRef.current && touch.identifier === pendingTouchDragRef.current.touchId) {
+      if (
+        pendingTouchDragRef.current &&
+        touch.identifier === pendingTouchDragRef.current.touchId
+      ) {
         const dx = touch.clientX - pendingTouchDragRef.current.startX;
         const dy = touch.clientY - pendingTouchDragRef.current.startY;
-        if (dx * dx + dy * dy > DRAG_THRESHOLD * DRAG_THRESHOLD) {
-          e.preventDefault();
-          const { blockId } = pendingTouchDragRef.current;
-          isPointerDraggingRef.current = true;
-          isDraggingIdRef.current = blockId;
-          setIsDraggingId(blockId);
+        // 롱프레스 대기 중 스크롤 의도 감지 → 타이머 취소
+        if (
+          dx * dx + dy * dy >
+          SCROLL_CANCEL_THRESHOLD * SCROLL_CANCEL_THRESHOLD
+        ) {
+          clearTimeout(pendingTouchDragRef.current.timer);
           pendingTouchDragRef.current = null;
-        } else {
-          return;
         }
+        return;
       }
 
       if (isPointerDraggingRef.current && isDraggingIdRef.current) {
@@ -268,7 +309,11 @@ export const useRecordEditorDnD = (
     };
 
     const handleGlobalUp = (e: PointerEvent) => {
-      if (pendingDragRef.current && e.pointerId === pendingDragRef.current.pointerId) {
+      if (
+        pendingDragRef.current &&
+        e.pointerId === pendingDragRef.current.pointerId
+      ) {
+        clearTimeout(pendingDragRef.current.timer);
         pendingDragRef.current = null;
       }
     };
@@ -280,12 +325,17 @@ export const useRecordEditorDnD = (
           (t) => t.identifier === pendingTouchDragRef.current?.touchId,
         )
       ) {
+        clearTimeout(pendingTouchDragRef.current.timer);
         pendingTouchDragRef.current = null;
       }
     };
 
-    document.addEventListener('pointermove', handleGlobalMove, { passive: true });
-    document.addEventListener('touchmove', handleGlobalTouchMove, { passive: false });
+    document.addEventListener('pointermove', handleGlobalMove, {
+      passive: true,
+    });
+    document.addEventListener('touchmove', handleGlobalTouchMove, {
+      passive: false,
+    });
     document.addEventListener('pointerup', handleGlobalUp);
     document.addEventListener('pointercancel', handleGlobalUp);
     document.addEventListener('touchend', handleTouchEnd);
@@ -302,8 +352,14 @@ export const useRecordEditorDnD = (
   }, [canBeHalfWidth, setBlocks]);
 
   const handleDragEnd = useCallback(() => {
-    pendingDragRef.current = null;
-    pendingTouchDragRef.current = null;
+    if (pendingDragRef.current) {
+      clearTimeout(pendingDragRef.current.timer);
+      pendingDragRef.current = null;
+    }
+    if (pendingTouchDragRef.current) {
+      clearTimeout(pendingTouchDragRef.current.timer);
+      pendingTouchDragRef.current = null;
+    }
     isPointerDraggingRef.current = false;
 
     if (pointerIdRef.current !== null && capturedElementRef.current !== null) {
@@ -320,7 +376,10 @@ export const useRecordEditorDnD = (
         e.stopPropagation();
         e.preventDefault();
       };
-      document.addEventListener('click', suppressClick, { capture: true, once: true });
+      document.addEventListener('click', suppressClick, {
+        capture: true,
+        once: true,
+      });
       setTimeout(() => {
         document.removeEventListener('click', suppressClick, { capture: true });
       }, 300);

--- a/frontend/src/app/(post)/group/[groupId]/edit/_components/GroupInfo.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/edit/_components/GroupInfo.tsx
@@ -17,6 +17,7 @@ import GalleryDrawer from '@/app/(post)/_components/GalleryDrawer';
 import AssetImage from '@/components/AssetImage';
 import { GroupEditResponse } from '@/lib/types/groupResponse';
 import { memo, useCallback } from 'react';
+import { useIMEInput } from '@/hooks/useIMEInput';
 
 type GroupInfoProps = Pick<Group, 'groupThumnail'> & {
   groupId: string;
@@ -60,12 +61,7 @@ const GroupInfo = memo(function GroupInfo({ groupId, me }: GroupInfoProps) {
     setGroupName('');
   }, [setGroupName]);
 
-  const handleGroupNameChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setGroupName(e.target.value);
-    },
-    [setGroupName],
-  );
+  const groupNameImeProps = useIMEInput(setGroupName);
 
   const handleNavigateToProfile = useCallback(() => {
     router.push(`/group/${groupId}/edit/profile`);
@@ -139,7 +135,7 @@ const GroupInfo = memo(function GroupInfo({ groupId, me }: GroupInfoProps) {
             disabled={me.role === 'VIEWER'}
             value={groupName}
             placeholder="그룹명을 작성해주세요."
-            onChange={handleGroupNameChange}
+            {...groupNameImeProps}
             className={`mobile-input w-full border-b-2 bg-transparent px-1 py-4 text-sm font-semibold transition-all outline-none dark:text-white dark:placeholder-gray-700 text-itta-black placeholder-gray-300 ${
               groupNameError
                 ? 'border-red-500 dark:border-red-500 focus:border-red-500 dark:focus:border-red-500'

--- a/frontend/src/app/(post)/group/_components/GroupInviteDrawer.tsx
+++ b/frontend/src/app/(post)/group/_components/GroupInviteDrawer.tsx
@@ -100,7 +100,8 @@ export default function GroupInviteDrawer({ groupId }: GroupInviteDrawerProps) {
   const handleCopyCode = async () => {
     const code = inviteResult?.code || '잇다-';
     try {
-      await navigator.clipboard.writeText(getFullInviteUrl(code));
+      const { copyToClipboard } = await import('@/lib/utils/clipboard');
+      await copyToClipboard(getFullInviteUrl(code));
       setCopyStatus('success');
     } catch {
       setCopyStatus('error');
@@ -123,7 +124,8 @@ export default function GroupInviteDrawer({ groupId }: GroupInviteDrawerProps) {
     } else {
       // navigator.share 미지원 환경 → 링크 복사
       try {
-        await navigator.clipboard.writeText(url);
+        const { copyToClipboard } = await import('@/lib/utils/clipboard');
+        await copyToClipboard(url);
         setCopyStatus('success');
         setTimeout(() => setCopyStatus('idle'), 2000);
       } catch {

--- a/frontend/src/app/(post)/shared/_components/SharedHeaderActions.tsx
+++ b/frontend/src/app/(post)/shared/_components/SharedHeaderActions.tsx
@@ -203,7 +203,6 @@ export default function SharedHeaderActions() {
                     기록함 이름
                   </label>
                   <input
-                    autoFocus
                     type="text"
                     placeholder="예: 제주도 여행기"
                     value={newGroupName}

--- a/frontend/src/app/(post)/shared/_components/SharedHeaderActions.tsx
+++ b/frontend/src/app/(post)/shared/_components/SharedHeaderActions.tsx
@@ -175,79 +175,85 @@ export default function SharedHeaderActions() {
         >
           <Plus className="w-4 h-4 sm:w-5 sm:h-5" />
         </DrawerTrigger>
-        <DrawerContent className="w-full px-6 sm:px-8 pt-4 pb-8 sm:pb-10">
-          <div className="flex justify-between items-center mb-6 sm:mb-8 w-full">
-            <DrawerHeader className="pl-0">
-              <DrawerTitle className="flex flex-col justify-center items-start pl-0">
-                <span className="text-[9px] sm:text-[10px] font-bold text-[#10B981] uppercase tracking-widest leading-none mb-1">
-                  CREATE GROUP
-                </span>
-                <span className="text-base sm:text-xl dark:text-white text-itta-black">
-                  새 공유 기록함 만들기
-                </span>
-              </DrawerTitle>
-            </DrawerHeader>
-            <DrawerClose
-              onClick={() => setShowCreateModal(false)}
-              className="cursor-pointer p-2 text-gray-400"
-            >
-              <X className="w-6 h-6" />
-            </DrawerClose>
-          </div>
+        <DrawerContent className="h-[85%]">
+          <div className="w-full flex flex-col h-full overflow-hidden">
+            <div className="flex-1 overflow-y-auto px-6 sm:px-8 pt-4">
+              <div className="flex justify-between items-center mb-6 sm:mb-8 w-full">
+                <DrawerHeader className="pl-0">
+                  <DrawerTitle className="flex flex-col justify-center items-start pl-0">
+                    <span className="text-[9px] sm:text-[10px] font-bold text-[#10B981] uppercase tracking-widest leading-none mb-1">
+                      CREATE GROUP
+                    </span>
+                    <span className="text-base sm:text-xl dark:text-white text-itta-black">
+                      새 공유 기록함 만들기
+                    </span>
+                  </DrawerTitle>
+                </DrawerHeader>
+                <DrawerClose
+                  onClick={() => setShowCreateModal(false)}
+                  className="cursor-pointer p-2 text-gray-400"
+                >
+                  <X className="w-6 h-6" />
+                </DrawerClose>
+              </div>
 
-          <div className="space-y-4 sm:space-y-6 mb-8 sm:mb-10">
-            <div className="space-y-2">
-              <label className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">
-                기록함 이름
-              </label>
-              <input
-                autoFocus
-                type="text"
-                placeholder="예: 제주도 여행기"
-                value={newGroupName}
-                onChange={(e) => setNewGroupName(e.target.value)}
-                className="w-full border-b-2 bg-transparent py-2.5 sm:py-3 text-base sm:text-lg font-bold transition-all outline-none dark:border-white/5 dark:focus:border-[#10B981] dark:text-white border-gray-100 focus:border-[#10B981] text-itta-black"
-              />
-              {groupNicknameError ? (
-                <p className="text-[10px] text-red-500 font-medium">
-                  {groupNicknameError}
-                </p>
-              ) : (
-                <p className="text-[10px] text-gray-400 px-1">
-                  * 그룹 이름은 한글/영문/숫자/공백만 사용이 가능합니다.
-                </p>
-              )}
+              <div className="space-y-4 sm:space-y-6">
+                <div className="space-y-2">
+                  <label className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">
+                    기록함 이름
+                  </label>
+                  <input
+                    autoFocus
+                    type="text"
+                    placeholder="예: 제주도 여행기"
+                    value={newGroupName}
+                    onChange={(e) => setNewGroupName(e.target.value)}
+                    className="w-full border-b-2 bg-transparent py-2.5 sm:py-3 text-base sm:text-lg font-bold transition-all outline-none dark:border-white/5 dark:focus:border-[#10B981] dark:text-white border-gray-100 focus:border-[#10B981] text-itta-black"
+                  />
+                  {groupNicknameError ? (
+                    <p className="text-[10px] text-red-500 font-medium">
+                      {groupNicknameError}
+                    </p>
+                  ) : (
+                    <p className="text-[10px] text-gray-400 px-1">
+                      * 그룹 이름은 한글/영문/숫자/공백만 사용이 가능합니다.
+                    </p>
+                  )}
+                </div>
+              </div>
             </div>
-          </div>
 
-          <div className="flex gap-4">
-            <DrawerClose
-              onClick={() => setShowCreateModal(false)}
-              className="cursor-pointer flex-1 py-3 sm:py-4 rounded-xl sm:rounded-2xl font-bold text-xs sm:text-sm dark:bg-white/5 dark:text-gray-500 bg-gray-50 text-gray-400"
-            >
-              취소
-            </DrawerClose>
-            <button
-              onClick={handleCreateGroup}
-              disabled={
-                !newGroupName.trim() || !!groupNicknameError || isCreating
-              }
-              className={cn(
-                'flex-2 py-3 sm:py-4 rounded-xl sm:rounded-2xl font-bold text-xs sm:text-sm transition-all flex items-center justify-center gap-2',
-                newGroupName.trim() && !isCreating && !groupNicknameError
-                  ? 'bg-[#10B981] text-white active:scale-95 cursor-pointer'
-                  : 'bg-gray-100 text-gray-300 cursor-not-allowed',
-              )}
-            >
-              {isCreating ? (
-                '생성 중...'
-              ) : (
-                <>
-                  <CheckCircle2 className="w-5 h-5" />
-                  기록함 만들기
-                </>
-              )}
-            </button>
+            <div className="px-6 sm:px-8 pb-8 sm:pb-10 pt-4">
+              <div className="flex gap-4">
+                <DrawerClose
+                  onClick={() => setShowCreateModal(false)}
+                  className="cursor-pointer flex-1 py-3 sm:py-4 rounded-xl sm:rounded-2xl font-bold text-xs sm:text-sm dark:bg-white/5 dark:text-gray-500 bg-gray-50 text-gray-400"
+                >
+                  취소
+                </DrawerClose>
+                <button
+                  onClick={handleCreateGroup}
+                  disabled={
+                    !newGroupName.trim() || !!groupNicknameError || isCreating
+                  }
+                  className={cn(
+                    'flex-2 py-3 sm:py-4 rounded-xl sm:rounded-2xl font-bold text-xs sm:text-sm transition-all flex items-center justify-center gap-2',
+                    newGroupName.trim() && !isCreating && !groupNicknameError
+                      ? 'bg-[#10B981] text-white active:scale-95 cursor-pointer'
+                      : 'bg-gray-100 text-gray-300 cursor-not-allowed',
+                  )}
+                >
+                  {isCreating ? (
+                    '생성 중...'
+                  ) : (
+                    <>
+                      <CheckCircle2 className="w-5 h-5" />
+                      기록함 만들기
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
           </div>
         </DrawerContent>
       </Drawer>

--- a/frontend/src/app/(search)/_components/TagSearchDrawer.tsx
+++ b/frontend/src/app/(search)/_components/TagSearchDrawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import { useIMEInput } from '@/hooks/useIMEInput';
 import { Loader2, Search, Tag, X } from 'lucide-react';
 import {
   Drawer,
@@ -26,6 +27,7 @@ export default function TagSearchDrawer({
   onReset,
 }: Props) {
   const [keyword, setKeyword] = useState('');
+  const imeProps = useIMEInput(setKeyword);
   const { data: tags, isPending } = useQuery(userProfileTagSummaryOptions(10));
 
   const suggestedTags = useMemo(() => {
@@ -92,7 +94,7 @@ export default function TagSearchDrawer({
                   : '태그를 입력하세요'
               }
               value={keyword}
-              onChange={(e) => setKeyword(e.target.value)}
+              {...imeProps}
               onKeyDown={handleKeyDown}
               className="w-full py-3 sm:py-4 pl-10 sm:pl-12 pr-3 sm:pr-4 rounded-lg sm:rounded-xl bg-gray-50 dark:bg-white/5 border-none mobile-input text-itta-black dark:text-white placeholder-gray-400 outline-none focus:ring-1 focus:ring-itta-point/60 transition-all shadow-inner"
             />

--- a/frontend/src/app/(search)/_components/TagSearchDrawer.tsx
+++ b/frontend/src/app/(search)/_components/TagSearchDrawer.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import { useIMEInput } from '@/hooks/useIMEInput';
-import { Loader2, Search, Tag, X } from 'lucide-react';
+import { Loader2, Plus, Search, Tag, X } from 'lucide-react';
 import {
   Drawer,
   DrawerContent,
@@ -46,6 +46,14 @@ export default function TagSearchDrawer({
     }
   };
 
+  // 태그 추가 로직
+  const addTag = () => {
+    if (!selectedTags.includes(keyword.trim())) {
+      onToggleTag(keyword.trim());
+    }
+    setKeyword(''); // 입력창 초기화
+  };
+
   return (
     <Drawer open={true} onOpenChange={(open) => !open && onClose()}>
       <DrawerContent className="h-[85%] dark:bg-[#1E1E1E]">
@@ -64,7 +72,7 @@ export default function TagSearchDrawer({
 
             {/* 현재 선택된 태그 리스트 */}
             {selectedTags.length !== 0 && (
-              <div className="flex flex-wrap gap-1.5 sm:gap-2 mb-2 sm:mb-3 min-h-7 sm:min-h-8">
+              <div className="flex flex-wrap gap-1.5 sm:gap-2 min-h-7 sm:min-h-8">
                 {selectedTags.map((tag) => (
                   <span
                     key={tag}
@@ -86,27 +94,36 @@ export default function TagSearchDrawer({
               </div>
             )}
             {/* 검색 및 상태 입력창 */}
-            <div className="relative group">
-              <input
-                type="text"
-                placeholder={
-                  selectedTags.length > 0
-                    ? `${selectedTags.length}개의 태그 선택됨`
-                    : '태그를 입력하세요'
-                }
-                value={keyword}
-                {...imeProps}
-                onKeyDown={handleKeyDown}
-                className="w-full py-3 sm:py-4 pl-10 sm:pl-12 pr-3 sm:pr-4 rounded-lg sm:rounded-xl bg-gray-50 dark:bg-white/5 border-none mobile-input text-itta-black dark:text-white placeholder-gray-400 outline-none focus:ring-1 focus:ring-itta-point/60 transition-all shadow-inner"
-              />
-              <Search
-                size={16}
-                className="absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-itta-point transition-colors sm:hidden"
-              />
-              <Search
-                size={18}
-                className="absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-itta-point transition-colors hidden sm:block"
-              />
+            <div className="relative group flex justify-center items-center gap-1.5 sm:gap-2">
+              <div className="w-full">
+                <input
+                  type="text"
+                  placeholder={
+                    selectedTags.length > 0
+                      ? `${selectedTags.length}개의 태그 선택됨`
+                      : '태그를 입력하세요'
+                  }
+                  value={keyword}
+                  {...imeProps}
+                  onKeyDown={handleKeyDown}
+                  className="w-full py-3 sm:py-4 pl-10 sm:pl-12 pr-3 sm:pr-4 rounded-lg sm:rounded-xl bg-gray-50 dark:bg-white/5 border-none mobile-input text-itta-black dark:text-white placeholder-gray-400 outline-none focus:ring-1 focus:ring-itta-point/60 transition-all shadow-inner"
+                />
+                <Search
+                  size={16}
+                  className="absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-itta-point transition-colors sm:hidden"
+                />
+                <Search
+                  size={18}
+                  className="absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-itta-point transition-colors hidden sm:block"
+                />
+              </div>
+              <button
+                onClick={addTag}
+                className="p-2.5 sm:p-3 rounded-xl sm:rounded-2xl bg-itta-point text-white shadow-lg shadow-itta-point/20 active:scale-90 transition-transform"
+              >
+                <Plus size={18} className="sm:hidden" />
+                <Plus size={20} className="hidden sm:block" />
+              </button>
             </div>
 
             {/* 태그 목록 영역 */}
@@ -135,7 +152,9 @@ export default function TagSearchDrawer({
                       >
                         <span
                           className={
-                            isSelected ? 'text-itta-point' : 'text-itta-point/40'
+                            isSelected
+                              ? 'text-itta-point'
+                              : 'text-itta-point/40'
                           }
                         >
                           #

--- a/frontend/src/app/(search)/_components/TagSearchDrawer.tsx
+++ b/frontend/src/app/(search)/_components/TagSearchDrawer.tsx
@@ -48,136 +48,140 @@ export default function TagSearchDrawer({
 
   return (
     <Drawer open={true} onOpenChange={(open) => !open && onClose()}>
-      <DrawerContent className="dark:bg-[#1E1E1E]">
-        <div className="w-full px-6 sm:px-8 pt-4 pb-10 sm:pb-12 flex flex-col gap-3 sm:gap-4">
-          <DrawerHeader className="px-0 relative">
-            <div className="flex flex-col text-left">
-              <span className="text-[10px] sm:text-[11px] font-black text-itta-point uppercase tracking-[0.2em] sm:tracking-widest mb-1">
-                COMBO SEARCH
-              </span>
-              <DrawerTitle className="text-base sm:text-lg font-bold text-itta-black dark:text-white">
-                여러 태그로 검색
-              </DrawerTitle>
-            </div>
-          </DrawerHeader>
-
-          {/* 현재 선택된 태그 리스트 */}
-          {selectedTags.length !== 0 && (
-            <div className="flex flex-wrap gap-1.5 sm:gap-2 mb-2 sm:mb-3 min-h-7 sm:min-h-8">
-              {selectedTags.map((tag) => (
-                <span
-                  key={tag}
-                  className="flex items-center gap-1 sm:gap-1.5 px-2 sm:px-3 py-1 sm:py-1.5 rounded-lg bg-itta-point/10 text-itta-point text-[11px] sm:text-xs font-bold animate-in fade-in zoom-in-95"
-                >
-                  #{tag}
-                  <X
-                    size={12}
-                    className="cursor-pointer hover:text-rose-500 transition-colors sm:hidden"
-                    onClick={() => onToggleTag(tag)}
-                  />
-                  <X
-                    size={14}
-                    className="cursor-pointer hover:text-rose-500 transition-colors hidden sm:block"
-                    onClick={() => onToggleTag(tag)}
-                  />
+      <DrawerContent className="h-[85%] dark:bg-[#1E1E1E]">
+        <div className="w-full flex flex-col h-full overflow-hidden">
+          <div className="flex-1 overflow-y-auto px-6 sm:px-8 pt-4 flex flex-col gap-3 sm:gap-4">
+            <DrawerHeader className="px-0 relative">
+              <div className="flex flex-col text-left">
+                <span className="text-[10px] sm:text-[11px] font-black text-itta-point uppercase tracking-[0.2em] sm:tracking-widest mb-1">
+                  COMBO SEARCH
                 </span>
-              ))}
-            </div>
-          )}
-          {/* 검색 및 상태 입력창 */}
-          <div className="flex-[2.5] relative group">
-            <input
-              type="text"
-              placeholder={
-                selectedTags.length > 0
-                  ? `${selectedTags.length}개의 태그 선택됨`
-                  : '태그를 입력하세요'
-              }
-              value={keyword}
-              {...imeProps}
-              onKeyDown={handleKeyDown}
-              className="w-full py-3 sm:py-4 pl-10 sm:pl-12 pr-3 sm:pr-4 rounded-lg sm:rounded-xl bg-gray-50 dark:bg-white/5 border-none mobile-input text-itta-black dark:text-white placeholder-gray-400 outline-none focus:ring-1 focus:ring-itta-point/60 transition-all shadow-inner"
-            />
-            <Search
-              size={16}
-              className="absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-itta-point transition-colors sm:hidden"
-            />
-            <Search
-              size={18}
-              className="absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-itta-point transition-colors hidden sm:block"
-            />
-          </div>
+                <DrawerTitle className="text-base sm:text-lg font-bold text-itta-black dark:text-white">
+                  여러 태그로 검색
+                </DrawerTitle>
+              </div>
+            </DrawerHeader>
 
-          {/* 태그 목록 영역 */}
-          <section className="flex flex-col space-y-3 sm:space-y-4">
-            <p className="text-[10px] sm:text-xs font-bold text-itta-gray3">
-              자주 사용한 태그
-            </p>
-            {isPending && (
-              <div className="flex-1 flex items-center justify-center">
-                <Loader2 className="w-5 sm:w-6 h-5 sm:h-6 animate-spin text-itta-point" />
-              </div>
-            )}
-            {suggestedTags && suggestedTags?.length > 0 && (
-              <div className="flex flex-wrap gap-1.5 sm:gap-2 mb-10 min-h-30 content-start overflow-y-auto max-h-75 hide-scrollbar">
-                {suggestedTags?.map((tag) => {
-                  const isSelected = selectedTags.includes(tag);
-                  return (
-                    <button
-                      key={tag}
+            {/* 현재 선택된 태그 리스트 */}
+            {selectedTags.length !== 0 && (
+              <div className="flex flex-wrap gap-1.5 sm:gap-2 mb-2 sm:mb-3 min-h-7 sm:min-h-8">
+                {selectedTags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="flex items-center gap-1 sm:gap-1.5 px-2 sm:px-3 py-1 sm:py-1.5 rounded-lg bg-itta-point/10 text-itta-point text-[11px] sm:text-xs font-bold animate-in fade-in zoom-in-95"
+                  >
+                    #{tag}
+                    <X
+                      size={12}
+                      className="cursor-pointer hover:text-rose-500 transition-colors sm:hidden"
                       onClick={() => onToggleTag(tag)}
-                      className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-2xl text-xs sm:text-sm font-bold border transition-all ${
-                        isSelected
-                          ? 'bg-itta-point/5 border-itta-point text-itta-point'
-                          : 'bg-white dark:bg-white/5 border-gray-100 dark:border-white/5 text-itta-gray3 hover:border-gray-200'
-                      }`}
-                    >
-                      <span
-                        className={
-                          isSelected ? 'text-itta-point' : 'text-itta-point/40'
-                        }
-                      >
-                        #
-                      </span>{' '}
-                      {tag}
-                    </button>
-                  );
-                })}
+                    />
+                    <X
+                      size={14}
+                      className="cursor-pointer hover:text-rose-500 transition-colors hidden sm:block"
+                      onClick={() => onToggleTag(tag)}
+                    />
+                  </span>
+                ))}
               </div>
             )}
-            {suggestedTags?.length === 0 && (
-              <div className="flex items-center justify-center h-full">
-                <div className="w-full py-4 flex flex-col items-center justify-center gap-2">
-                  <div className="w-10 sm:w-12 h-10 sm:h-12 rounded-full flex items-center justify-center dark:bg-[#10B981]/10 bg-[#10B981]/10">
-                    <Tag className="w-4 sm:w-5 h-4 sm:h-5 text-[#10B981]" />
-                  </div>
-                  <div className="space-y-0.5 sm:space-y-1 text-center">
-                    <p className="text-xs sm:text-sm font-bold dark:text-gray-200 text-gray-700">
-                      아직 사용한 태그가 없어요
-                    </p>
-                    <p className="text-[11px] sm:text-xs text-gray-400">
-                      태그를 추가하여 기록을 분류해보세요
-                    </p>
+            {/* 검색 및 상태 입력창 */}
+            <div className="relative group">
+              <input
+                type="text"
+                placeholder={
+                  selectedTags.length > 0
+                    ? `${selectedTags.length}개의 태그 선택됨`
+                    : '태그를 입력하세요'
+                }
+                value={keyword}
+                {...imeProps}
+                onKeyDown={handleKeyDown}
+                className="w-full py-3 sm:py-4 pl-10 sm:pl-12 pr-3 sm:pr-4 rounded-lg sm:rounded-xl bg-gray-50 dark:bg-white/5 border-none mobile-input text-itta-black dark:text-white placeholder-gray-400 outline-none focus:ring-1 focus:ring-itta-point/60 transition-all shadow-inner"
+              />
+              <Search
+                size={16}
+                className="absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-itta-point transition-colors sm:hidden"
+              />
+              <Search
+                size={18}
+                className="absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-itta-point transition-colors hidden sm:block"
+              />
+            </div>
+
+            {/* 태그 목록 영역 */}
+            <section className="flex flex-col space-y-3 sm:space-y-4">
+              <p className="text-[10px] sm:text-xs font-bold text-itta-gray3">
+                자주 사용한 태그
+              </p>
+              {isPending && (
+                <div className="flex-1 flex items-center justify-center">
+                  <Loader2 className="w-5 sm:w-6 h-5 sm:h-6 animate-spin text-itta-point" />
+                </div>
+              )}
+              {suggestedTags && suggestedTags?.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 sm:gap-2 mb-10 min-h-30 content-start overflow-y-auto max-h-75 hide-scrollbar">
+                  {suggestedTags?.map((tag) => {
+                    const isSelected = selectedTags.includes(tag);
+                    return (
+                      <button
+                        key={tag}
+                        onClick={() => onToggleTag(tag)}
+                        className={`px-3 sm:px-4 py-1.5 sm:py-2 rounded-2xl text-xs sm:text-sm font-bold border transition-all ${
+                          isSelected
+                            ? 'bg-itta-point/5 border-itta-point text-itta-point'
+                            : 'bg-white dark:bg-white/5 border-gray-100 dark:border-white/5 text-itta-gray3 hover:border-gray-200'
+                        }`}
+                      >
+                        <span
+                          className={
+                            isSelected ? 'text-itta-point' : 'text-itta-point/40'
+                          }
+                        >
+                          #
+                        </span>{' '}
+                        {tag}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+              {suggestedTags?.length === 0 && (
+                <div className="flex items-center justify-center h-full">
+                  <div className="w-full py-4 flex flex-col items-center justify-center gap-2">
+                    <div className="w-10 sm:w-12 h-10 sm:h-12 rounded-full flex items-center justify-center dark:bg-[#10B981]/10 bg-[#10B981]/10">
+                      <Tag className="w-4 sm:w-5 h-4 sm:h-5 text-[#10B981]" />
+                    </div>
+                    <div className="space-y-0.5 sm:space-y-1 text-center">
+                      <p className="text-xs sm:text-sm font-bold dark:text-gray-200 text-gray-700">
+                        아직 사용한 태그가 없어요
+                      </p>
+                      <p className="text-[11px] sm:text-xs text-gray-400">
+                        태그를 추가하여 기록을 분류해보세요
+                      </p>
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
-          </section>
+              )}
+            </section>
+          </div>
 
-          {/* 하단 액션바 */}
-          <div className="flex gap-2 sm:gap-3 items-center">
-            <button
-              onClick={onReset}
-              className="flex-1 py-3 sm:py-4 bg-white dark:bg-white/5 border border-gray-50 dark:border-white/5 rounded-2xl text-itta-point font-bold text-xs sm:text-sm shadow-sm active:scale-95 transition-all"
-            >
-              초기화
-            </button>
-            <button
-              onClick={onClose}
-              className="flex-1 py-3 sm:py-4 bg-itta-black text-white dark:bg-white dark:text-black border border-gray-50 dark:border-white/5 rounded-2xl font-bold text-xs sm:text-sm shadow-sm active:scale-95 transition-all"
-            >
-              완료
-            </button>
+          {/* 고정 푸터 */}
+          <div className="px-6 sm:px-8 pb-8 sm:pb-10 pt-4">
+            <div className="flex gap-2 sm:gap-3 items-center">
+              <button
+                onClick={onReset}
+                className="flex-1 py-3 sm:py-4 bg-white dark:bg-white/5 border border-gray-50 dark:border-white/5 rounded-2xl text-itta-point font-bold text-xs sm:text-sm shadow-sm active:scale-95 transition-all"
+              >
+                초기화
+              </button>
+              <button
+                onClick={onClose}
+                className="flex-1 py-3 sm:py-4 bg-itta-black text-white dark:bg-white dark:text-black border border-gray-50 dark:border-white/5 rounded-2xl font-bold text-xs sm:text-sm shadow-sm active:scale-95 transition-all"
+              >
+                완료
+              </button>
+            </div>
           </div>
         </div>
       </DrawerContent>

--- a/frontend/src/app/(search)/search/page.tsx
+++ b/frontend/src/app/(search)/search/page.tsx
@@ -114,7 +114,7 @@ export default function SearchPage() {
     <div className="w-full flex flex-col h-full bg-white dark:bg-[#121212]">
       <header
         style={{ marginTop: 'calc(env(safe-area-inset-top))' }}
-        className="fixed top-0 left-0 right-0 z-20 bg-white/90 dark:bg-[#121212]/90 backdrop-blur-md p-3 sm:p-4 space-y-3 sm:space-y-4"
+        className="fixed top-0 left-0 right-0 max-w-4xl mx-auto z-20 bg-white/90 dark:bg-[#121212]/90 backdrop-blur-md p-3 sm:p-4 space-y-3 sm:space-y-4"
       >
         {/* 검색바 영역 */}
         <div className="flex items-center gap-2 sm:gap-3">

--- a/frontend/src/app/(search)/search/page.tsx
+++ b/frontend/src/app/(search)/search/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useRef, useState } from 'react';
+import { useIMEInput } from '@/hooks/useIMEInput';
 import { useRouter } from 'next/navigation';
 import { Search, X, Loader2, Clock } from 'lucide-react';
 import { FilterChip } from '@/components/search/FilterChip';
@@ -104,6 +105,7 @@ export default function SearchPage() {
 
     debouncedUpdateQuery(val);
   };
+  const queryImeProps = useIMEInput(handleQueryChange);
 
   // 키워드 클릭 핸들러
   const handleKeywordClick = (val: string) => {
@@ -124,7 +126,7 @@ export default function SearchPage() {
               type="text"
               placeholder="제목이나 내용으로 검색"
               value={localQuery}
-              onChange={(e) => handleQueryChange(e.target.value)}
+              {...queryImeProps}
               className="w-full rounded-lg px-9 sm:px-11 py-2.5 sm:py-3 bg-gray-50 dark:bg-white/5 mobile-input outline-none dark:text-white"
             />
             <Search className="absolute left-3 sm:left-4 top-1/2 -translate-y-1/2 w-3.5 sm:w-4 h-3.5 sm:h-4 text-gray-400" />

--- a/frontend/src/app/AuthContext.tsx
+++ b/frontend/src/app/AuthContext.tsx
@@ -1,15 +1,22 @@
 'use client';
 
-import { SessionProvider, getSession, signOut, useSession } from 'next-auth/react';
+import {
+  SessionProvider,
+  getSession,
+  signOut,
+  useSession,
+} from 'next-auth/react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useEffect } from 'react';
+import { useTheme } from 'next-themes';
 import { useAuthStore } from '@/store/useAuthStore';
 import { invalidateSessionCache } from '@/lib/api/auth';
 
 const isNativePlatform = () =>
   typeof window !== 'undefined' &&
-  !!(window as unknown as { Capacitor?: { isNativePlatform?: () => boolean } })
-    .Capacitor?.isNativePlatform?.();
+  !!(
+    window as unknown as { Capacitor?: { isNativePlatform?: () => boolean } }
+  ).Capacitor?.isNativePlatform?.();
 
 function SessionGuard({ children }: { children: React.ReactNode }) {
   const { status, data: session } = useSession();
@@ -17,6 +24,26 @@ function SessionGuard({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const userType = useAuthStore((state) => state.userType);
   const logout = useAuthStore((state) => state.logout);
+  const { resolvedTheme } = useTheme();
+
+  // Android 네이티브 앱: 테마 변경 시 상태바 아이콘 색상 동기화
+  useEffect(() => {
+    if (!isNativePlatform()) return;
+    if (typeof window === 'undefined') return;
+    const platform = (
+      window as unknown as { Capacitor?: { getPlatform?: () => string } }
+    ).Capacitor?.getPlatform?.();
+    if (platform !== 'android') return;
+
+    (async () => {
+      try {
+        const { StatusBar, Style } = await import('@capacitor/status-bar');
+        await StatusBar.setStyle({
+          style: resolvedTheme === 'dark' ? Style.Dark : Style.Light,
+        });
+      } catch {}
+    })();
+  }, [resolvedTheme]);
 
   // Capacitor 네이티브 앱: 포그라운드 복귀 시 세션 갱신
   // refetchOnWindowFocus가 네이티브 WebView에서 동작하지 않으므로 명시적으로 처리

--- a/frontend/src/app/AuthContext.tsx
+++ b/frontend/src/app/AuthContext.tsx
@@ -26,24 +26,6 @@ function SessionGuard({ children }: { children: React.ReactNode }) {
   const logout = useAuthStore((state) => state.logout);
   const { resolvedTheme } = useTheme();
 
-  // Android 네이티브 앱: 테마 변경 시 상태바 아이콘 색상 동기화
-  useEffect(() => {
-    if (!isNativePlatform()) return;
-    if (typeof window === 'undefined') return;
-    const platform = (
-      window as unknown as { Capacitor?: { getPlatform?: () => string } }
-    ).Capacitor?.getPlatform?.();
-    if (platform !== 'android') return;
-
-    (async () => {
-      try {
-        const { StatusBar, Style } = await import('@capacitor/status-bar');
-        await StatusBar.setStyle({
-          style: resolvedTheme === 'dark' ? Style.Dark : Style.Light,
-        });
-      } catch {}
-    })();
-  }, [resolvedTheme]);
 
   // Capacitor 네이티브 앱: 포그라운드 복귀 시 세션 갱신
   // refetchOnWindowFocus가 네이티브 WebView에서 동작하지 않으므로 명시적으로 처리
@@ -91,8 +73,9 @@ function SessionGuard({ children }: { children: React.ReactNode }) {
       } else {
         try {
           const { StatusBar, Style } = await import('@capacitor/status-bar');
+          // Style.Light = light icons (dark background용), Style.Dark = dark icons (light background용)
           await StatusBar.setStyle({
-            style: resolvedTheme === 'dark' ? Style.Dark : Style.Light,
+            style: resolvedTheme === 'dark' ? Style.Light : Style.Dark,
           });
         } catch {}
       }

--- a/frontend/src/app/AuthContext.tsx
+++ b/frontend/src/app/AuthContext.tsx
@@ -75,27 +75,37 @@ function SessionGuard({ children }: { children: React.ReactNode }) {
     if (!isNativePlatform()) return;
 
     (async () => {
-      try {
-        const platform = (
-          window as unknown as { Capacitor?: { getPlatform?: () => string } }
-        ).Capacitor?.getPlatform?.();
-        if (platform === 'android') {
+      const platform = (
+        window as unknown as { Capacitor?: { getPlatform?: () => string } }
+      ).Capacitor?.getPlatform?.();
+      const androidTheme = resolvedTheme === 'dark' ? 'dark' : 'light';
+      const androidBridge = (
+        window as unknown as {
+          AndroidBridge?: { themeChange: (t: string) => void };
+        }
+      ).AndroidBridge;
+
+      // SplashScreen 페이드아웃 전: 커버뷰 배경색 + 아이콘 색상 먼저 설정
+      if (platform === 'android') {
+        androidBridge?.themeChange(androidTheme);
+      } else {
+        try {
           const { StatusBar, Style } = await import('@capacitor/status-bar');
           await StatusBar.setStyle({
             style: resolvedTheme === 'dark' ? Style.Dark : Style.Light,
           });
-          // 커버뷰 배경색도 SplashScreen 숨기기 전에 미리 설정 (흰색 flash 방지)
-          (
-            window as unknown as {
-              AndroidBridge?: { themeChange: (t: string) => void };
-            }
-          ).AndroidBridge?.themeChange(resolvedTheme === 'dark' ? 'dark' : 'light');
-        }
-      } catch {}
+        } catch {}
+      }
+
       try {
         const { SplashScreen } = await import('@capacitor/splash-screen');
         await SplashScreen.hide({ fadeOutDuration: 300 });
       } catch {}
+
+      // SplashScreen hide 완료 후 재적용: hide() 내부에서 플래그가 리셋될 수 있음
+      if (platform === 'android') {
+        androidBridge?.themeChange(androidTheme);
+      }
     })();
   }, [status, resolvedTheme]);
 

--- a/frontend/src/app/AuthContext.tsx
+++ b/frontend/src/app/AuthContext.tsx
@@ -67,18 +67,37 @@ function SessionGuard({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  // 세션 확정 시 스플래시 숨기기
+  // 세션 + 테마 모두 확정된 후 status bar 설정 → 스플래시 숨기기
+  // resolvedTheme가 결정되기 전에 숨기면 status bar가 잠깐 기본(light) 상태로 노출됨
   useEffect(() => {
     if (status === 'loading') return;
+    if (!resolvedTheme) return; // 테마 미확정 시 대기
     if (!isNativePlatform()) return;
 
     (async () => {
+      try {
+        const platform = (
+          window as unknown as { Capacitor?: { getPlatform?: () => string } }
+        ).Capacitor?.getPlatform?.();
+        if (platform === 'android') {
+          const { StatusBar, Style } = await import('@capacitor/status-bar');
+          await StatusBar.setStyle({
+            style: resolvedTheme === 'dark' ? Style.Dark : Style.Light,
+          });
+          // 커버뷰 배경색도 SplashScreen 숨기기 전에 미리 설정 (흰색 flash 방지)
+          (
+            window as unknown as {
+              AndroidBridge?: { themeChange: (t: string) => void };
+            }
+          ).AndroidBridge?.themeChange(resolvedTheme === 'dark' ? 'dark' : 'light');
+        }
+      } catch {}
       try {
         const { SplashScreen } = await import('@capacitor/splash-screen');
         await SplashScreen.hide({ fadeOutDuration: 300 });
       } catch {}
     })();
-  }, [status]);
+  }, [status, resolvedTheme]);
 
   useEffect(() => {
     if (pathname.startsWith('/invite')) {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -22,7 +22,7 @@ html.cap-native [data-layout-spacer] {
 
 /* cap-native: StatusBarCover는 native UIView가 담당하므로 web layer에서 숨김.
    숨기면 drawer 열릴 때 statusbar 영역도 콘텐츠 영역과 동일한 배경 + DrawerOverlay로 seamless하게 렌더링됨. */
-html.cap-native [data-status-bar-cover] {
+html.cap-native:not(.cap-android) [data-status-bar-cover] {
   display: none;
 }
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -15,6 +15,7 @@ import { Suspense } from 'react';
 import StatusBarCover from '@/components/StatusBarCover';
 import NativeStatusBarSync from '@/components/NativeStatusBarSync';
 import NetworkGuard from '@/components/NetworkGuard';
+import AndroidBackHandler from '@/components/AndroidBackHandler';
 import { GoogleAnalytics } from '@next/third-parties/google';
 
 const notoSans = Noto_Sans_KR({
@@ -234,6 +235,7 @@ export default function RootLayout({
               <ThemeColorSetter />
               <NativeStatusBarSync />
               <NetworkGuard />
+              <AndroidBackHandler />
               <div data-app-root className="flex flex-col min-h-screen w-full mx-auto max-w-4xl relative transition-colors duration-300 dark:bg-[#121212] dark:text-white bg-white text-itta-black">
                 {/* status bar 커버: position fixed + 인라인 zIndex로 스크롤과 무관하게 항상 가림 */}
                 <StatusBarCover />

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -72,7 +72,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         richColors
         closeButton
         duration={3000}
-        offset={{ top: 32, bottom: 'calc(env(safe-area-inset-bottom) + 72px)' }}
+        offset={{ top: 32, bottom: 'var(--bottom-nav-height)' }}
         toastOptions={{
           classNames: {
             error: 'bg-red-500 text-white',

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -72,6 +72,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         richColors
         closeButton
         duration={3000}
+        offset={{ top: 32, bottom: 'calc(env(safe-area-inset-bottom) + 72px)' }}
         toastOptions={{
           classNames: {
             error: 'bg-red-500 text-white',

--- a/frontend/src/components/AndroidBackHandler.tsx
+++ b/frontend/src/components/AndroidBackHandler.tsx
@@ -6,10 +6,23 @@ import { toast } from 'sonner';
 
 /**
  * Android 하드웨어/제스처 뒤로가기 처리 컴포넌트.
+ * - drawer 등 오버레이가 열려 있으면 → 오버레이 닫기 (핸들러 스택)
  * - 뒤로 갈 히스토리가 있으면 → history.back()
  * - 루트(히스토리 없음)에서 한 번 → "한 번 더 누르면 종료" 토스트
  * - 2초 내 한 번 더 → 앱 종료
  */
+
+type BackHandler = () => void;
+const backHandlerStack: BackHandler[] = [];
+
+export function pushBackHandler(handler: BackHandler): () => void {
+  backHandlerStack.push(handler);
+  return () => {
+    const idx = backHandlerStack.lastIndexOf(handler);
+    if (idx >= 0) backHandlerStack.splice(idx, 1);
+  };
+}
+
 export default function AndroidBackHandler() {
   useEffect(() => {
     const platform = (
@@ -20,17 +33,14 @@ export default function AndroidBackHandler() {
     let backPressedOnce = false;
     let timer: ReturnType<typeof setTimeout>;
 
-    // 같은 pathname의 검색 파라미터 변경 히스토리를 건너뛰어 이전 "실제 페이지"로 이동
     const goBackToRealPage = () => {
       const originPathname = window.location.pathname;
 
       const tryBack = () => {
         const onPopState = () => {
           if (window.location.pathname === originPathname) {
-            // 같은 페이지(검색 파라미터만 다름) → 한 번 더 뒤로
             tryBack();
           }
-          // 다른 pathname으로 이동됐으면 완료
         };
         window.addEventListener('popstate', onPopState, { once: true });
         window.history.back();
@@ -40,6 +50,12 @@ export default function AndroidBackHandler() {
     };
 
     const listenerPromise = App.addListener('backButton', (data) => {
+      // 오버레이(drawer 등)가 열려 있으면 최상단 핸들러 실행
+      if (backHandlerStack.length > 0) {
+        backHandlerStack[backHandlerStack.length - 1]();
+        return;
+      }
+
       if (data.canGoBack) {
         goBackToRealPage();
         return;

--- a/frontend/src/components/AndroidBackHandler.tsx
+++ b/frontend/src/components/AndroidBackHandler.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect } from 'react';
+import { App } from '@capacitor/app';
+import { toast } from 'sonner';
+
+/**
+ * Android 하드웨어/제스처 뒤로가기 처리 컴포넌트.
+ * - 뒤로 갈 히스토리가 있으면 → history.back()
+ * - 루트(히스토리 없음)에서 한 번 → "한 번 더 누르면 종료" 토스트
+ * - 2초 내 한 번 더 → 앱 종료
+ */
+export default function AndroidBackHandler() {
+  useEffect(() => {
+    const platform = (
+      window as unknown as { Capacitor?: { getPlatform?: () => string } }
+    ).Capacitor?.getPlatform?.();
+    if (platform !== 'android') return;
+
+    let backPressedOnce = false;
+    let timer: ReturnType<typeof setTimeout>;
+
+    // 같은 pathname의 검색 파라미터 변경 히스토리를 건너뛰어 이전 "실제 페이지"로 이동
+    const goBackToRealPage = () => {
+      const originPathname = window.location.pathname;
+
+      const tryBack = () => {
+        const onPopState = () => {
+          if (window.location.pathname === originPathname) {
+            // 같은 페이지(검색 파라미터만 다름) → 한 번 더 뒤로
+            tryBack();
+          }
+          // 다른 pathname으로 이동됐으면 완료
+        };
+        window.addEventListener('popstate', onPopState, { once: true });
+        window.history.back();
+      };
+
+      tryBack();
+    };
+
+    const listenerPromise = App.addListener('backButton', (data) => {
+      if (data.canGoBack) {
+        goBackToRealPage();
+        return;
+      }
+
+      if (backPressedOnce) {
+        clearTimeout(timer);
+        App.exitApp();
+        return;
+      }
+
+      backPressedOnce = true;
+      toast('뒤로 가기를 한 번 더 누르면 앱이 종료됩니다.', {
+        duration: 2000,
+        position: 'bottom-center',
+      });
+
+      timer = setTimeout(() => {
+        backPressedOnce = false;
+      }, 2000);
+    });
+
+    return () => {
+      clearTimeout(timer);
+      listenerPromise.then((handle) => handle.remove());
+    };
+  }, []);
+
+  return null;
+}

--- a/frontend/src/components/AndroidBackHandler.tsx
+++ b/frontend/src/components/AndroidBackHandler.tsx
@@ -54,7 +54,6 @@ export default function AndroidBackHandler() {
       backPressedOnce = true;
       toast('뒤로 가기를 한 번 더 누르면 앱이 종료됩니다.', {
         duration: 2000,
-        position: 'bottom-center',
       });
 
       timer = setTimeout(() => {

--- a/frontend/src/components/BottomNavigation.tsx
+++ b/frontend/src/components/BottomNavigation.tsx
@@ -84,7 +84,7 @@ export default function BottomNavigation() {
   if (isGroupDetail) return null;
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 max-w-4xl mx-auto px-4 py-3 pb-3 sm:px-8 sm:py-4 sm:pb-4 flex items-center justify-between z-50 backdrop-blur-xl border-t transition-all duration-300 dark:bg-[#121212]/90 dark:border-white/5 bg-white/90 border-gray-100 shadow-[0_-10px_40px_rgba(0,0,0,0.04)]">
+    <nav className="fixed bottom-0 left-0 right-0 max-w-4xl mx-auto px-4 py-1 sm:px-8 sm:py-4 flex items-center justify-between z-50 backdrop-blur-xl border-t transition-all duration-300 dark:bg-[#121212]/90 dark:border-white/5 bg-white/90 border-gray-100 shadow-[0_-10px_40px_rgba(0,0,0,0.04)]">
       <AnimatePresence mode="wait" initial={false}>
         {effectiveGroupId ? (
           <motion.div

--- a/frontend/src/components/BottomNavigation.tsx
+++ b/frontend/src/components/BottomNavigation.tsx
@@ -84,7 +84,7 @@ export default function BottomNavigation() {
   if (isGroupDetail) return null;
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 max-w-4xl mx-auto px-4 py-3 pb-4 sm:px-8 sm:py-4 sm:pb-6 flex items-center justify-between z-50 backdrop-blur-xl border-t transition-all duration-300 dark:bg-[#121212]/90 dark:border-white/5 bg-white/90 border-gray-100 shadow-[0_-10px_40px_rgba(0,0,0,0.04)]">
+    <nav className="fixed bottom-0 left-0 right-0 max-w-4xl mx-auto px-4 py-3 pb-3 sm:px-8 sm:py-4 sm:pb-4 flex items-center justify-between z-50 backdrop-blur-xl border-t transition-all duration-300 dark:bg-[#121212]/90 dark:border-white/5 bg-white/90 border-gray-100 shadow-[0_-10px_40px_rgba(0,0,0,0.04)]">
       <AnimatePresence mode="wait" initial={false}>
         {effectiveGroupId ? (
           <motion.div

--- a/frontend/src/components/NativeStatusBarSync.tsx
+++ b/frontend/src/components/NativeStatusBarSync.tsx
@@ -36,6 +36,7 @@ export default function NativeStatusBarSync() {
 
   // pathname 또는 테마 변경 시 기본 테마 갱신 + 전송 (drawer가 없을 때만)
   useEffect(() => {
+    if (!resolvedTheme) return; // 테마 미확정 시 잘못된 'light' fallback 방지
     const base = isMapPage ? 'transparent' : resolvedTheme === 'dark' ? 'dark' : 'light';
     baseThemeRef.current = base;
 

--- a/frontend/src/components/ProfileInfo.tsx
+++ b/frontend/src/components/ProfileInfo.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Camera, X } from 'lucide-react';
+import { useIMEInput } from '@/hooks/useIMEInput';
 import Image from 'next/image';
 import { useRef, useMemo, useEffect } from 'react';
 import { useProfileEdit } from '../app/(main)/profile/edit/_components/ProfileEditContext';
@@ -17,6 +18,7 @@ export default function ProfileInfo({
 }: ProfileInfoProps) {
   const { image, setImage, nickname, setNickname, email } = useProfileEdit();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const nicknameImeProps = useIMEInput(setNickname);
 
   // Blob URL을 메모이제이션하여 불필요한 재생성 방지
   const imagePreviewUrl = useMemo(() => {
@@ -114,7 +116,7 @@ export default function ProfileInfo({
               <input
                 type="text"
                 value={nickname}
-                onChange={(e) => setNickname(e.target.value)}
+                {...nicknameImeProps}
                 className={`w-full border-b-2 bg-transparent px-1 py-4 text-base font-semibold transition-all outline-none dark:text-white dark:placeholder-gray-700 text-itta-black placeholder-gray-300 ${
                   nicknameError
                     ? 'border-red-500 dark:border-red-500 focus:border-red-500 dark:focus:border-red-500'

--- a/frontend/src/components/SocialShareDrawer.tsx
+++ b/frontend/src/components/SocialShareDrawer.tsx
@@ -68,29 +68,37 @@ export default function SocialShareDrawer({
   const { data } = useMediaResolveSingle(record.image ?? undefined);
   const [copied, setCopied] = useState(false);
 
-  const canNativeShare = typeof navigator !== 'undefined' && !!navigator.share;
+  const isNative =
+    typeof window !== 'undefined' && !!window.Capacitor?.isNativePlatform?.();
+  const canNativeShare =
+    isNative || (typeof navigator !== 'undefined' && !!navigator.share);
 
   const handleCopyLink = async () => {
     try {
-      await navigator.clipboard.writeText(path);
+      const { copyToClipboard } = await import('@/lib/utils/clipboard');
+      await copyToClipboard(path);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
       toast.info('클립보드를 지원하지 않는 환경입니다.');
-      // 클립보드 API 미지원 환경에서는 무시
     }
   };
 
   const handleNativeShare = async () => {
-    if (!navigator.share) return;
+    const shareData = {
+      title: record.title || '오늘의 기록을 확인해보세요',
+      text:
+        record.content ||
+        '기억과 맥락을 잇는 우리의 소중한 순간을 확인해보세요.',
+      url: path,
+    };
     try {
-      await navigator.share({
-        title: record.title || '오늘의 기록을 확인해보세요',
-        text:
-          record.content ||
-          '기억과 맥락을 잇는 우리의 소중한 순간을 확인해보세요.',
-        url: path,
-      });
+      if (isNative) {
+        const { Share } = await import('@capacitor/share');
+        await Share.share(shareData);
+      } else if (navigator.share) {
+        await navigator.share(shareData);
+      }
     } catch {
       // 사용자가 공유 취소한 경우 등 — 무시
     }

--- a/frontend/src/components/StatusBarCover.tsx
+++ b/frontend/src/components/StatusBarCover.tsx
@@ -1,36 +1,26 @@
 'use client';
 
 import { cn } from '@/lib/utils';
-import { useTheme } from 'next-themes';
 import { usePathname } from 'next/navigation';
 
 /**
- * iOS safe area 상단(status bar 영역)을 앱 배경색으로 덮는 고정 오버레이.
- * position: fixed + zIndex 9999 인라인 스타일로 스크롤과 무관하게 항상 표시.
- * ThemeColorSetter와 동일하게 JS로 배경색을 적용해 다크/라이트 모드에서도 확실히 동작.
+ * Android 네이티브 앱의 status bar 영역을 앱 배경색으로 덮는 고정 오버레이.
+ * CSS dark: 클래스로 테마 색상을 적용해 hydration 이슈 없이 동작.
  */
 export default function StatusBarCover() {
-  const { resolvedTheme } = useTheme();
   const pathname = usePathname();
-  const bg = resolvedTheme === 'dark' ? '#121212' : '#ffffff';
   const isMapPath = pathname.includes('map');
 
   return (
     <div
       data-status-bar-cover
       className={cn(
-        'fixed, top-0 left-0 right-0 z-300 pointer-events-none',
-        isMapPath && 'opacity-100',
+        'fixed top-0 left-0 right-0 pointer-events-none bg-white dark:bg-[#121212]',
+        isMapPath && 'opacity-0',
       )}
       style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
         height: 'env(safe-area-inset-top)',
         zIndex: 49,
-        pointerEvents: 'none',
-        backgroundColor: isMapPath ? 'transparent' : bg,
       }}
     />
   );

--- a/frontend/src/components/map/MapSearchBar.tsx
+++ b/frontend/src/components/map/MapSearchBar.tsx
@@ -4,6 +4,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { useState } from 'react';
+import { useIMEInput } from '@/hooks/useIMEInput';
 import Input from '../Input';
 import { Search, MapPin, Loader2, X } from 'lucide-react';
 
@@ -29,6 +30,7 @@ export function MapSearchBar({
 }: MapSearchBarProps) {
   const [query, setQuery] = useState('');
   const [showResults, setShowResults] = useState(false);
+  const queryImeProps = useIMEInput(setQuery);
 
   // 검색 실행 함수
   const triggerSearch = () => {
@@ -60,7 +62,7 @@ export function MapSearchBar({
             <Input.Field
               placeholder={placeholder}
               value={query}
-              onChange={(e) => setQuery(e.target.value)}
+              {...queryImeProps}
               onKeyDown={(e) => {
                 if (e.key === 'Enter') triggerSearch();
               }}

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -4,11 +4,36 @@ import * as React from 'react';
 import { Drawer as DrawerPrimitive } from 'vaul';
 
 import { cn } from '@/lib/utils';
+import { pushBackHandler } from '@/components/AndroidBackHandler';
 
 function Drawer({
+  open,
+  onOpenChange,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+  const onOpenChangeRef = React.useRef(onOpenChange);
+  React.useEffect(() => {
+    onOpenChangeRef.current = onOpenChange;
+  });
+
+  React.useEffect(() => {
+    if (open === undefined || !open) return;
+
+    // drawer 열릴 때 Android 백버튼 핸들러 등록 → 닫힐 때 자동 해제
+    const remove = pushBackHandler(() => {
+      onOpenChangeRef.current?.(false);
+    });
+    return remove;
+  }, [open]);
+
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      open={open}
+      onOpenChange={onOpenChange}
+      {...props}
+    />
+  );
 }
 
 function DrawerTrigger({

--- a/frontend/src/hooks/useIMEInput.ts
+++ b/frontend/src/hooks/useIMEInput.ts
@@ -1,21 +1,10 @@
 import { useRef } from 'react';
-import { Capacitor } from '@capacitor/core';
 
 /**
- * Android Capacitor WebView에서 한국어 등 IME 조합 입력 시 글자가 잘리는 문제를 방지하는 hook.
+ * 한국어 등 IME 조합 입력 시 마지막 글자가 잘리는 문제를 방지하는 hook.
  *
- * 핵심 원리:
- *   React는 controlled input에서 `node.value !== props.value`일 때만 DOM을 업데이트한다.
- *   따라서 onChange를 항상 호출해 React state를 IME 현재값과 동기화하면,
- *   React가 DOM을 건드릴 이유가 없어지고 IME 버퍼가 보호된다.
- *
- * Android 전략 (value setter override 대신):
- *   조합 중에도 onChange를 호출해 localQuery = IME 현재값을 유지.
- *   → React re-render 시 `node.value === localQuery` → DOM 업데이트 스킵 → IME 보호.
- *   compositionEnd 이후에는 최종 확정값으로 한 번 더 호출해 확정.
- *
- * 비-Android 전략 (기존 동작 유지):
- *   조합 중 onChange 차단, compositionEnd 시 최종값 반영.
+ * 브라우저 표준 동작:
+ *   compositionStart → onChange 차단 → compositionEnd 시 최종값 반영
  *
  * 사용법 (ref 없는 컴포넌트):
  *   const imeProps = useIMEInput(setValue);
@@ -31,29 +20,7 @@ type InputElement = HTMLInputElement | HTMLTextAreaElement;
 
 export function useIMEInput(onChange: (value: string) => void) {
   const isComposingRef = useRef(false);
-  const isAndroid = Capacitor.getPlatform() === 'android';
 
-  // Android: 조합 중에도 onChange를 항상 호출해 React state = IME 현재값 유지.
-  // 이렇게 하면 React re-render 시 node.value === localQuery → DOM 업데이트 스킵.
-  if (isAndroid) {
-    return {
-      onChange: (e: React.ChangeEvent<InputElement>) => {
-        onChange(e.target.value);
-      },
-      onCompositionStart: () => {
-        isComposingRef.current = true;
-      },
-      onCompositionEnd: (e: React.CompositionEvent<InputElement>) => {
-        isComposingRef.current = false;
-        // compositionEnd 시 onChange가 이미 최신 값으로 불렸겠지만,
-        // Android에서는 compositionEnd 후 input event가 발생하지 않는 경우가 있어
-        // 최종값으로 한 번 더 명시적 호출.
-        onChange((e.target as InputElement).value);
-      },
-    };
-  }
-
-  // 비-Android: 조합 중 onChange 차단, compositionEnd 시 최종값 반영 (기존 동작).
   return {
     onChange: (e: React.ChangeEvent<InputElement>) => {
       if (!isComposingRef.current) {

--- a/frontend/src/hooks/useIMEInput.ts
+++ b/frontend/src/hooks/useIMEInput.ts
@@ -1,0 +1,46 @@
+import { useRef } from 'react';
+
+/**
+ * Android Capacitor WebView에서 한국어 등 IME 조합 입력 시 마지막 글자가 잘리는 문제를 방지하는 hook.
+ *
+ * 원인: Android WebView에서 React controlled input의 onChange가 IME 조합 중에 state를
+ *       업데이트하면 Android IME 버퍼가 리셋되어 조합 중인 글자가 사라짐.
+ *       (데스크탑 브라우저는 composition 중 update를 차단하면 오히려 입력이 안 되므로 적용 안 함)
+ *
+ * 해결: Android에서만 조합 중(onCompositionStart~onCompositionEnd)에 state 업데이트를 차단하고,
+ *       조합 완료 시점에만 최종 값으로 업데이트.
+ *
+ * 사용법:
+ *   const imeProps = useIMEInput(setValue);
+ *   <input value={value} {...imeProps} />
+ */
+
+function isAndroidCapacitor() {
+  return (
+    typeof window !== 'undefined' &&
+    (window as unknown as { Capacitor?: { getPlatform?: () => string } })
+      .Capacitor?.getPlatform?.() === 'android'
+  );
+}
+
+export function useIMEInput(onChange: (value: string) => void) {
+  const isComposingRef = useRef(false);
+  const isAndroid = isAndroidCapacitor();
+
+  return {
+    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      if (!isAndroid || !isComposingRef.current) {
+        onChange(e.target.value);
+      }
+    },
+    onCompositionStart: () => {
+      isComposingRef.current = true;
+    },
+    onCompositionEnd: (e: React.CompositionEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      isComposingRef.current = false;
+      if (isAndroid) {
+        onChange((e.target as HTMLInputElement | HTMLTextAreaElement).value);
+      }
+    },
+  };
+}

--- a/frontend/src/hooks/useIMEInput.ts
+++ b/frontend/src/hooks/useIMEInput.ts
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import { Capacitor } from '@capacitor/core';
 
 /**
  * Android Capacitor WebView에서 한국어 등 IME 조합 입력 시 글자가 잘리는 문제를 방지하는 hook.
@@ -26,20 +27,11 @@ import { useRef } from 'react';
  *   <textarea ref={setRef} {...imeHandlers} />
  */
 
-function isAndroidCapacitor() {
-  return (
-    typeof window !== 'undefined' &&
-    (
-      window as unknown as { Capacitor?: { getPlatform?: () => string } }
-    ).Capacitor?.getPlatform?.() === 'android'
-  );
-}
-
 type InputElement = HTMLInputElement | HTMLTextAreaElement;
 
 export function useIMEInput(onChange: (value: string) => void) {
   const isComposingRef = useRef(false);
-  const isAndroid = isAndroidCapacitor();
+  const isAndroid = Capacitor.getPlatform() === 'android';
 
   // Android: 조합 중에도 onChange를 항상 호출해 React state = IME 현재값 유지.
   // 이렇게 하면 React re-render 시 node.value === localQuery → DOM 업데이트 스킵.

--- a/frontend/src/hooks/useIMEInput.ts
+++ b/frontend/src/hooks/useIMEInput.ts
@@ -1,37 +1,22 @@
-import { useRef } from 'react';
-
 /**
- * 한국어 등 IME 조합 입력 시 마지막 글자가 잘리는 문제를 방지하는 hook.
+ * captureInput: false (Capacitor Android 설정) 환경에서는 WebView가 표준 IME를
+ * 직접 처리하므로 조합 차단 없이 onChange를 그대로 전달합니다.
  *
- * 브라우저 표준 동작:
- *   compositionStart → onChange 차단 → compositionEnd 시 최종값 반영
+ * 브라우저(데스크톱/iOS)에서는 compositionEnd로 최종값을 보장합니다.
  *
- * 사용법 (ref 없는 컴포넌트):
+ * 사용법:
  *   const imeProps = useIMEInput(setValue);
  *   <input value={value} {...imeProps} />
- *
- * 사용법 (기존 ref가 있는 컴포넌트 - CoreField 등):
- *   const { ref: imeRef, ...imeHandlers } = useIMEInput(onChange);
- *   const setRef = useCallback((el) => { myRef.current = el; imeRef?.(el); }, [imeRef]);
- *   <textarea ref={setRef} {...imeHandlers} />
  */
 
 type InputElement = HTMLInputElement | HTMLTextAreaElement;
 
 export function useIMEInput(onChange: (value: string) => void) {
-  const isComposingRef = useRef(false);
-
   return {
     onChange: (e: React.ChangeEvent<InputElement>) => {
-      if (!isComposingRef.current) {
-        onChange(e.target.value);
-      }
-    },
-    onCompositionStart: () => {
-      isComposingRef.current = true;
+      onChange(e.target.value);
     },
     onCompositionEnd: (e: React.CompositionEvent<InputElement>) => {
-      isComposingRef.current = false;
       onChange((e.target as InputElement).value);
     },
   };

--- a/frontend/src/hooks/useIMEInput.ts
+++ b/frontend/src/hooks/useIMEInput.ts
@@ -1,46 +1,79 @@
 import { useRef } from 'react';
 
 /**
- * Android Capacitor WebView에서 한국어 등 IME 조합 입력 시 마지막 글자가 잘리는 문제를 방지하는 hook.
+ * Android Capacitor WebView에서 한국어 등 IME 조합 입력 시 글자가 잘리는 문제를 방지하는 hook.
  *
- * 원인: Android WebView에서 React controlled input의 onChange가 IME 조합 중에 state를
- *       업데이트하면 Android IME 버퍼가 리셋되어 조합 중인 글자가 사라짐.
- *       (데스크탑 브라우저는 composition 중 update를 차단하면 오히려 입력이 안 되므로 적용 안 함)
+ * 핵심 원리:
+ *   React는 controlled input에서 `node.value !== props.value`일 때만 DOM을 업데이트한다.
+ *   따라서 onChange를 항상 호출해 React state를 IME 현재값과 동기화하면,
+ *   React가 DOM을 건드릴 이유가 없어지고 IME 버퍼가 보호된다.
  *
- * 해결: Android에서만 조합 중(onCompositionStart~onCompositionEnd)에 state 업데이트를 차단하고,
- *       조합 완료 시점에만 최종 값으로 업데이트.
+ * Android 전략 (value setter override 대신):
+ *   조합 중에도 onChange를 호출해 localQuery = IME 현재값을 유지.
+ *   → React re-render 시 `node.value === localQuery` → DOM 업데이트 스킵 → IME 보호.
+ *   compositionEnd 이후에는 최종 확정값으로 한 번 더 호출해 확정.
  *
- * 사용법:
+ * 비-Android 전략 (기존 동작 유지):
+ *   조합 중 onChange 차단, compositionEnd 시 최종값 반영.
+ *
+ * 사용법 (ref 없는 컴포넌트):
  *   const imeProps = useIMEInput(setValue);
  *   <input value={value} {...imeProps} />
+ *
+ * 사용법 (기존 ref가 있는 컴포넌트 - CoreField 등):
+ *   const { ref: imeRef, ...imeHandlers } = useIMEInput(onChange);
+ *   const setRef = useCallback((el) => { myRef.current = el; imeRef?.(el); }, [imeRef]);
+ *   <textarea ref={setRef} {...imeHandlers} />
  */
 
 function isAndroidCapacitor() {
   return (
     typeof window !== 'undefined' &&
-    (window as unknown as { Capacitor?: { getPlatform?: () => string } })
-      .Capacitor?.getPlatform?.() === 'android'
+    (
+      window as unknown as { Capacitor?: { getPlatform?: () => string } }
+    ).Capacitor?.getPlatform?.() === 'android'
   );
 }
+
+type InputElement = HTMLInputElement | HTMLTextAreaElement;
 
 export function useIMEInput(onChange: (value: string) => void) {
   const isComposingRef = useRef(false);
   const isAndroid = isAndroidCapacitor();
 
+  // Android: 조합 중에도 onChange를 항상 호출해 React state = IME 현재값 유지.
+  // 이렇게 하면 React re-render 시 node.value === localQuery → DOM 업데이트 스킵.
+  if (isAndroid) {
+    return {
+      onChange: (e: React.ChangeEvent<InputElement>) => {
+        onChange(e.target.value);
+      },
+      onCompositionStart: () => {
+        isComposingRef.current = true;
+      },
+      onCompositionEnd: (e: React.CompositionEvent<InputElement>) => {
+        isComposingRef.current = false;
+        // compositionEnd 시 onChange가 이미 최신 값으로 불렸겠지만,
+        // Android에서는 compositionEnd 후 input event가 발생하지 않는 경우가 있어
+        // 최종값으로 한 번 더 명시적 호출.
+        onChange((e.target as InputElement).value);
+      },
+    };
+  }
+
+  // 비-Android: 조합 중 onChange 차단, compositionEnd 시 최종값 반영 (기존 동작).
   return {
-    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      if (!isAndroid || !isComposingRef.current) {
+    onChange: (e: React.ChangeEvent<InputElement>) => {
+      if (!isComposingRef.current) {
         onChange(e.target.value);
       }
     },
     onCompositionStart: () => {
       isComposingRef.current = true;
     },
-    onCompositionEnd: (e: React.CompositionEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    onCompositionEnd: (e: React.CompositionEvent<InputElement>) => {
       isComposingRef.current = false;
-      if (isAndroid) {
-        onChange((e.target as HTMLInputElement | HTMLTextAreaElement).value);
-      }
+      onChange((e.target as InputElement).value);
     },
   };
 }

--- a/frontend/src/hooks/useMediaUpload.ts
+++ b/frontend/src/hooks/useMediaUpload.ts
@@ -22,7 +22,10 @@ export const useMediaUpload = () => {
       const fileInfos = await Promise.all(
         files.map(async (f) => ({
           file: f,
-          dimensions: await getImageDimensions(f),
+          dimensions: await getImageDimensions(f).catch(() => ({
+            width: 0,
+            height: 0,
+          })),
         })),
       );
 

--- a/frontend/src/lib/api/presignMedia.ts
+++ b/frontend/src/lib/api/presignMedia.ts
@@ -23,21 +23,46 @@ export const postMediaPresign = async (files: PresignRequestFile[]) => {
   return response.data.items;
 };
 
-/** MinIO에 직접 PUT하여 업로드 */
+/** MinIO에 직접 PUT하여 업로드
+ * Android Capacitor: XMLHttpRequest 사용
+ *   → fetch PUT + binary body가 Capacitor HTTP 인터셉터에서 무한 대기에 빠지는 문제 우회
+ * 그 외(웹/iOS): 표준 fetch 사용
+ */
 export const uploadFileToStorage = async (
   uploadUrl: string,
   file: File,
-  //dimensions: { width: number; height: number },
-) => {
-  const response = await fetch(uploadUrl, {
+): Promise<void> => {
+  const isAndroidCapacitor =
+    typeof window !== 'undefined' &&
+    (window as unknown as { Capacitor?: { getPlatform?: () => string } })
+      .Capacitor?.getPlatform?.() === 'android';
+
+  if (isAndroidCapacitor) {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open('PUT', uploadUrl);
+      xhr.setRequestHeader('Content-Type', file.type);
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve();
+        } else {
+          reject(new Error(`파일 업로드 실패: ${xhr.status}`));
+        }
+      };
+      xhr.onerror = () => reject(new Error('파일 업로드 실패'));
+      xhr.ontimeout = () => reject(new Error('파일 업로드 시간 초과'));
+      xhr.timeout = 60000;
+      xhr.send(file);
+    });
+  }
+
+  const res = await fetch(uploadUrl, {
     method: 'PUT',
     body: file,
-    headers: {
-      'Content-Type': file.type,
-    },
+    headers: { 'Content-Type': file.type },
+    signal: AbortSignal.timeout(60000),
   });
-
-  if (!response.ok) throw new Error('파일 업로드 실패');
+  if (!res.ok) throw new Error('파일 업로드 실패');
 };
 
 /** 업로드 완료 확정 */

--- a/frontend/src/lib/api/presignMedia.ts
+++ b/frontend/src/lib/api/presignMedia.ts
@@ -23,11 +23,39 @@ export const postMediaPresign = async (files: PresignRequestFile[]) => {
   return response.data.items;
 };
 
-/** MinIO에 직접 PUT하여 업로드 */
+/** MinIO에 직접 PUT하여 업로드
+ * Android Capacitor: XMLHttpRequest 사용
+ *   → fetch PUT + binary body가 Capacitor HTTP 인터셉터에서 무한 대기에 빠지는 문제 우회
+ * 그 외(웹/iOS): 표준 fetch 사용
+ */
 export const uploadFileToStorage = async (
   uploadUrl: string,
   file: File,
 ): Promise<void> => {
+  const isAndroidCapacitor =
+    typeof window !== 'undefined' &&
+    (window as unknown as { Capacitor?: { getPlatform?: () => string } })
+      .Capacitor?.getPlatform?.() === 'android';
+
+  if (isAndroidCapacitor) {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open('PUT', uploadUrl);
+      xhr.setRequestHeader('Content-Type', file.type);
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve();
+        } else {
+          reject(new Error(`파일 업로드 실패: ${xhr.status}`));
+        }
+      };
+      xhr.onerror = () => reject(new Error('파일 업로드 실패'));
+      xhr.ontimeout = () => reject(new Error('파일 업로드 시간 초과'));
+      xhr.timeout = 60000;
+      xhr.send(file);
+    });
+  }
+
   const res = await fetch(uploadUrl, {
     method: 'PUT',
     body: file,

--- a/frontend/src/lib/api/presignMedia.ts
+++ b/frontend/src/lib/api/presignMedia.ts
@@ -23,39 +23,11 @@ export const postMediaPresign = async (files: PresignRequestFile[]) => {
   return response.data.items;
 };
 
-/** MinIO에 직접 PUT하여 업로드
- * Android Capacitor: XMLHttpRequest 사용
- *   → fetch PUT + binary body가 Capacitor HTTP 인터셉터에서 무한 대기에 빠지는 문제 우회
- * 그 외(웹/iOS): 표준 fetch 사용
- */
+/** MinIO에 직접 PUT하여 업로드 */
 export const uploadFileToStorage = async (
   uploadUrl: string,
   file: File,
 ): Promise<void> => {
-  const isAndroidCapacitor =
-    typeof window !== 'undefined' &&
-    (window as unknown as { Capacitor?: { getPlatform?: () => string } })
-      .Capacitor?.getPlatform?.() === 'android';
-
-  if (isAndroidCapacitor) {
-    return new Promise((resolve, reject) => {
-      const xhr = new XMLHttpRequest();
-      xhr.open('PUT', uploadUrl);
-      xhr.setRequestHeader('Content-Type', file.type);
-      xhr.onload = () => {
-        if (xhr.status >= 200 && xhr.status < 300) {
-          resolve();
-        } else {
-          reject(new Error(`파일 업로드 실패: ${xhr.status}`));
-        }
-      };
-      xhr.onerror = () => reject(new Error('파일 업로드 실패'));
-      xhr.ontimeout = () => reject(new Error('파일 업로드 시간 초과'));
-      xhr.timeout = 60000;
-      xhr.send(file);
-    });
-  }
-
   const res = await fetch(uploadUrl, {
     method: 'PUT',
     body: file,

--- a/frontend/src/lib/utils/clipboard.ts
+++ b/frontend/src/lib/utils/clipboard.ts
@@ -1,0 +1,27 @@
+/**
+ * 클립보드 복사 유틸리티.
+ * Android WebView에서 navigator.clipboard.writeText()가 동작하지 않는 경우
+ * textarea + execCommand 폴백을 사용합니다.
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      // fall through to execCommand fallback
+    }
+  }
+
+  // Android WebView 폴백
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  textArea.style.cssText =
+    'position:fixed;left:-9999px;top:-9999px;opacity:0;';
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+  const success = document.execCommand('copy');
+  document.body.removeChild(textArea);
+  if (!success) throw new Error('execCommand copy failed');
+}

--- a/frontend/src/lib/utils/clipboard.ts
+++ b/frontend/src/lib/utils/clipboard.ts
@@ -1,3 +1,5 @@
+import { Capacitor } from '@capacitor/core';
+
 /**
  * 클립보드 복사 유틸리티.
  *
@@ -5,16 +7,8 @@
  * 예외 없이 resolve되지만 실제 클립보드에 쓰지 않는 문제가 있어,
  * Android Capacitor에서는 @capacitor/clipboard 네이티브 플러그인을 사용합니다.
  */
-function isAndroidCapacitor() {
-  return (
-    typeof window !== 'undefined' &&
-    (window as unknown as { Capacitor?: { getPlatform?: () => string } })
-      .Capacitor?.getPlatform?.() === 'android'
-  );
-}
-
 export async function copyToClipboard(text: string): Promise<void> {
-  if (isAndroidCapacitor()) {
+  if (Capacitor.getPlatform() === 'android') {
     const { Clipboard } = await import('@capacitor/clipboard');
     await Clipboard.write({ string: text });
     return;

--- a/frontend/src/lib/utils/clipboard.ts
+++ b/frontend/src/lib/utils/clipboard.ts
@@ -1,9 +1,25 @@
 /**
  * 클립보드 복사 유틸리티.
- * Android WebView에서 navigator.clipboard.writeText()가 동작하지 않는 경우
- * textarea + execCommand 폴백을 사용합니다.
+ *
+ * Android Capacitor WebView에서 navigator.clipboard.writeText()가
+ * 예외 없이 resolve되지만 실제 클립보드에 쓰지 않는 문제가 있어,
+ * Android Capacitor에서는 @capacitor/clipboard 네이티브 플러그인을 사용합니다.
  */
+function isAndroidCapacitor() {
+  return (
+    typeof window !== 'undefined' &&
+    (window as unknown as { Capacitor?: { getPlatform?: () => string } })
+      .Capacitor?.getPlatform?.() === 'android'
+  );
+}
+
 export async function copyToClipboard(text: string): Promise<void> {
+  if (isAndroidCapacitor()) {
+    const { Clipboard } = await import('@capacitor/clipboard');
+    await Clipboard.write({ string: text });
+    return;
+  }
+
   if (navigator.clipboard && window.isSecureContext) {
     try {
       await navigator.clipboard.writeText(text);
@@ -13,7 +29,7 @@ export async function copyToClipboard(text: string): Promise<void> {
     }
   }
 
-  // Android WebView 폴백
+  // 최후 폴백: textarea + execCommand
   const textArea = document.createElement('textarea');
   textArea.value = text;
   textArea.style.cssText =

--- a/frontend/src/lib/utils/getRedirectUri.ts
+++ b/frontend/src/lib/utils/getRedirectUri.ts
@@ -3,6 +3,7 @@ type GetRedirectUriArg = {
   callback?: string;
   forceAccountSelect?: boolean;
   mobile?: boolean;
+  android?: boolean;
 };
 
 export const getRedirectUri = ({
@@ -10,6 +11,7 @@ export const getRedirectUri = ({
   callback,
   forceAccountSelect = false,
   mobile = false,
+  android = false,
 }: GetRedirectUriArg) => {
   const baseUrl = `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000'}/v1/auth/${provider}`;
 
@@ -22,6 +24,9 @@ export const getRedirectUri = ({
   }
   if (mobile) {
     params.set('mobile', 'true');
+  }
+  if (android) {
+    params.set('android', 'true');
   }
 
   const queryString = params.toString();

--- a/frontend/src/lib/utils/image.ts
+++ b/frontend/src/lib/utils/image.ts
@@ -10,7 +10,7 @@
 export const getImageDimensions = (
   file: File,
 ): Promise<{ width: number; height: number }> => {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const img = new Image();
 
     img.onload = () => {
@@ -19,6 +19,11 @@ export const getImageDimensions = (
 
       // 사용이 끝난 Object URL을 해제 = 메모리 누수 방지
       URL.revokeObjectURL(img.src);
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(img.src);
+      reject(new Error(`이미지 로드 실패: ${file.name}`));
     };
 
     // 파일 객체를 브라우저에서 접근 가능한 임시 URL로 변환

--- a/mobile-app/android/app/capacitor.build.gradle
+++ b/mobile-app/android/app/capacitor.build.gradle
@@ -11,7 +11,10 @@ apply from: "../capacitor-cordova-android-plugins/cordova.variables.gradle"
 dependencies {
     implementation project(':capacitor-app')
     implementation project(':capacitor-browser')
+    implementation project(':capacitor-clipboard')
+    implementation project(':capacitor-share')
     implementation project(':capacitor-splash-screen')
+    implementation project(':capacitor-status-bar')
 
 }
 

--- a/mobile-app/android/app/src/main/AndroidManifest.xml
+++ b/mobile-app/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation"

--- a/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
+++ b/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
@@ -33,10 +33,8 @@ public class MainActivity extends BridgeActivity {
 
         addStatusBarCover(isDarkMode);
 
-        WindowInsetsControllerCompat insetsController = new WindowInsetsControllerCompat(
-                getWindow(), getWindow().getDecorView()
-        );
-        insetsController.setAppearanceLightStatusBars(!isDarkMode);
+        new WindowInsetsControllerCompat(getWindow(), getWindow().getDecorView())
+            .setAppearanceLightStatusBars(!isDarkMode);
 
         // WebView 로드 전에 브릿지 등록 (onStart보다 이른 시점 → 타이밍 문제 해소)
         getBridge().getWebView().addJavascriptInterface(new StatusBarBridge(), "AndroidBridge");
@@ -68,41 +66,39 @@ public class MainActivity extends BridgeActivity {
     }
 
     private void applyStatusBarTheme(String theme) {
-        WindowInsetsControllerCompat controller = new WindowInsetsControllerCompat(
-            getWindow(), getWindow().getDecorView()
-        );
+        // 배경색·가시성: 즉시 적용
+        // 아이콘 색상: 다음 프레임으로 미룸 (같은 프레임 내 Android/Capacitor 덮어쓰기 방지)
+        final boolean lightBars;
         switch (theme) {
             case "transparent":
-                // 지도 페이지: 커버 뷰 숨김 → 지도 타일이 status bar 아래까지 보임
                 getWindow().setStatusBarColor(Color.TRANSPARENT);
-                controller.setAppearanceLightStatusBars(false);
                 if (statusBarCoverView != null) statusBarCoverView.setVisibility(View.GONE);
+                lightBars = false;
                 break;
             case "map-overlay":
-                // 지도 페이지 + drawer 열림: 커버 뷰 숨기고 반투명 오버레이
                 getWindow().setStatusBarColor(Color.argb(102, 0, 0, 0));
-                controller.setAppearanceLightStatusBars(false);
                 if (statusBarCoverView != null) statusBarCoverView.setVisibility(View.GONE);
+                lightBars = false;
                 break;
             case "dark":
-                // 다크 모드 일반 페이지
                 getWindow().setStatusBarColor(Color.parseColor("#121212"));
-                controller.setAppearanceLightStatusBars(false);
                 if (statusBarCoverView != null) {
                     statusBarCoverView.setBackgroundColor(Color.parseColor("#121212"));
                     statusBarCoverView.setVisibility(View.VISIBLE);
                 }
+                lightBars = false;
                 break;
             default:
-                // 라이트 모드 일반 페이지
                 getWindow().setStatusBarColor(Color.WHITE);
-                controller.setAppearanceLightStatusBars(true);
                 if (statusBarCoverView != null) {
                     statusBarCoverView.setBackgroundColor(Color.WHITE);
                     statusBarCoverView.setVisibility(View.VISIBLE);
                 }
+                lightBars = true;
                 break;
         }
+        new WindowInsetsControllerCompat(getWindow(), getWindow().getDecorView())
+            .setAppearanceLightStatusBars(lightBars);
     }
 
     private class StatusBarBridge {

--- a/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
+++ b/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
@@ -1,5 +1,6 @@
 package com.ittda.app;
 
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.view.View;
@@ -40,7 +41,10 @@ public class MainActivity extends BridgeActivity {
         statusBarCoverView = new View(this);
         statusBarCoverView.setClickable(false);
         statusBarCoverView.setFocusable(false);
-        statusBarCoverView.setBackgroundColor(Color.WHITE); // 기본: 라이트 모드
+        // JS 로드 전 flash 방지: 시스템 다크모드 설정으로 초기 배경색 결정
+        boolean isDarkMode = (getResources().getConfiguration().uiMode &
+                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+        statusBarCoverView.setBackgroundColor(isDarkMode ? Color.parseColor("#121212") : Color.WHITE);
 
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.MATCH_PARENT,

--- a/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
+++ b/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
@@ -22,10 +22,14 @@ public class MainActivity extends BridgeActivity {
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        SplashScreen splashScreen = SplashScreen.installSplashScreen(this);
+        
         super.onCreate(savedInstanceState);
         // 컨텐츠가 status bar / navigation bar 영역으로 확장되도록 설정
         WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
         getWindow().setStatusBarColor(Color.TRANSPARENT);
+        // WebView 로드 전 검은 화면 방지: 스플래시 배경을 window background로 유지
+        getWindow().setBackgroundDrawableResource(R.drawable.splash);
 
         // JS 로드 전 flash 방지: 시스템 다크모드를 기준으로 커버뷰 배경색 + 아이콘 색상 초기 설정
         boolean isDarkMode = (getResources().getConfiguration().uiMode &
@@ -33,8 +37,10 @@ public class MainActivity extends BridgeActivity {
 
         addStatusBarCover(isDarkMode);
 
-        new WindowInsetsControllerCompat(getWindow(), getWindow().getDecorView())
-            .setAppearanceLightStatusBars(!isDarkMode);
+        WindowInsetsControllerCompat insetsController =
+            new WindowInsetsControllerCompat(getWindow(), getWindow().getDecorView());
+        insetsController.setAppearanceLightStatusBars(!isDarkMode);
+        insetsController.setAppearanceLightNavigationBars(!isDarkMode);
 
         // WebView 로드 전에 브릿지 등록 (onStart보다 이른 시점 → 타이밍 문제 해소)
         getBridge().getWebView().addJavascriptInterface(new StatusBarBridge(), "AndroidBridge");
@@ -97,8 +103,10 @@ public class MainActivity extends BridgeActivity {
                 lightBars = true;
                 break;
         }
-        new WindowInsetsControllerCompat(getWindow(), getWindow().getDecorView())
-            .setAppearanceLightStatusBars(lightBars);
+        WindowInsetsControllerCompat insetsController =
+            new WindowInsetsControllerCompat(getWindow(), getWindow().getDecorView());
+        insetsController.setAppearanceLightStatusBars(lightBars);
+        insetsController.setAppearanceLightNavigationBars(lightBars);
     }
 
     private class StatusBarBridge {

--- a/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
+++ b/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
@@ -2,28 +2,60 @@ package com.ittda.app;
 
 import android.graphics.Color;
 import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
 import android.webkit.JavascriptInterface;
+import android.widget.FrameLayout;
 
+import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
 
 import com.getcapacitor.BridgeActivity;
 
 public class MainActivity extends BridgeActivity {
 
+    // iOS의 statusBarCoverView와 동일한 역할: 상태바 영역을 앱 배경색으로 덮는 네이티브 뷰
+    private View statusBarCoverView;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        // 컨텐츠가 status bar 영역으로 확장되도록 설정
+        // 컨텐츠가 status bar / navigation bar 영역으로 확장되도록 설정
         WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
         getWindow().setStatusBarColor(Color.TRANSPARENT);
+
+        // 네이티브 커버 뷰 추가 (iOS addStatusBarCover() 동일 패턴)
+        addStatusBarCover();
+
+        // WebView 로드 전에 브릿지 등록 (onStart보다 이른 시점 → 타이밍 문제 해소)
+        getBridge().getWebView().addJavascriptInterface(new StatusBarBridge(), "AndroidBridge");
     }
 
-    @Override
-    public void onStart() {
-        super.onStart();
-        // WebView에 Android 브릿지 등록 (JS: window.AndroidBridge.themeChange(theme))
-        getBridge().getWebView().addJavascriptInterface(new StatusBarBridge(), "AndroidBridge");
+    // iOS addStatusBarCover()에 대응: 상태바 높이만큼 View를 DecorView 최상단에 추가
+    private void addStatusBarCover() {
+        ViewGroup rootView = (ViewGroup) getWindow().getDecorView();
+
+        statusBarCoverView = new View(this);
+        statusBarCoverView.setClickable(false);
+        statusBarCoverView.setFocusable(false);
+        statusBarCoverView.setBackgroundColor(Color.WHITE); // 기본: 라이트 모드
+
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.MATCH_PARENT,
+            0 // 실제 높이는 WindowInsets 콜백에서 설정
+        );
+        rootView.addView(statusBarCoverView, params);
+
+        // 상태바 실제 높이를 insets에서 가져와 적용
+        ViewCompat.setOnApplyWindowInsetsListener(statusBarCoverView, (v, insets) -> {
+            int statusBarHeight = insets.getInsets(WindowInsetsCompat.Type.statusBars()).top;
+            ViewGroup.LayoutParams lp = v.getLayoutParams();
+            lp.height = statusBarHeight;
+            v.setLayoutParams(lp);
+            return insets;
+        });
     }
 
     private void applyStatusBarTheme(String theme) {
@@ -32,24 +64,34 @@ public class MainActivity extends BridgeActivity {
         );
         switch (theme) {
             case "transparent":
-                // 지도 페이지: 투명 (지도 타일이 status bar 아래에 보임)
+                // 지도 페이지: 커버 뷰 숨김 → 지도 타일이 status bar 아래까지 보임
                 getWindow().setStatusBarColor(Color.TRANSPARENT);
-                controller.setAppearanceLightStatusBars(false); // 밝은 아이콘
+                controller.setAppearanceLightStatusBars(false);
+                if (statusBarCoverView != null) statusBarCoverView.setVisibility(View.GONE);
                 break;
             case "map-overlay":
-                // 지도 페이지 + drawer 열림: 반투명 어두운 오버레이 (~40%)
+                // 지도 페이지 + drawer 열림: 커버 뷰 숨기고 반투명 오버레이
                 getWindow().setStatusBarColor(Color.argb(102, 0, 0, 0));
-                controller.setAppearanceLightStatusBars(false); // 밝은 아이콘
+                controller.setAppearanceLightStatusBars(false);
+                if (statusBarCoverView != null) statusBarCoverView.setVisibility(View.GONE);
                 break;
             case "dark":
                 // 다크 모드 일반 페이지
                 getWindow().setStatusBarColor(Color.parseColor("#121212"));
-                controller.setAppearanceLightStatusBars(false); // 밝은 아이콘
+                controller.setAppearanceLightStatusBars(false);
+                if (statusBarCoverView != null) {
+                    statusBarCoverView.setBackgroundColor(Color.parseColor("#121212"));
+                    statusBarCoverView.setVisibility(View.VISIBLE);
+                }
                 break;
             default:
                 // 라이트 모드 일반 페이지
                 getWindow().setStatusBarColor(Color.WHITE);
-                controller.setAppearanceLightStatusBars(true); // 어두운 아이콘
+                controller.setAppearanceLightStatusBars(true);
+                if (statusBarCoverView != null) {
+                    statusBarCoverView.setBackgroundColor(Color.WHITE);
+                    statusBarCoverView.setVisibility(View.VISIBLE);
+                }
                 break;
         }
     }

--- a/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
+++ b/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
@@ -27,23 +27,28 @@ public class MainActivity extends BridgeActivity {
         WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
         getWindow().setStatusBarColor(Color.TRANSPARENT);
 
-        // 네이티브 커버 뷰 추가 (iOS addStatusBarCover() 동일 패턴)
-        addStatusBarCover();
+        // JS 로드 전 flash 방지: 시스템 다크모드를 기준으로 커버뷰 배경색 + 아이콘 색상 초기 설정
+        boolean isDarkMode = (getResources().getConfiguration().uiMode &
+                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+
+        addStatusBarCover(isDarkMode);
+
+        WindowInsetsControllerCompat insetsController = new WindowInsetsControllerCompat(
+                getWindow(), getWindow().getDecorView()
+        );
+        insetsController.setAppearanceLightStatusBars(!isDarkMode);
 
         // WebView 로드 전에 브릿지 등록 (onStart보다 이른 시점 → 타이밍 문제 해소)
         getBridge().getWebView().addJavascriptInterface(new StatusBarBridge(), "AndroidBridge");
     }
 
     // iOS addStatusBarCover()에 대응: 상태바 높이만큼 View를 DecorView 최상단에 추가
-    private void addStatusBarCover() {
+    private void addStatusBarCover(boolean isDarkMode) {
         ViewGroup rootView = (ViewGroup) getWindow().getDecorView();
 
         statusBarCoverView = new View(this);
         statusBarCoverView.setClickable(false);
         statusBarCoverView.setFocusable(false);
-        // JS 로드 전 flash 방지: 시스템 다크모드 설정으로 초기 배경색 결정
-        boolean isDarkMode = (getResources().getConfiguration().uiMode &
-                Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
         statusBarCoverView.setBackgroundColor(isDarkMode ? Color.parseColor("#121212") : Color.WHITE);
 
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(

--- a/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
+++ b/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
@@ -30,7 +30,7 @@ public class MainActivity extends BridgeActivity {
         WindowCompat.setDecorFitsSystemWindows(getWindow(), false);
         getWindow().setStatusBarColor(Color.TRANSPARENT);
         // WebView 로드 전 검은 화면 방지: 스플래시 배경을 window background로 유지
-        getWindow().setBackgroundDrawableResource(R.drawable.splash);
+        getWindow().setBackgroundDrawableResource(R.drawable.splash_background);
 
         // JS 로드 전 flash 방지: 시스템 다크모드를 기준으로 커버뷰 배경색 + 아이콘 색상 초기 설정
         boolean isDarkMode = (getResources().getConfiguration().uiMode &

--- a/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
+++ b/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
@@ -12,6 +12,7 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.core.view.WindowInsetsControllerCompat;
+import androidx.core.splashscreen.SplashScreen;
 
 import com.getcapacitor.BridgeActivity;
 

--- a/mobile-app/android/app/src/main/res/drawable/splash_background.xml
+++ b/mobile-app/android/app/src/main/res/drawable/splash_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <color android:color="@color/colorSplash" />
+    </item>
+    <item>
+        <bitmap
+            android:src="@drawable/splash"
+            android:gravity="center"
+            android:tileMode="disabled" />
+    </item>
+</layer-list>

--- a/mobile-app/android/app/src/main/res/values/styles.xml
+++ b/mobile-app/android/app/src/main/res/values/styles.xml
@@ -14,6 +14,7 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:background">@null</item>
+        <item name="android:windowBackground">@color/colorSplash</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:windowTranslucentStatus">false</item>
     </style>

--- a/mobile-app/android/app/src/main/res/values/styles.xml
+++ b/mobile-app/android/app/src/main/res/values/styles.xml
@@ -21,8 +21,10 @@
 
 
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
-        <item name="android:background">@drawable/splash</item>
-        <item name="android:statusBarColor">@color/colorSplash</item>
-        <item name="android:windowLightStatusBar">false</item>
+      <item name="windowSplashScreenAnimatedIcon">@drawable/splash</item>
+      <item name="windowSplashScreenBackground">@color/colorSplash</item>
+      <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
+      <item name="android:statusBarColor">@color/colorSplash</item>
+      <item name="android:windowLightStatusBar">false</item>
     </style>
 </resources>

--- a/mobile-app/android/app/src/main/res/values/styles.xml
+++ b/mobile-app/android/app/src/main/res/values/styles.xml
@@ -21,7 +21,7 @@
 
 
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
-      <item name="windowSplashScreenAnimatedIcon">@drawable/splash</item>
+      <item name="windowSplashScreenAnimatedIcon">@drawable/splash_background</item>
       <item name="windowSplashScreenBackground">@color/colorSplash</item>
       <item name="postSplashScreenTheme">@style/AppTheme.NoActionBar</item>
       <item name="android:statusBarColor">@color/colorSplash</item>

--- a/mobile-app/android/app/src/main/res/xml/network_security_config.xml
+++ b/mobile-app/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- 로컬 개발: 사설 IP 대역 HTTP 허용 -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">172.30.1.83</domain>
+        <domain includeSubdomains="false">192.168.0.1</domain>
+        <domain includeSubdomains="false">10.0.0.1</domain>
+    </domain-config>
+</network-security-config>

--- a/mobile-app/android/capacitor.settings.gradle
+++ b/mobile-app/android/capacitor.settings.gradle
@@ -8,5 +8,14 @@ project(':capacitor-app').projectDir = new File('../../node_modules/.pnpm/@capac
 include ':capacitor-browser'
 project(':capacitor-browser').projectDir = new File('../../node_modules/.pnpm/@capacitor+browser@7.0.4_@capacitor+core@7.5.0/node_modules/@capacitor/browser/android')
 
+include ':capacitor-clipboard'
+project(':capacitor-clipboard').projectDir = new File('../../node_modules/.pnpm/@capacitor+clipboard@7.0.4_@capacitor+core@7.5.0/node_modules/@capacitor/clipboard/android')
+
+include ':capacitor-share'
+project(':capacitor-share').projectDir = new File('../../node_modules/.pnpm/@capacitor+share@7.0.4_@capacitor+core@7.5.0/node_modules/@capacitor/share/android')
+
 include ':capacitor-splash-screen'
 project(':capacitor-splash-screen').projectDir = new File('../../node_modules/.pnpm/@capacitor+splash-screen@7.0.5_@capacitor+core@7.5.0/node_modules/@capacitor/splash-screen/android')
+
+include ':capacitor-status-bar'
+project(':capacitor-status-bar').projectDir = new File('../../node_modules/.pnpm/@capacitor+status-bar@7.0.6_@capacitor+core@7.5.0/node_modules/@capacitor/status-bar/android')

--- a/mobile-app/capacitor.config.ts
+++ b/mobile-app/capacitor.config.ts
@@ -23,7 +23,7 @@ const config: CapacitorConfig = {
   },
   android: {
     allowMixedContent: false,
-    captureInput: true,
+    captureInput: false,
     webContentsDebuggingEnabled: isLocal,
   },
   plugins: {

--- a/mobile-app/capacitor.config.ts
+++ b/mobile-app/capacitor.config.ts
@@ -28,7 +28,7 @@ const config: CapacitorConfig = {
   },
   plugins: {
     CapacitorHttp: {
-      enabled: true,
+      enabled: false,
     },
     SplashScreen: {
       launchShowDuration: 0,

--- a/mobile-app/capacitor.config.ts
+++ b/mobile-app/capacitor.config.ts
@@ -35,7 +35,7 @@ const config: CapacitorConfig = {
       showSpinner: false,
     },
     Keyboard: {
-      resize: 'none',
+      resize: 'body',
       scrollAssist: false,
     },
   },

--- a/mobile-app/capacitor.config.ts
+++ b/mobile-app/capacitor.config.ts
@@ -1,12 +1,16 @@
 import type { CapacitorConfig } from '@capacitor/cli';
 
+const serverUrl = process.env.CAPACITOR_SERVER_URL;
+const isLocal = !!serverUrl && !serverUrl.startsWith('https://ittda.vercel.app');
+
 const config: CapacitorConfig = {
   appId: 'com.ittda.app',
   appName: '잇다',
   webDir: 'src',
   server: {
-    url: 'https://ittda.vercel.app',
-    androidScheme: 'https',
+    url: serverUrl || 'https://ittda.vercel.app',
+    androidScheme: isLocal ? 'http' : 'https',
+    ...(isLocal ? { cleartext: true } : {}),
     allowNavigation: ['ittda.vercel.app', 'ittda-be.o-r.kr'],
   },
   ios: {
@@ -20,7 +24,7 @@ const config: CapacitorConfig = {
   android: {
     allowMixedContent: false,
     captureInput: true,
-    webContentsDebuggingEnabled: false,
+    webContentsDebuggingEnabled: isLocal,
   },
   plugins: {
     SplashScreen: {

--- a/mobile-app/capacitor.config.ts
+++ b/mobile-app/capacitor.config.ts
@@ -27,6 +27,9 @@ const config: CapacitorConfig = {
     webContentsDebuggingEnabled: isLocal,
   },
   plugins: {
+    CapacitorHttp: {
+      enabled: false,
+    },
     SplashScreen: {
       launchShowDuration: 0,
       launchAutoHide: false, // JS에서 직접 hide() 호출

--- a/mobile-app/capacitor.config.ts
+++ b/mobile-app/capacitor.config.ts
@@ -35,7 +35,7 @@ const config: CapacitorConfig = {
       showSpinner: false,
     },
     Keyboard: {
-      resize: 'body',
+      resize: 'none',
       scrollAssist: false,
     },
   },

--- a/mobile-app/capacitor.config.ts
+++ b/mobile-app/capacitor.config.ts
@@ -28,7 +28,7 @@ const config: CapacitorConfig = {
   },
   plugins: {
     CapacitorHttp: {
-      enabled: false,
+      enabled: true,
     },
     SplashScreen: {
       launchShowDuration: 0,

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "sync": "cap sync",
     "open:ios": "cap open ios",
-    "open:android": "cap open android"
+    "open:android": "cap open android",
+    "dev:android": "adb reverse tcp:3000 tcp:3000 && cap sync android && cap run android"
   },
   "dependencies": {
     "@capacitor/android": "^7.0.0",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@capacitor/cli": "^7.0.0",
+    "@types/node": "^25.5.0",
     "typescript": "^5.9.3"
   }
 }

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -14,7 +14,8 @@
     "@capacitor/browser": "^7.0.0",
     "@capacitor/core": "^7.0.0",
     "@capacitor/ios": "^7.0.0",
-    "@capacitor/splash-screen": "^7.0.5"
+    "@capacitor/splash-screen": "^7.0.5",
+    "@capacitor/status-bar": "^7.0.6"
   },
   "devDependencies": {
     "@capacitor/cli": "^7.0.0",

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -12,6 +12,7 @@
     "@capacitor/android": "^7.0.0",
     "@capacitor/app": "^7.0.0",
     "@capacitor/browser": "^7.0.0",
+    "@capacitor/clipboard": "^7.0.4",
     "@capacitor/core": "^7.0.0",
     "@capacitor/ios": "^7.0.0",
     "@capacitor/share": "^7.0.4",

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -14,6 +14,7 @@
     "@capacitor/browser": "^7.0.0",
     "@capacitor/core": "^7.0.0",
     "@capacitor/ios": "^7.0.0",
+    "@capacitor/share": "^7.0.4",
     "@capacitor/splash-screen": "^7.0.5",
     "@capacitor/status-bar": "^7.0.6"
   },

--- a/mobile-app/tsconfig.json
+++ b/mobile-app/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,6 +451,9 @@ importers:
       '@capacitor/browser':
         specifier: ^7.0.0
         version: 7.0.4(@capacitor/core@7.5.0)
+      '@capacitor/clipboard':
+        specifier: ^7.0.4
+        version: 7.0.4(@capacitor/core@7.5.0)
       '@capacitor/core':
         specifier: ^7.0.0
         version: 7.5.0
@@ -14764,7 +14767,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.10
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -14791,7 +14794,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -14806,13 +14809,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -14827,7 +14830,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       '@capacitor/browser':
         specifier: ^7.0.0
         version: 7.0.4(@capacitor/core@7.5.0)
+      '@capacitor/clipboard':
+        specifier: ^7.0.4
+        version: 7.0.4(@capacitor/core@7.5.0)
       '@capacitor/core':
         specifier: ^7.0.0
         version: 7.5.0
@@ -928,6 +931,11 @@ packages:
     resolution: {integrity: sha512-mlohsvLZjWrO5eAVTn1+dABNQwQawcphVp6NQVJZ3I4x2BAoNmJj53QflX7PYGUipL9gF9EM9Yiku3m1McxFZg==}
     engines: {node: '>=20.0.0'}
     hasBin: true
+
+  '@capacitor/clipboard@7.0.4':
+    resolution: {integrity: sha512-+kiTRFjwD5UiWRg/m1JA/0Z0DDdsZLa25MLqI1e3MUi3yNZIwVZV5Oj6v4O0gxmpoBxf5A1L1v3weq+vWOBUuQ==}
+    peerDependencies:
+      '@capacitor/core': '>=7.0.0'
 
   '@capacitor/core@7.5.0':
     resolution: {integrity: sha512-4Y4trISe2Bp3lwsoGFoQIvgX4hiZO8S1Slmbz6oFaMxAuEc4noipQGCQx974PF4glwVVe/8+H3P9iEmCXtrUgA==}
@@ -9913,6 +9921,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@capacitor/clipboard@7.0.4(@capacitor/core@7.5.0)':
+    dependencies:
+      '@capacitor/core': 7.5.0
+
   '@capacitor/core@7.5.0':
     dependencies:
       tslib: 2.8.1
@@ -16269,7 +16281,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.7
+      '@types/node': 20.19.27
       merge-stream: 2.0.0
       supports-color: 8.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       '@capacitor/network':
         specifier: ^8.0.1
         version: 8.0.1(@capacitor/core@7.5.0)
+      '@capacitor/share':
+        specifier: ^7.0.4
+        version: 7.0.4(@capacitor/core@7.5.0)
       '@capacitor/splash-screen':
         specifier: ^7.0.5
         version: 7.0.5(@capacitor/core@7.5.0)
@@ -451,6 +454,9 @@ importers:
       '@capacitor/ios':
         specifier: ^7.0.0
         version: 7.5.0(@capacitor/core@7.5.0)
+      '@capacitor/share':
+        specifier: ^7.0.4
+        version: 7.0.4(@capacitor/core@7.5.0)
       '@capacitor/splash-screen':
         specifier: ^7.0.5
         version: 7.0.5(@capacitor/core@7.5.0)
@@ -935,6 +941,11 @@ packages:
     resolution: {integrity: sha512-9xK/FHFmzKGanB6BdoSZOzXk8vF0OFVQSQ4PAsIrzAzLuXHryO317qy8dcHVpgxYeuZq2noI0My9z1DvVDi/9w==}
     peerDependencies:
       '@capacitor/core': '>=8.0.0'
+
+  '@capacitor/share@7.0.4':
+    resolution: {integrity: sha512-wNXxmXUcChrtbZ5jQv8scFIbIGKo3rk6B7qpWySxfUhYJP5NANgAqQ9Z69m0k/zYsucdh66SBU7XW1ykd9aUug==}
+    peerDependencies:
+      '@capacitor/core': '>=7.0.0'
 
   '@capacitor/splash-screen@7.0.5':
     resolution: {integrity: sha512-bPG2SamFL7VT5I3XsgsGgJhkiyxq3OXCOVKEDupSieVdtEiG7j2vLbSD0xL+91zteF/qLuxsjbugGy5LD8mS2A==}
@@ -9911,6 +9922,10 @@ snapshots:
       '@capacitor/core': 7.5.0
 
   '@capacitor/network@8.0.1(@capacitor/core@7.5.0)':
+    dependencies:
+      '@capacitor/core': 7.5.0
+
+  '@capacitor/share@7.0.4(@capacitor/core@7.5.0)':
     dependencies:
       '@capacitor/core': 7.5.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
       '@capacitor/splash-screen':
         specifier: ^7.0.5
         version: 7.0.5(@capacitor/core@7.5.0)
+      '@capacitor/status-bar':
+        specifier: ^7.0.6
+        version: 7.0.6(@capacitor/core@7.5.0)
       '@googlemaps/markerclusterer':
         specifier: ^2.6.2
         version: 2.6.2
@@ -451,6 +454,9 @@ importers:
       '@capacitor/splash-screen':
         specifier: ^7.0.5
         version: 7.0.5(@capacitor/core@7.5.0)
+      '@capacitor/status-bar':
+        specifier: ^7.0.6
+        version: 7.0.6(@capacitor/core@7.5.0)
     devDependencies:
       '@capacitor/cli':
         specifier: ^7.0.0
@@ -932,6 +938,11 @@ packages:
 
   '@capacitor/splash-screen@7.0.5':
     resolution: {integrity: sha512-bPG2SamFL7VT5I3XsgsGgJhkiyxq3OXCOVKEDupSieVdtEiG7j2vLbSD0xL+91zteF/qLuxsjbugGy5LD8mS2A==}
+    peerDependencies:
+      '@capacitor/core': '>=7.0.0'
+
+  '@capacitor/status-bar@7.0.6':
+    resolution: {integrity: sha512-7AVqj46b26QikImQzWfsJmzG8NUJZBGkrVSuoeTo+SX/YH3hXH0MqwwFgMqMGHfa/BICDgSvTjM9miVFlq0+RQ==}
     peerDependencies:
       '@capacitor/core': '>=7.0.0'
 
@@ -9907,6 +9918,10 @@ snapshots:
     dependencies:
       '@capacitor/core': 7.5.0
 
+  '@capacitor/status-bar@7.0.6(@capacitor/core@7.5.0)':
+    dependencies:
+      '@capacitor/core': 7.5.0
+
   '@chromatic-com/storybook@4.1.3(storybook@10.1.11(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))':
     dependencies:
       '@neoconfetti/react': 1.0.0
@@ -10587,7 +10602,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 22.19.7
+      '@types/node': 25.5.0
       jest-regex-util: 30.0.1
     optional: true
 
@@ -10705,7 +10720,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.19.7
+      '@types/node': 25.5.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
     optional: true
@@ -14722,7 +14737,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.10
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -14749,7 +14764,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -14764,13 +14779,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -14785,7 +14800,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -16049,7 +16064,7 @@ snapshots:
   jest-haste-map@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 22.19.7
+      '@types/node': 25.5.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -16210,7 +16225,7 @@ snapshots:
   jest-util@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 22.19.7
+      '@types/node': 25.5.0
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -16252,7 +16267,7 @@ snapshots:
 
   jest-worker@30.2.0:
     dependencies:
-      '@types/node': 22.19.7
+      '@types/node': 25.5.0
       '@ungap/structured-clone': 1.3.0
       jest-util: 30.2.0
       merge-stream: 2.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,9 @@ importers:
       '@capacitor/cli':
         specifier: ^7.0.0
         version: 7.5.0
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3562,6 +3565,9 @@ packages:
 
   '@types/node@22.19.7':
     resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
+
+  '@types/node@25.5.0':
+    resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
   '@types/oauth@0.9.6':
     resolution: {integrity: sha512-H9TRCVKBNOhZZmyHLqFt9drPM9l+ShWiqqJijU1B8P3DX3ub84NjxDuy+Hjrz+fEca5Kwip3qPMKNyiLgNJtIA==}
@@ -8539,6 +8545,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
@@ -10499,7 +10508,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -10512,14 +10521,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.19.2)(ts-node@10.9.2(@swc/core@1.15.4)(@types/node@22.19.2)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.19.7)(ts-node@10.9.2(@swc/core@1.15.4)(@types/node@22.19.2)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -10590,7 +10599,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -10686,7 +10695,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -12706,7 +12715,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
 
   '@types/chai@5.2.3':
     dependencies:
@@ -12715,7 +12724,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
 
   '@types/cookie-parser@1.4.10(@types/express@5.0.6)':
     dependencies:
@@ -12725,7 +12734,7 @@ snapshots:
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
 
   '@types/d3-array@3.2.2': {}
 
@@ -12769,7 +12778,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.0':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -12782,7 +12791,7 @@ snapshots:
 
   '@types/fs-extra@8.1.5':
     dependencies:
-      '@types/node': 22.19.7
+      '@types/node': 25.5.0
 
   '@types/geojson@7946.0.16': {}
 
@@ -12820,7 +12829,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
 
   '@types/luxon@3.4.2': {}
 
@@ -12848,9 +12857,13 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@25.5.0':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/oauth@0.9.6':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
 
   '@types/passport-google-oauth20@2.0.17':
     dependencies:
@@ -12909,12 +12922,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
 
   '@types/slice-ansi@4.0.0': {}
 
@@ -12926,7 +12939,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       form-data: 4.0.5
 
   '@types/supercluster@7.1.3':
@@ -14521,7 +14534,7 @@ snapshots:
   engine.io@6.6.5:
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.7.2
@@ -14709,7 +14722,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.10
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -14736,7 +14749,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -14751,13 +14764,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -14772,7 +14785,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15956,6 +15969,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@29.7.0(@types/node@22.19.7)(ts-node@10.9.2(@swc/core@1.15.4)(@types/node@22.19.2)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.19.7
+      ts-node: 10.9.2(@swc/core@1.15.4)(@types/node@22.19.2)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@29.7.0:
     dependencies:
       chalk: 4.1.2
@@ -15990,7 +16034,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -16083,7 +16127,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -16111,7 +16155,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -16157,7 +16201,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -16186,7 +16230,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.2
+      '@types/node': 22.19.7
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -18601,6 +18645,8 @@ snapshots:
       through: 2.3.8
 
   undici-types@6.21.0: {}
+
+  undici-types@7.18.2: {}
 
   unique-string@2.0.0:
     dependencies:


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- 안드로이드 실 기기로 테스트하며 발견한 모바일 버그 수정
- 기록 작성시 블록을 일정 시간 동안 꾹 눌러야 레이아웃 이동 가능하도록 변경(스크롤과 이벤트가 겹쳐 불편 접수)
- TEXT 내용이 길어져 입력 중 스크롤 이동이 필요할 때 현재 높이 기준 스크롤이 자동으로 이동하도록 수정
  - 기존에는 스크롤 이동시 0으로 일시적으로 바뀌었다가 이동하면서 약간의 버그 존재했음

## 작업 내용 + 스크린샷

- 안드로이드와 next.js 브릿지 코드 추가
  - 상태바와 인디케이터 색상 변경
  - 인디케이터의 뒤로가기 버튼 조작 변경('한 번 더 누르면 앱이 종료됩니다' 출력)
- 스플래시 화면 이미지 적용
- 안드로이드에서 클립보드 복사가 안되던 문제 수정
  - capacitor 플러그인을 사용해 네이티브 기능 활용하도록 변경(안드로이드에서)
- 안드로이드 IME 문제로 인한 입력 지연 문제 수정
  - 웹뷰(브라우저)의 입력 기능을 그대로 사용하도록 모바일 입력 기능 비활성화
- 안드로이드 이미지 업로드 무한 로딩 이슈 부분 수정
  - 이미지 업로드에 reject 호출이 없어 무한로딩 발생 원인
  - resolve와 reject를 모두 사용하도록 하여 무한로딩 제거 (에러 토스트 출력)
  - **실 기기에서 이미지 업로드 테스트 필요**
- drawer가 열린 후 닫힐 때 인디케이터 영역까지 drawer 콘텐츠가 내려가는 이슈
  - drawer가 닫히면서 인디케이터 영역 높이를 판단하지 못해 발생한 이슈 (키보드가 닫히면서 높이가 달라지므로)
  - 레이아웃의 문제로 키보드와 분리되어 동작하던 것
  - content와 푸터(버튼 위치)를 분리하여 키보드와 함께 이동하도록 수정

## 실제 걸린 시간

## 작업하며 고민했던 점(선택)

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
