### PR TITLE
프론트엔드 백엔드 URL 분기 구조 정리

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,20 +1,29 @@
-# backend/.env.local.example
+# backend/.env.local 예시
 # =========
-# Inmemory DB 설정
+# 앱
 # =========
 NODE_ENV=local
 PORT=4000
 USE_INMEMORY_DB=true   # true면 TypeORM 연결 안 함
 DEV_AUTH_KEY=dev-secret
+
 # =========
-# Database
+# 프론트엔드 / 인증
 # =========
-FRONTEND_URL=http://<서버 public ip or domain(https)> # 프론트엔드 도커 서비스 이름 기준 URL, 포트 포함
-JWT_SECRET=<your_jwt_secret> # 당신의 jwt 비밀키
-GOOGLE_CLIENT_ID=<your_oauth_google_client_id> # 구글 OAuth앱이 발급하는 클라이언트 ID
-GOOGLE_CLIENT_SECRET=<your_oauth_google_client_secret> # 구글 OAuth앱이 발급하는 클라이언트 ID
-KAKAO_CLIENT_ID=<your_oauth_kakao_client_id> # 카카오 REST API 키
-KAKAO_CLIENT_SECRET=<your_oauth_kakao_client_secret> # 카카오 로그인 On인경우만 필수
+# 프론트엔드 origin 주소입니다.
+# 백엔드 CORS, WebSocket origin 검사, OAuth 콜백 리다이렉트에 사용됩니다.
+# 로컬 예시: http://localhost:3000
+FRONTEND_URL=http://localhost:3000
+
+# 백엔드 JWT 서명/검증에 사용하는 비밀키입니다.
+# 환경별로 길고 예측 불가능한 값을 사용하고, 같은 환경에서는 계속 동일한 값을 유지하세요.
+JWT_SECRET=<your_jwt_secret>
+
+# OAuth 공급자 자격 증명
+GOOGLE_CLIENT_ID=<your_oauth_google_client_id>
+GOOGLE_CLIENT_SECRET=<your_oauth_google_client_secret>
+KAKAO_CLIENT_ID=<your_oauth_kakao_client_id>
+KAKAO_CLIENT_SECRET=<your_oauth_kakao_client_secret> # 카카오 로그인을 사용할 때만 필요
 
 
 # =========
@@ -28,8 +37,8 @@ DRAFT_LIST_REFRESH_MS=3000 # 그룹 드래프트 목록 소켓 갱신 주기(ms)
 # =========
 # Database
 # =========
-# Postgres (Docker)
-# be, fe를 로컬로 띄울 때는 localhost로 설정합니다.
+# Postgres
+# 로컬 개발에서는 localhost를 사용하고, 배포 환경에서는 실제 운영 DB 연결 문자열을 사용합니다.
 DATABASE_URL="postgresql://dev:dev@localhost:5432/app?schema=public"
 MIGRATION_DATABASE_URL="postgresql://dev:dev@localhost:5432/app?schema=public"
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,8 +52,9 @@ S3_ACCESS_KEY="minioadmin"
 S3_SECRET_KEY="minioadmin"
 S3_BUCKET="images"
 
-# Optional: if your AWS SDK needs it for MinIO
-S3_FORCE_PATH_STYLE="true"
+# Optional
+S3_FORCE_PATH_STYLE="true" # MinIO는 path-style URL을 사용하므로 true로 설정, B2는 false로 설정
+AWS_REQUEST_CHECKSUM_CALCULATION=WHEN_REQUIRED # B2는 WHEN_REQUIRED로 설정하여 체크섬 계산 최적화 기본은 WHEN_SUPPORTED
 
 # backend/.env.docker.example
 # be, fe를 도커 컨테이너로 띄울 때는 서비스명으로 설정합니다.

--- a/cors-dev.xml
+++ b/cors-dev.xml
@@ -1,0 +1,12 @@
+<CORSConfiguration>
+  <CORSRule>
+    <AllowedOrigin>http://localhost:3000</AllowedOrigin>
+    <AllowedOrigin>https://ittda-preview.vercel.app</AllowedOrigin>
+    <AllowedMethod>GET</AllowedMethod>
+    <AllowedMethod>PUT</AllowedMethod>
+    <AllowedMethod>HEAD</AllowedMethod>
+    <AllowedHeader>*</AllowedHeader>
+    <ExposeHeader>ETag</ExposeHeader>
+    <MaxAgeSeconds>300</MaxAgeSeconds>
+  </CORSRule>
+</CORSConfiguration>

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,13 +1,14 @@
 NEXT_PUBLIC_MOCK=false
+NEXT_PUBLIC_BACKEND_TARGET=local
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=xxxx
 NODE_ENV=development
 NEXT_PUBLIC_MOVIE_API_KEY=TMDB_API_KEY
 NEXT_PUBLIC_KOPIS_API_KEY=KOPIS_API_KEY
