### PR TITLE
lighthouse 성능 지표 결과 기반 개선 작업

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,10 @@
+import bundleAnalyzer from '@next/bundle-analyzer';
 import { withSentryConfig } from '@sentry/nextjs';
 import type { NextConfig } from 'next';
+
+const withBundleAnalyzer = bundleAnalyzer({
+  enabled: process.env.ANALYZE === 'true',
+});
 
 // TODO: 나중에는 이미지 호스팅용 CDN 도메인으로 변경 필요
 const imageDomains = [
@@ -22,6 +27,28 @@ const backendHost =
     : 'http://localhost:4000';
 
 const nextConfig: NextConfig = {
+  experimental: {
+    optimizePackageImports: [
+      'lucide-react',
+      'framer-motion',
+      '@radix-ui/react-dialog',
+      '@radix-ui/react-popover',
+      'date-fns',
+    ],
+  },
+
+  webpack(config, { isServer }) {
+    if (!isServer) {
+      // Node.js 전용 패키지가 클라이언트 번들에 포함되지 않도록 제거
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        'import-in-the-middle': false,
+        'require-in-the-middle': false,
+      };
+    }
+    return config;
+  },
+
   async rewrites() {
     return [
       {
@@ -100,7 +127,7 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withSentryConfig(nextConfig, {
+export default withBundleAnalyzer(withSentryConfig(nextConfig, {
   // For all available options, see:
   // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
@@ -117,6 +144,13 @@ export default withSentryConfig(nextConfig, {
   // Upload a larger set of source maps for prettier stack traces (increases build time)
   widenClientFileUpload: true,
 
+  bundleSizeOptimizations: {
+    excludeDebugStatements: true,
+    excludeReplayIframe: true,
+    excludeReplayShadowDom: true,
+    excludeReplayWorker: true,
+  },
+
   // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
   // This can increase your server load as well as your hosting bill.
   // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
@@ -128,4 +162,4 @@ export default withSentryConfig(nextConfig, {
   // https://docs.sentry.io/product/crons/
   // https://vercel.com/docs/cron-jobs
   automaticVercelMonitors: true,
-});
+}));

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -128,39 +128,46 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withBundleAnalyzer(withSentryConfig(nextConfig, {
-  // For all available options, see:
-  // https://www.npmjs.com/package/@sentry/webpack-plugin#options
+export default withBundleAnalyzer(
+  withSentryConfig(nextConfig, {
+    // For all available options, see:
+    // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
-  org: 'ee4bfb86ef7d',
+    org: 'ee4bfb86ef7d',
 
-  project: 'javascript-nextjs',
+    project: 'javascript-nextjs',
 
-  // Only print logs for uploading source maps in CI
-  silent: !process.env.CI,
+    // Only print logs for uploading source maps in CI
+    silent: !process.env.CI,
 
-  // For all available options, see:
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
+    // For all available options, see:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 
-  // Upload a larger set of source maps for prettier stack traces (increases build time)
-  widenClientFileUpload: true,
+    // Upload a larger set of source maps for prettier stack traces (increases build time)
+    widenClientFileUpload: true,
 
-  bundleSizeOptimizations: {
-    excludeDebugStatements: true,
-    excludeReplayIframe: true,
-    excludeReplayShadowDom: true,
-    excludeReplayWorker: true,
-  },
+    // 소스맵을 Sentry에 업로드한 뒤 빌드 결과물에서 삭제 (보안 + Lighthouse 경고 제거)
+    sourcemaps: {
+      deleteSourcemapsAfterUpload: true,
+    },
 
-  // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
-  // This can increase your server load as well as your hosting bill.
-  // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
-  // side errors will fail.
-  tunnelRoute: '/monitoring',
+    bundleSizeOptimizations: {
+      excludeDebugStatements: true,
+      excludeReplayIframe: true,
+      excludeReplayShadowDom: true,
+      excludeReplayWorker: true,
+    },
 
-  // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
-  // See the following for more information:
-  // https://docs.sentry.io/product/crons/
-  // https://vercel.com/docs/cron-jobs
-  automaticVercelMonitors: true,
-}));
+    // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+    // This can increase your server load as well as your hosting bill.
+    // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
+    // side errors will fail.
+    tunnelRoute: '/monitoring',
+
+    // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+    // See the following for more information:
+    // https://docs.sentry.io/product/crons/
+    // https://vercel.com/docs/cron-jobs
+    automaticVercelMonitors: true,
+  }),
+);

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -28,6 +28,7 @@ const backendHost =
 
 const nextConfig: NextConfig = {
   experimental: {
+    optimizeCss: true,
     optimizePackageImports: [
       'lucide-react',
       'framer-motion',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
     "@faker-js/faker": "^10.1.0",
+    "@next/bundle-analyzer": "^16.2.4",
     "@storybook/addon-a11y": "^10.1.11",
     "@storybook/addon-docs": "^10.1.11",
     "@storybook/addon-onboarding": "^10.1.11",

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -1,23 +1,2 @@
-// This file configures the initialization of Sentry for edge features (middleware, edge routes, and so on).
-// The config you add here will be used whenever one of the edge features is loaded.
-// Note that this config is unrelated to the Vercel Edge Runtime and is also required when running locally.
-// https://docs.sentry.io/platforms/javascript/guides/nextjs/
-
-import * as Sentry from "@sentry/nextjs";
-
-Sentry.init({
-  dsn: "https://3b4171913799a34232d6d4f273783ce4@o4510817007501312.ingest.us.sentry.io/4510817061765121",
-
-  // Only enable Sentry in production
-  enabled: process.env.NODE_ENV === 'production',
-
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-
-  // Enable logs to be sent to Sentry
-  enableLogs: true,
-
-  // Enable sending user PII (Personally Identifiable Information)
-  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
-  sendDefaultPii: true,
-});
+// 미들웨어 에러는 서버 Sentry에서 커버되므로 edge Sentry는 사용하지 않음
+export {};

--- a/frontend/src/app/(main)/_components/RecordList.tsx
+++ b/frontend/src/app/(main)/_components/RecordList.tsx
@@ -24,12 +24,14 @@ interface RecordListProps {
 interface RecordItemProps {
   record: RecordPreview;
   imageLayout: ImageLayout;
+  isFirst?: boolean;
   onClick: () => void;
 }
 
 const RecordItem = memo(function RecordItem({
   record,
   imageLayout,
+  isFirst,
   onClick,
 }: RecordItemProps) {
   const sortedRows = useMemo(() => {
@@ -143,6 +145,7 @@ const RecordItem = memo(function RecordItem({
                     key={`${block.id}-${rowNumber}-${block.layout.col}`}
                     block={block}
                     imageLayout={imageLayout}
+                    priorityImage={isFirst}
                   />
                 ))}
               </div>
@@ -163,7 +166,7 @@ const RecordItem = memo(function RecordItem({
                     )}
                   >
                     <div className="truncate whitespace-nowrap overflow-hidden">
-                      <BlockContent block={block} imageLayout={imageLayout} />
+                      <BlockContent block={block} imageLayout={imageLayout} priorityImage={isFirst} />
                     </div>
                   </div>
                 ))}
@@ -242,11 +245,12 @@ export default function RecordList({ imageLayout = 'tile' }: RecordListProps) {
       </div>
 
       {(records ?? []).length > 0 ? (
-        (records ?? []).map((record) => (
+        (records ?? []).map((record, index) => (
           <RecordItem
             key={record.postId}
             record={record}
             imageLayout={imageLayout}
+            isFirst={index === 0}
             onClick={() => router.push(`/record/${record.postId}`)}
           />
         ))

--- a/frontend/src/app/(main)/profile/_components/EmotionDashboard.tsx
+++ b/frontend/src/app/(main)/profile/_components/EmotionDashboard.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import MonthlyPatternChart from '../../_components/MonthlyPatternChart';
+import dynamic from 'next/dynamic';
+
+const MonthlyPatternChart = dynamic(() => import('../../_components/MonthlyPatternChart'), { ssr: false });
 import { cn } from '@/lib/utils';
 import { Smile } from 'lucide-react';
 import { EMOTION_MAP } from '@/lib/constants/constants';

--- a/frontend/src/app/(main)/profile/_components/RecordStatistics.tsx
+++ b/frontend/src/app/(main)/profile/_components/RecordStatistics.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import { useState } from 'react';
-import MonthlyUsageChart from './MonthlyUsageChart';
+import dynamic from 'next/dynamic';
+
+const MonthlyUsageChart = dynamic(() => import('./MonthlyUsageChart'), {
+  ssr: false,
+});
 import WritingRecordStatistics from './WritingRecordStatistics';
-import { cn } from '@/lib/utils';
 import PlaceDashboard from './PlaceDashboard';
 import EmotionDashboard from './EmotionDashboard';
 

--- a/frontend/src/app/(map)/_components/MapRecordItem.tsx
+++ b/frontend/src/app/(map)/_components/MapRecordItem.tsx
@@ -13,12 +13,14 @@ interface MapRecordItemProps {
   isHighlighted: boolean;
   onSelect: (e: React.MouseEvent) => void;
   onNavigate: () => void;
+  priorityLoad?: boolean;
 }
 export function MapRecordItem({
   post,
   isHighlighted,
   onSelect,
   onNavigate,
+  priorityLoad,
 }: MapRecordItemProps) {
   const [isError, setIsError] = useState(false);
 
@@ -44,6 +46,7 @@ export function MapRecordItem({
             onError={() => setIsError(true)}
             assetId={post.thumbnailMediaId ?? randomBaseImage(post.id)}
             alt={post.title}
+            priorityLoad={priorityLoad}
           />
         </div>
       )}

--- a/frontend/src/app/(map)/_components/RecordMapDrawer.tsx
+++ b/frontend/src/app/(map)/_components/RecordMapDrawer.tsx
@@ -161,6 +161,7 @@ export default function RecordMapDrawer({
                           onSelectPost(post.id);
                         }}
                         onNavigate={() => router.push(`/record/${post.id}`)}
+                        priorityLoad={idx === 0}
                       />
                     </div>
                   );

--- a/frontend/src/app/(post)/_components/MonthRecords.tsx
+++ b/frontend/src/app/(post)/_components/MonthRecords.tsx
@@ -41,11 +41,13 @@ const MonthCard = memo(function MonthCard({
   onNavigate,
   onChangeCover,
   canChangeCover,
+  priorityLoad,
 }: {
   month: ConvertedMonthRecord;
   onNavigate: (monthId: string) => void;
   onChangeCover: (monthId: string) => void;
   canChangeCover: boolean;
+  priorityLoad?: boolean;
 }) {
   const handleClick = useCallback(() => {
     onNavigate(month.id);
@@ -65,6 +67,7 @@ const MonthCard = memo(function MonthCard({
       cover={month.cover}
       onClick={handleClick}
       onChangeCover={canChangeCover ? handleChangeCover : undefined}
+      priorityLoad={priorityLoad}
     />
   );
 });
@@ -192,13 +195,14 @@ const MonthRecords = memo(function MonthRecords({
   return (
     <>
       <div className="grid grid-cols-2 gap-4 md:grid-cols-3 pb-bottom-nav">
-        {months.map((m) => (
+        {months.map((m, index) => (
           <MonthCard
             key={m.id}
             month={m}
             onNavigate={handleNavigate}
             onChangeCover={openGallery}
             canChangeCover={canChangeCover}
+            priorityLoad={index === 0}
           />
         ))}
       </div>

--- a/frontend/src/app/(post)/_components/MonthlyDetailRecords.tsx
+++ b/frontend/src/app/(post)/_components/MonthlyDetailRecords.tsx
@@ -54,7 +54,7 @@ export default function MonthlyDetailRecords({
   return (
     <>
       <div className="grid grid-cols-2 gap-4 xs:grid-cols-3 md:grid-cols-4">
-        {sortedGroups.map((d) => (
+        {sortedGroups.map((d, index) => (
           <DateRecordCard
             key={d.date}
             date={d.date}
@@ -63,6 +63,7 @@ export default function MonthlyDetailRecords({
             count={d.count}
             coverUrl={d.coverUrl}
             routePath={`${routePath}/${d.date}`}
+            priorityLoad={index === 0}
           />
         ))}
 

--- a/frontend/src/app/(post)/record/_components/RecordDetail.tsx
+++ b/frontend/src/app/(post)/record/_components/RecordDetail.tsx
@@ -28,6 +28,11 @@ export default function RecordDetail({ recordId }: RecordDetailProps) {
   // row 순서대로 정렬
   const sortedRows = Array.from(rowMap.entries()).sort(([a], [b]) => a - b);
 
+  // 첫 번째 IMAGE 블록 id (priority 힌트용)
+  const firstImageBlockId = sortedRows
+    .flatMap(([, blocks]) => blocks)
+    .find((b) => b.type === 'IMAGE')?.id;
+
   return (
     <div className="flex flex-col flex-1 -mt-6 transition-colors duration-300 dark:bg-[#121212] bg-[#FDFDFD]">
       <header className="-mx-4 sm:-mx-6 sticky top-0 z-50 backdrop-blur-md px-2 sm:px-4 py-2 sm:p-6 flex items-center justify-between transition-colors duration-300 dark:bg-[#121212]/90 bg-white/90">
@@ -64,7 +69,10 @@ export default function RecordDetail({ recordId }: RecordDetailProps) {
                 <div key={rowNumber} className="w-full">
                   {sortedBlocks.map((block) => (
                     <div key={block.id}>
-                      <BlockContent block={block} />
+                      <BlockContent
+                        block={block}
+                        priorityImage={block.id === firstImageBlockId}
+                      />
                     </div>
                   ))}
                 </div>
@@ -85,7 +93,10 @@ export default function RecordDetail({ recordId }: RecordDetailProps) {
                       )}
                     >
                       <div className="truncate whitespace-nowrap overflow-hidden">
-                        <BlockContent block={block} />
+                        <BlockContent
+                          block={block}
+                          priorityImage={block.id === firstImageBlockId}
+                        />
                       </div>
                     </div>
                   ))}

--- a/frontend/src/app/(search)/_components/SearchItem.tsx
+++ b/frontend/src/app/(search)/_components/SearchItem.tsx
@@ -8,9 +8,14 @@ import AssetImage from '@/components/AssetImage';
 interface SearchItemProps {
   record: RecordSearchItem;
   onClick: (id: string) => void;
+  priorityLoad?: boolean;
 }
 
-const SearchItem: React.FC<SearchItemProps> = ({ record, onClick }) => {
+const SearchItem: React.FC<SearchItemProps> = ({
+  record,
+  onClick,
+  priorityLoad,
+}) => {
   return (
     <button
       onClick={() => onClick(record.id)}
@@ -25,6 +30,7 @@ const SearchItem: React.FC<SearchItemProps> = ({ record, onClick }) => {
             width={48}
             height={48}
             className="w-full h-full object-cover rounded-xl"
+            priorityLoad={priorityLoad}
           />
         </div>
       ) : (
@@ -43,17 +49,23 @@ const SearchItem: React.FC<SearchItemProps> = ({ record, onClick }) => {
             {record.snippet}
           </p>
         )}
-        <div className="flex items-center gap-1.5 sm:gap-2 text-[10px] sm:text-xs text-itta-gray3 overflow-hidden">
-          <div className="flex items-center gap-1 sm:gap-1.5 shrink-0">
-            <Calendar size={9} className="text-itta-point sm:hidden" />
-            <Calendar size={10} className="text-itta-point hidden sm:block" />
+        <div className="flex items-center gap-1.5 sm:gap-2 text-[10px] sm:text-xs text-itta-gray3">
+          <div className="flex items-center gap-0.5 sm:gap-1 truncate">
+            <Calendar size={9} className="shrink-0 text-itta-point sm:hidden" />
+            <Calendar
+              size={10}
+              className="shrink-0 text-itta-point hidden sm:block"
+            />
             <span>{formatDateDot(new Date(record.date))}</span>
           </div>
 
           {record.address && (
             <div className="flex items-center gap-1 sm:gap-1.5 min-w-0">
               <MapPin size={9} className="shrink-0 text-itta-point sm:hidden" />
-              <MapPin size={10} className="shrink-0 text-itta-point hidden sm:block" />
+              <MapPin
+                size={10}
+                className="shrink-0 text-itta-point hidden sm:block"
+              />
               <span className="truncate">{record.address}</span>
             </div>
           )}

--- a/frontend/src/app/(search)/search/page.tsx
+++ b/frontend/src/app/(search)/search/page.tsx
@@ -238,6 +238,7 @@ export default function SearchPage() {
                           snippet: record.snippet || '',
                         }}
                         onClick={(id) => router.push(`/record/${id}`)}
+                        priorityLoad={idx === 0}
                       />
                     </div>
                   );

--- a/frontend/src/app/AuthContext.tsx
+++ b/frontend/src/app/AuthContext.tsx
@@ -26,6 +26,10 @@ function SessionGuard({ children }: { children: React.ReactNode }) {
   const logout = useAuthStore((state) => state.logout);
   const { resolvedTheme } = useTheme();
 
+  // skipHydration: true이므로 마운트 후 localStorage에서 상태 복원
+  useEffect(() => {
+    useAuthStore.persist.rehydrate();
+  }, []);
 
   // Capacitor 네이티브 앱: 포그라운드 복귀 시 세션 갱신
   // refetchOnWindowFocus가 네이티브 WebView에서 동작하지 않으므로 명시적으로 처리

--- a/frontend/src/app/api/media-image/[id]/route.ts
+++ b/frontend/src/app/api/media-image/[id]/route.ts
@@ -14,8 +14,7 @@ export async function GET(
 ) {
   const { id } = await params;
 
-  const session = await auth();
-  const cookieStore = await cookies();
+  const [session, cookieStore] = await Promise.all([auth(), cookies()]);
   const guestToken = cookieStore.get('x-guest-access-token')?.value;
   const accessToken = session?.accessToken ?? guestToken;
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -248,7 +248,7 @@ export default function RootLayout({
       >
         <Script
           src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places&loading=async`}
-          strategy="afterInteractive"
+          strategy="lazyOnload"
         />
         <KakaoScript />
         <AuthContext>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -246,10 +246,7 @@ export default function RootLayout({
         className={`${notoSans.variable} antialiased relative`}
         suppressHydrationWarning
       >
-        <Script
-          src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}&libraries=places&loading=async`}
-          strategy="lazyOnload"
-        />
+        {/* Google Maps API는 APIProvider가 필요한 페이지에서만 로드 */}
         <KakaoScript />
         <AuthContext>
           <Providers>

--- a/frontend/src/components/AssetImage.tsx
+++ b/frontend/src/components/AssetImage.tsx
@@ -10,6 +10,7 @@ interface AssetImageProps extends Omit<ImageProps, 'src'> {
   url?: string; // 직접 solve 완료한 URL
   fallback?: React.ReactNode;
   wrapperClassName?: string; // 스켈레톤 wrapper에 적용할 클래스 (fill 사용 시 필요)
+  priorityLoad?: boolean; // priority(deprecated) 대신 사용
 }
 
 export default function AssetImage({
@@ -19,6 +20,7 @@ export default function AssetImage({
   className,
   wrapperClassName,
   fallback,
+  priorityLoad,
   ...props
 }: AssetImageProps) {
   const [hasError, setHasError] = useState(false);
@@ -62,6 +64,8 @@ export default function AssetImage({
           alt={alt}
           className={cn(className, !isLoaded && 'opacity-0')}
           unoptimized={isProxyUrl}
+          fetchPriority={priorityLoad ? 'high' : undefined}
+          loading={priorityLoad ? 'eager' : 'lazy'}
           onLoad={() => setIsLoaded(true)}
           onError={() => { setHasError(true); setIsLoaded(true); }}
           {...props}
@@ -81,6 +85,8 @@ export default function AssetImage({
         alt={alt}
         className={cn(className, !isLoaded && 'opacity-0')}
         unoptimized={isProxyUrl}
+        fetchPriority={priorityLoad ? 'high' : undefined}
+        loading={priorityLoad ? 'eager' : 'lazy'}
         onLoad={() => setIsLoaded(true)}
         onError={() => { setHasError(true); setIsLoaded(true); }}
         {...props}

--- a/frontend/src/components/BlockContent.tsx
+++ b/frontend/src/components/BlockContent.tsx
@@ -15,9 +15,11 @@ type ImageLayout = 'carousel' | 'tile' | 'responsive';
 const BlockContent = memo(function BlockContent({
   block,
   imageLayout = 'carousel',
+  priorityImage,
 }: {
   block: Block;
   imageLayout?: ImageLayout;
+  priorityImage?: boolean;
 }) {
   if (!block.value) return null;
 
@@ -90,7 +92,7 @@ const BlockContent = memo(function BlockContent({
     case 'IMAGE':
       if ('mediaIds' in block.value || 'tempUrls' in block.value) {
         return (
-          <ImageBlock value={block.value as ImageValue} layout={imageLayout} />
+          <ImageBlock value={block.value as ImageValue} layout={imageLayout} priorityLoad={priorityImage} />
         );
       }
       return null;
@@ -201,9 +203,11 @@ export default BlockContent;
 const ImageBlock = memo(function ImageBlock({
   value,
   layout = 'carousel',
+  priorityLoad,
 }: {
   value: ImageValue;
   layout?: ImageLayout;
+  priorityLoad?: boolean;
 }) {
   const [isDesktop, setIsDesktop] = useState(false);
 
@@ -242,9 +246,9 @@ const ImageBlock = memo(function ImageBlock({
   return (
     <div className="relative w-full">
       {shouldShowTile ? (
-        <ImageTileGrid images={displayImages} />
+        <ImageTileGrid images={displayImages} priorityLoad={priorityLoad} />
       ) : (
-        <ImageCarousel images={displayImages} />
+        <ImageCarousel images={displayImages} priorityLoad={priorityLoad} />
       )}
     </div>
   );

--- a/frontend/src/components/ImageCarousel.tsx
+++ b/frontend/src/components/ImageCarousel.tsx
@@ -9,6 +9,7 @@ import { pushBackHandler } from './AndroidBackHandler';
 
 interface ImageCarouselProps {
   images: string[];
+  priorityLoad?: boolean;
 }
 
 function ImageLightbox({
@@ -184,7 +185,7 @@ function ImageLightbox({
   return createPortal(content, document.body);
 }
 
-export default function ImageCarousel({ images }: ImageCarouselProps) {
+export default function ImageCarousel({ images, priorityLoad }: ImageCarouselProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
   const [isMoved, setIsMoved] = useState(false);
@@ -252,7 +253,7 @@ export default function ImageCarousel({ images }: ImageCarouselProps) {
 
   const handleImageClick = (e: React.MouseEvent) => {
     if (!isMoved) {
-      e.stopPropagation(); // 부모 카드 onClick(페이지 이동) 전파 차단
+      e.stopPropagation();
       setLightboxIndex(currentIndex);
     }
   };
@@ -278,6 +279,7 @@ export default function ImageCarousel({ images }: ImageCarouselProps) {
             unoptimized={true}
             sizes="(max-width: 768px) 100vw, 800px"
             className="select-none pointer-events-none w-full h-full object-cover rounded-sm"
+            priorityLoad={priorityLoad}
           />
         </div>
         {lightboxIndex !== null && (
@@ -327,6 +329,7 @@ export default function ImageCarousel({ images }: ImageCarouselProps) {
                   draggable={false}
                   unoptimized={true}
                   className="w-full h-full select-none pointer-events-none object-cover"
+                  priorityLoad={priorityLoad && index === 0}
                 />
               </div>
             ))}

--- a/frontend/src/components/ImageTileGrid.tsx
+++ b/frontend/src/components/ImageTileGrid.tsx
@@ -4,9 +4,10 @@ import AssetImage from './AssetImage';
 
 interface ImageTileGridProps {
   images: string[];
+  priorityLoad?: boolean;
 }
 
-export default function ImageTileGrid({ images }: ImageTileGridProps) {
+export default function ImageTileGrid({ images, priorityLoad }: ImageTileGridProps) {
   if (images.length === 0) return null;
 
   // 1개: 큰 이미지 (원본 비율, 최대 높이 제한)
@@ -21,6 +22,7 @@ export default function ImageTileGrid({ images }: ImageTileGridProps) {
             width={600}
             height={600}
             className="w-full h-full object-cover"
+            priorityLoad={priorityLoad}
           />
         </div>
       </div>
@@ -40,6 +42,7 @@ export default function ImageTileGrid({ images }: ImageTileGridProps) {
                 alt={`이미지 ${index + 1}`}
                 fill
                 className="object-cover"
+                priorityLoad={priorityLoad && index === 0}
               />
             </div>
           ))}
@@ -60,6 +63,7 @@ export default function ImageTileGrid({ images }: ImageTileGridProps) {
               alt="메인 이미지"
               fill
               className="object-cover"
+              priorityLoad={priorityLoad}
             />
           </div>
           {images.slice(1, 3).map((url, index) => (
@@ -91,6 +95,7 @@ export default function ImageTileGrid({ images }: ImageTileGridProps) {
                 alt={`이미지 ${index + 1}`}
                 fill
                 className="object-cover"
+                priorityLoad={priorityLoad && index === 0}
               />
             </div>
           ))}
@@ -110,6 +115,7 @@ export default function ImageTileGrid({ images }: ImageTileGridProps) {
             alt="메인 이미지"
             fill
             className="object-cover"
+            priorityLoad={priorityLoad}
           />
         </div>
         {images.slice(1, 5).map((url, index) => (

--- a/frontend/src/components/ui/PostCard.tsx
+++ b/frontend/src/components/ui/PostCard.tsx
@@ -12,6 +12,7 @@ export interface BaseCardProps {
   imageAlt?: string;
   className?: string;
   children: ReactNode;
+  priorityLoad?: boolean;
 }
 
 export interface CardOverlayProps {
@@ -53,6 +54,7 @@ export function PostCard({
   imageAlt = '',
   className = '',
   children,
+  priorityLoad,
 }: BaseCardProps) {
   return (
     <div className={cn('group relative', height)}>
@@ -75,6 +77,7 @@ export function PostCard({
               alt={imageAlt}
               fill
               className="object-cover transition-transform duration-700 group-hover:scale-105 dark:opacity-60 opacity-90"
+              priorityLoad={priorityLoad}
             />
           ) : (
             <div className={cn('flex items-center justify-center', className)}>

--- a/frontend/src/components/ui/RecordCard.tsx
+++ b/frontend/src/components/ui/RecordCard.tsx
@@ -23,6 +23,7 @@ export interface RecordCardProps {
   height?: string;
   onClick?: () => void;
   onChangeCover?: (id: string) => void;
+  priorityLoad?: boolean;
 }
 
 export const RecordCard = memo(function RecordCard({
@@ -37,6 +38,7 @@ export const RecordCard = memo(function RecordCard({
   onChangeCover,
   createdAt,
   height,
+  priorityLoad,
 }: RecordCardProps) {
   const baseImage = randomBaseImage(id);
   return (
@@ -45,6 +47,7 @@ export const RecordCard = memo(function RecordCard({
       imageUrl={cover?.assetId || baseImage}
       imageAlt={name}
       onClick={onClick}
+      priorityLoad={priorityLoad}
     >
       {/* 커버 변경 버튼 */}
       {onChangeCover && (
@@ -107,6 +110,7 @@ export interface DateRecordCardProps {
   onClick?: () => void;
   routePath?: string;
   icon?: React.ReactNode;
+  priorityLoad?: boolean;
 }
 
 export const DateRecordCard = memo(function DateRecordCard({
@@ -118,6 +122,7 @@ export const DateRecordCard = memo(function DateRecordCard({
   onClick,
   routePath,
   icon,
+  priorityLoad,
 }: DateRecordCardProps) {
   const router = useRouter();
 
@@ -126,6 +131,7 @@ export const DateRecordCard = memo(function DateRecordCard({
       height="aspect-square"
       imageUrl={coverUrl}
       imageAlt={title}
+      priorityLoad={priorityLoad}
       onClick={() => {
         if (routePath) {
           router.push(routePath);
@@ -178,6 +184,7 @@ export interface SimpleRecordCardProps {
   badge?: string;
   onClick?: () => void;
   height?: string;
+  priorityLoad?: boolean;
 }
 
 export const SimpleRecordCard = memo(function SimpleRecordCard({
@@ -187,6 +194,7 @@ export const SimpleRecordCard = memo(function SimpleRecordCard({
   badge,
   onClick,
   height,
+  priorityLoad,
 }: SimpleRecordCardProps) {
   return (
     <PostCard
@@ -194,6 +202,7 @@ export const SimpleRecordCard = memo(function SimpleRecordCard({
       imageAlt={title}
       onClick={onClick}
       height={height}
+      priorityLoad={priorityLoad}
     >
       <PostCard.Overlay>
         <div className="flex items-center justify-between">

--- a/frontend/src/instrumentation-client.ts
+++ b/frontend/src/instrumentation-client.ts
@@ -10,8 +10,8 @@ Sentry.init({
   // Only enable Sentry in production
   enabled: process.env.NODE_ENV === 'production',
 
-  // Add optional integrations for additional features
-  integrations: [Sentry.replayIntegration()],
+  // Replay는 초기 로드 시 번들에 포함되지 않도록 지연 로딩
+  integrations: [],
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
@@ -19,8 +19,6 @@ Sentry.init({
   enableLogs: true,
 
   // Define how likely Replay events are sampled.
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
   replaysSessionSampleRate: 0.1,
 
   // Define how likely Replay events are sampled when an error occurs.
@@ -30,5 +28,12 @@ Sentry.init({
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
   sendDefaultPii: true,
 });
+
+// 페이지 로드 완료 후 Replay 초기화 (이미 로드된 Sentry 인스턴스 사용)
+if (typeof window !== 'undefined') {
+  window.addEventListener('load', () => {
+    Sentry.addIntegration(Sentry.replayIntegration());
+  });
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -110,6 +110,6 @@ export const useAuthStore = create<State & Action>()(
         Cookies.remove(guestTokenKey);
       },
     }),
-    { name: 'auth-storage' },
+    { name: 'auth-storage', skipHydration: true },
   ),
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,9 @@ importers:
       '@faker-js/faker':
         specifier: ^10.1.0
         version: 10.1.0
+      '@next/bundle-analyzer':
+        specifier: ^16.2.4
+        version: 16.2.4
       '@storybook/addon-a11y':
         specifier: ^10.1.11
         version: 10.1.11(storybook@10.1.11(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
@@ -991,6 +994,10 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@discoveryjs/json-ext@0.5.7':
+    resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
+    engines: {node: '>=10.0.0'}
 
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
@@ -1985,6 +1992,9 @@ packages:
     peerDependenciesMeta:
       '@nestjs/platform-socket.io':
         optional: true
+
+  '@next/bundle-analyzer@16.2.4':
+    resolution: {integrity: sha512-EAA9xTDv0P1IiUcZaASJJPkNDjRvL7OMTha6XN8MBzALYGfn7I52Mn7vRiyjVfNrtUPi2qiacY+eFVXe3lKCXA==}
 
   '@next/env@16.0.0':
     resolution: {integrity: sha512-s5j2iFGp38QsG1LWRQaE2iUY3h1jc014/melHFfLdrsMJPqxqDQwWNwyQTcNoUSGZlCVZuM7t7JDMmSyRilsnA==}
@@ -4719,6 +4729,10 @@ packages:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -4914,6 +4928,9 @@ packages:
   dayjs@1.11.19:
     resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
 
+  debounce@1.2.1:
+    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -5092,6 +5109,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  duplexer@0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -5787,6 +5807,10 @@ packages:
     resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  gzip-size@6.0.0:
+    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
+    engines: {node: '>=10'}
+
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
@@ -6086,6 +6110,10 @@ packages:
 
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
+    engines: {node: '>=0.10.0'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
   is-promise@4.0.0:
@@ -7106,6 +7134,10 @@ packages:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
 
+  opener@1.5.2:
+    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
+    hasBin: true
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -7873,6 +7905,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sirv@2.0.4:
+    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
+    engines: {node: '>= 10'}
 
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
@@ -8795,6 +8831,11 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webpack-bundle-analyzer@4.10.1:
+    resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
+    engines: {node: '>= 10.13.0'}
+    hasBin: true
 
   webpack-node-externals@3.0.0:
     resolution: {integrity: sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==}
@@ -9981,6 +10022,8 @@ snapshots:
 
   '@date-fns/tz@1.4.1': {}
 
+  '@discoveryjs/json-ext@0.5.7': {}
+
   '@emnapi/core@1.7.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -11103,6 +11146,13 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@nestjs/platform-socket.io': 11.1.12(@nestjs/common@11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@11.1.9)(rxjs@7.8.2)
+
+  '@next/bundle-analyzer@16.2.4':
+    dependencies:
+      webpack-bundle-analyzer: 4.10.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@next/env@16.0.0': {}
 
@@ -14209,6 +14259,8 @@ snapshots:
 
   commander@6.2.1: {}
 
+  commander@7.2.0: {}
+
   commander@8.3.0: {}
 
   comment-json@4.4.1:
@@ -14404,6 +14456,8 @@ snapshots:
 
   dayjs@1.11.19: {}
 
+  debounce@1.2.1: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -14529,6 +14583,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -14767,7 +14823,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.10
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -14794,7 +14850,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -14809,13 +14865,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -14830,7 +14886,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15505,6 +15561,10 @@ snapshots:
 
   graphql@16.12.0: {}
 
+  gzip-size@6.0.0:
+    dependencies:
+      duplexer: 0.1.2
+
   handlebars@4.7.8:
     dependencies:
       minimist: 1.2.8
@@ -15791,6 +15851,8 @@ snapshots:
   is-obj@2.0.0: {}
 
   is-plain-obj@1.1.0: {}
+
+  is-plain-object@5.0.0: {}
 
   is-promise@4.0.0: {}
 
@@ -17031,6 +17093,8 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  opener@1.5.2: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -17930,6 +17994,12 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  sirv@2.0.4:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
 
   sirv@3.0.2:
     dependencies:
@@ -18919,6 +18989,25 @@ snapshots:
   webdriver-bidi-protocol@0.4.1: {}
 
   webidl-conversions@3.0.1: {}
+
+  webpack-bundle-analyzer@4.10.1:
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      commander: 7.2.0
+      debounce: 1.2.1
+      escape-string-regexp: 4.0.0
+      gzip-size: 6.0.0
+      html-escaper: 2.0.2
+      is-plain-object: 5.0.0
+      opener: 1.5.2
+      picocolors: 1.1.1
+      sirv: 2.0.4
+      ws: 7.5.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   webpack-node-externals@3.0.0: {}
 


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- #282 

작업한 것들을 설명하기엔 내용이 많아서, 노션에 [lighthouse 성능 개선](https://long-cowl-6f3.notion.site/lighthouse-34518227616c80c69bd8c8e248c9691e?source=copy_link) 페이지 추가해 업로드해놨어요.

## 작업 내용 + 스크린샷

### 번들 분석 및 불필요한 요청 제거

- `@next/bundle-analyzer` 추가 후 빌드 파일 분석
  - experimental.optimizePackageImports` 설정으로 `lucide-react`, `framer-motion` 등 패키지 트리쉐이킹 강화
- sentry `bundleSizeOptimizations` 적용 (debug statements, replay iframe/shadow DOM/worker 제거)
- `sentry.edge.config.ts` 비움 → 미들웨어 번들에서 sentry 153KB 제거 (서버사이드 sentry가 커버)
- 마이페이지에서 사용하는 chart 관련 라이브러리가 초기 로드시 사용하지 않더라도 번들에 포함되는 문제로 recharts를 동적으로 import 하도록 지연 로딩

<br />

### Google Maps 로드 방식 개선

모든 페이지에서 메인 스레드를 막는 가장 큰 병목인 google maps 로드 코드인
`layout.tsx`의 `<Script strategy="beforeInteractive">` 제거
google maps 관련 라이브러리인 `@vis.gl/react-google-maps`에서 제공하는 `APIProvider`가 필요한 페이지에서만 Google Maps를 로드하도록 위임

<br />

### Sentry Replay 초기화 지연

페이지 load 이벤트 이후에 Replay integration을 추가하도록 변경 → 초기 메인 스레드 부하 감소

<br />

### 이미지 우선순위(fetchPriority) 체인 구축

`AssetImage`에 `priorityLoad` prop 추가 → `fetchPriority="high"` + `loading="eager"` 적용
각 리스트에서 첫 번째 아이템의 첫 번째 이미지만 `priority` 지정 (LCP 후보 1개 집중)
`priorityLoad`가 false인 이미지는 명시적으로 `loading="lazy"` 적용

<br />

### 소스맵 처리

`sourcemaps.deleteSourcemapsAfterUpload: true` 설정 → sentry에 업로드 후 `.map` 파일 삭제
sentry에서는 에러 디버깅 가능, 프로덕션에서 소스코드 노출 없음, lighthouse 경고 제거

## 실제 걸린 시간

4h

## 작업하며 고민했던 점

- sentry replay 유지?

번들 크기 절감을 위해서 replay 제거를 고민했어요.
만약 replay 기능을 사용하지 않는다고 하면, 에러 발생 문맥을 파악하기 어려워질 것 같아 서비스 운영을 위해 그대로 두는 것으로 결정했어요.
대신, load 이벤트 이후에 초기화되도록 지연시키는걸로 조금 개선했어요.

<br />

### 전 후 비교

edge 미들웨어 번들 사이즈

<img width="45%" alt="image" src="https://github.com/user-attachments/assets/d0ada043-1223-4b22-aa3b-05bcc0241ab9" />

<img width="45%" alt="image" src="https://github.com/user-attachments/assets/4127fbd4-a4b5-47bc-b22b-f45dde73b92e" />

504.57KB → 357.69KB로 총 번들 사이즈는 줄어들었고, edge-instrumentation.js 파일은 155.2KB → 10.91KB로 줄었어요.

edge 번들은 미들웨어이고, 미들웨어는 모든 페이지 요청마다 실행되기 때문에, edge 번들이 작아지면 TTFB를 개선할 수 있어요.

client 번들 사이즈

<img width="45%" alt="image" src="https://github.com/user-attachments/assets/94d7b5d1-6d8e-42d6-9189-571726c8b68e" />

<img width="45%" alt="image" src="https://github.com/user-attachments/assets/73f39856-7e18-4b57-bac8-0ed790106571" />

`Bar.js`가 사라지고 `main` 청크가 393.02KB -> 366.03KB로 줄어들었어요.
instrumentation-client.ts 블록은 sentry의 replay 기능이기에 지울 수가 없네요,,

next.js에서 config 설정에서 추가된 실험 단계 기능(최적화 설정)을 사용해봤어요.
이후에 변경되거나 한다면 수정이 필요하니 지켜볼 필요가 있을 것 같아요.

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