-NEXT_PUBLIC_API_URL=<your server path>
+NEXT_PUBLIC_DEVELOPMENT_API_URL=<your development server path>
 NEXT_PUBLIC_PRODUCTION_API_URL=<your production server path>
 NEXT_PUBLIC_GOOGLE_MAPS_ID=<your google map id>
 NEXT_PUBLIC_KAKAO_JS_KEY=<your_kakao_js_key>
 AUTH_URL=<auth.js redirect url>
 AUTH_SECRET=<your auth.js secret>
 NEXT_PUBLIC_IMAGE_DOMAIN=http://localhost:3000
-NEXT_PUBLIC_CLIENT_URL=localhost:3000
+NEXT_PUBLIC_CLIENT_URL=http://localhost:3000

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -21,10 +21,18 @@ const imageDomains = [
 ];
 
 // 환경에 따라 백엔드 주소 분기
-const backendHost =
+const trimTrailingSlash = (url: string) => url.replace(/\/+$/, '');
+
+const developmentBackendHost =
+  process.env.NEXT_PUBLIC_BACKEND_TARGET === 'local'
+    ? 'http://localhost:4000'
+    : process.env.NEXT_PUBLIC_DEVELOPMENT_API_URL || 'http://localhost:4000';
+
+const backendHost = trimTrailingSlash(
   process.env.NODE_ENV === 'production'
-    ? process.env.NEXT_PUBLIC_PRODUCTION_API_URL
-    : 'http://localhost:4000';
+    ? process.env.NEXT_PUBLIC_PRODUCTION_API_URL || 'http://localhost:4000'
+    : developmentBackendHost,
+);
 
 const nextConfig: NextConfig = {
   experimental: {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:backend:local": "NEXT_PUBLIC_BACKEND_TARGET=local next dev",
+    "dev:backend:dev": "NEXT_PUBLIC_BACKEND_TARGET=dev next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import { getBackendOrigin } from '@/lib/config/backend';
 import {
   Lock,
   Plus,
@@ -51,7 +52,7 @@ const EMPTY_FORM: FormState = {
 };
 
 const SESSION_KEY = 'admin-key';
-const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+const API_BASE = getBackendOrigin();
 
 function isValidUrl(url: string): boolean {
   try {

--- a/frontend/src/app/api/auth/logout/route.ts
+++ b/frontend/src/app/api/auth/logout/route.ts
@@ -1,4 +1,5 @@
 import { auth } from '@/auth';
+import { getBackendApiBaseUrl } from '@/lib/config/backend';
 import { NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import { logger } from '@/lib/utils/logger';
@@ -8,7 +9,7 @@ export async function POST() {
 
   if (session?.accessToken) {
     try {
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v1/auth/logout`, {
+      await fetch(`${getBackendApiBaseUrl()}/auth/logout`, {
         method: 'POST',
         headers: {
           Authorization: `Bearer ${session.accessToken}`,

--- a/frontend/src/app/api/media-image/[id]/route.ts
+++ b/frontend/src/app/api/media-image/[id]/route.ts
@@ -1,12 +1,10 @@
 import { auth } from '@/auth';
+import { getBackendOrigin } from '@/lib/config/backend';
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import sharp from 'sharp';
 
-const backendUrl =
-  process.env.NODE_ENV === 'production'
-    ? process.env.NEXT_PUBLIC_PRODUCTION_API_URL
-    : 'http://localhost:4000';
+const backendUrl = getBackendOrigin();
 
 export async function GET(
   request: Request,
@@ -56,7 +54,9 @@ export async function GET(
   const originalBuffer = Buffer.from(await imageRes.arrayBuffer());
 
   // WebP로 변환
-  const webpBuffer = await sharp(originalBuffer).webp({ quality: 85 }).toBuffer();
+  const webpBuffer = await sharp(originalBuffer)
+    .webp({ quality: 85 })
+    .toBuffer();
 
   return new NextResponse(new Uint8Array(webpBuffer), {
     headers: {

--- a/frontend/src/auth.ts
+++ b/frontend/src/auth.ts
@@ -2,6 +2,7 @@
 import NextAuth from 'next-auth';
 import Credentials from 'next-auth/providers/credentials';
 import { refreshServerAccessToken } from './lib/api/auth';
+import { getBackendApiBaseUrl } from './lib/config/backend';
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [
@@ -10,7 +11,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       async authorize(credentials) {
         // credentials로 전달받은 code를 백엔드에 전달
         const exchangeRes = await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL}/v1/auth/exchange`,
+          `${getBackendApiBaseUrl()}/auth/exchange`,
           {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },

--- a/frontend/src/components/PWAInstallBanner.tsx
+++ b/frontend/src/components/PWAInstallBanner.tsx
@@ -1,12 +1,10 @@
 import { auth } from '@/auth';
 import { cookies } from 'next/headers';
 import PWAInstallBannerClient from './PWAInstallBannerClient';
+import { getBackendOrigin } from '@/lib/config/backend';
 import { getCookieFromString } from '@/lib/utils/cookie';
 
-const backendUrl =
-  process.env.NODE_ENV === 'production'
-    ? process.env.NEXT_PUBLIC_PRODUCTION_API_URL
-    : 'http://localhost:4000';
+const backendUrl = getBackendOrigin();
 
 async function shouldShowBanner(): Promise<boolean> {
   const session = await auth();

--- a/frontend/src/lib/api/api.ts
+++ b/frontend/src/lib/api/api.ts
@@ -2,6 +2,7 @@ import { ApiResponse } from '../types/response';
 import { getAccessToken, refreshAccessToken, handleLogout } from './auth';
 import * as Sentry from '@sentry/nextjs';
 import { useAuthStore } from '@/store/useAuthStore';
+import { getBackendApiBaseUrl } from '@/lib/config/backend';
 
 /**
  * API Base URL 결정
@@ -19,14 +20,8 @@ function getApiBaseUrl() {
   }
 
   // 서버 환경 - 백엔드 절대 URL
-  const backendUrl =
-    process.env.NODE_ENV === 'production'
-      ? process.env.NEXT_PUBLIC_PRODUCTION_API_URL
-      : process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/v1';
-  return backendUrl;
+  return getBackendApiBaseUrl();
 }
-
-const API_BASE_URL = getApiBaseUrl();
 
 interface FetchOptions extends RequestInit {
   params?: Record<string, string | number | boolean>;
@@ -308,8 +303,7 @@ export async function fetchApi<T>(
   let fullUrl = `${currentBaseUrl}${finalEndpoint}`;
   // 서버 환경인데 여전히 상대경로라면 강제로 도메인을 붙여줌 (방어 코드)
   if (typeof window === 'undefined' && !fullUrl.startsWith('http')) {
-    const fallback =
-      process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000/v1';
+    const fallback = getBackendApiBaseUrl();
     fullUrl = `${fallback}${finalEndpoint.replace(/^\/api/, '')}`;
   }
 

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -5,6 +5,7 @@ import { guestCookieKey, guestTokenKey, useAuthStore } from '@/store/useAuthStor
 import type { Session } from 'next-auth';
 import * as Sentry from '@sentry/nextjs';
 import { logger } from '../utils/logger';
+import { getBackendApiBaseUrl } from '@/lib/config/backend';
 
 const INSTANCE_ID =
   typeof window !== 'undefined'
@@ -224,7 +225,7 @@ export async function refreshServerAccessToken(token: any) {
   serverRefreshPromise = (async () => {
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/v1/auth/refresh`,
+        `${getBackendApiBaseUrl()}/auth/refresh`,
         {
           method: 'POST',
           headers: {

--- a/frontend/src/lib/api/serverFetch.ts
+++ b/frontend/src/lib/api/serverFetch.ts
@@ -1,4 +1,5 @@
 import { auth } from '@/auth';
+import { getBackendOrigin } from '@/lib/config/backend';
 
 export async function serverFetch(url: string, options: RequestInit = {}) {
   const session = await auth();
@@ -11,7 +12,7 @@ export async function serverFetch(url: string, options: RequestInit = {}) {
     headers.set('Authorization', `Bearer ${accessToken}`);
   }
 
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+  const baseUrl = getBackendOrigin();
   const fullUrl = url.startsWith('http') ? url : `${baseUrl}${url}`;
 
   const response = await fetch(fullUrl, {

--- a/frontend/src/lib/config/backend.ts
+++ b/frontend/src/lib/config/backend.ts
@@ -1,0 +1,35 @@
+const LOCAL_BACKEND_ORIGIN = 'http://localhost:4000';
+
+function trimTrailingSlash(url: string) {
+  return url.replace(/\/+$/, '');
+}
+
+function getDevelopmentBackendOrigin() {
+  return trimTrailingSlash(
+    process.env.NEXT_PUBLIC_DEVELOPMENT_API_URL || LOCAL_BACKEND_ORIGIN,
+  );
+}
+
+export function getBackendTarget() {
+  return process.env.NEXT_PUBLIC_BACKEND_TARGET === 'local' ? 'local' : 'dev';
+}
+
+export function getBackendOrigin() {
+  if (process.env.NODE_ENV === 'production') {
+    return trimTrailingSlash(
+      process.env.NEXT_PUBLIC_PRODUCTION_API_URL ||
+        getDevelopmentBackendOrigin(),
+    );
+  }
+
+  if (getBackendTarget() === 'local') {
+    return LOCAL_BACKEND_ORIGIN;
+  }
+
+  return getDevelopmentBackendOrigin();
+}
+
+export function getBackendApiBaseUrl() {
+  const origin = getBackendOrigin();
+  return origin.endsWith('/v1') ? origin : `${origin}/v1`;
+}

--- a/frontend/src/lib/utils/getRedirectUri.ts
+++ b/frontend/src/lib/utils/getRedirectUri.ts
@@ -1,3 +1,5 @@
+import { getBackendApiBaseUrl } from '@/lib/config/backend';
+
 type GetRedirectUriArg = {
   provider: 'kakao' | 'google';
   callback?: string;
@@ -13,7 +15,7 @@ export const getRedirectUri = ({
   mobile = false,
   android = false,
 }: GetRedirectUriArg) => {
-  const baseUrl = `${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000'}/v1/auth/${provider}`;
+  const baseUrl = `${getBackendApiBaseUrl()}/auth/${provider}`;
 
   const params = new URLSearchParams();
   if (callback) {

--- a/frontend/src/store/useSocketStore.ts
+++ b/frontend/src/store/useSocketStore.ts
@@ -5,6 +5,7 @@ import { SocketExceptionResponse } from '@/lib/types/recordCollaboration';
 import { toast } from 'sonner';
 import * as Sentry from '@sentry/nextjs';
 import { logger } from '@/lib/utils/logger';
+import { getBackendOrigin } from '@/lib/config/backend';
 
 interface SocketStore {
   socket: Socket | null;
@@ -44,7 +45,7 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
 
       return;
     }
-    const socket = io(process.env.NEXT_PUBLIC_API_URL || '', {
+    const socket = io(getBackendOrigin(), {
       transports: ['websocket'],
       withCredentials: true,
       auth: {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "prepare": "husky || true",
     "install:all": "pnpm -r install && pnpm prepare",
     "dev:fe": "pnpm --filter frontend dev",
+    "dev:fe:local": "pnpm --filter frontend dev:backend:local",
+    "dev:fe:dev": "pnpm --filter frontend dev:backend:dev",
     "build:fe": "pnpm --filter frontend build",
     "preview:fe": "pnpm --filter frontend preview",
     "infra:up": "docker compose -f docker-compose.dev.yml up -d",


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- 프론트엔드의 백엔드 URL 분기 구조를 정리했습니다.
- 로컬 백엔드와 개발 서버를 스크립트로 명확히 전환할 수 있도록 개선했습니다.
- 연관 이슈: 없음

## 작업 내용 + 스크린샷

- `NEXT_PUBLIC_API_URL` 레거시 변수를 제거했습니다.
- `local / dev / prod` 기준으로 백엔드 선택 로직을 정리했습니다.
- 로컬 환경은 코드 기본값 `http://localhost:4000` 을 사용하도록 단순화했습니다.
- OAuth, 서버 fetch, 소켓 연결, Next.js rewrites가 동일한 기준으로 백엔드를 바라보도록 통일했습니다.
- `dev:fe:local`, `dev:fe:dev` 스크립트를 추가해 실행 경로를 분리했습니다.
- `.env.example`을 현재 구조에 맞게 정리했습니다.

## 실제 걸린 시간

- 약 1시간

## 작업하며 고민했던 점(선택)

- 단순히 `.env` 값만 바꾸는 방식으로 두면 OAuth, SSR fetch, 소켓, rewrites처럼 서로 다른 경로에서 다시 어긋날 수 있어 공통 기준으로 정리했습니다.
- `NEXT_PUBLIC_LOCAL_API_URL`까지 env로 둘지 고민했지만, 로컬 주소는 사실상 고정값이라 오히려 복잡도만 늘어 코드 기본값으로 두는 방향을 선택했습니다.
- 기존 `NEXT_PUBLIC_API_URL`은 역할이 중복되고 의미가 애매해서 제거했습니다.

## 테스트 실행 여부

- [x] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

실행 내용:
- `pnpm --filter frontend exec tsc --noEmit`
- `pnpm exec eslint src/lib/config/backend.ts next.config.ts`

## 리뷰 참고사항(선택)

- 로컬 프론트 실행 시:
  - 로컬 백엔드 연결: `pnpm dev:fe:local`
  - 개발 서버 연결: `pnpm dev:fe:dev`
- 현재 기준으로 local은 코드 기본값 `http://localhost:4000` 을 사용합니다.
- 개발 서버 주소는 `NEXT_PUBLIC_DEVELOPMENT_API_URL` 로 설정해야 합니다.

## 시각 자료(이미지/영상, 있다면)(선택)

- 없음
