### PR TITLE
staging 배포를 위한 github action 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,36 @@
+name: Sync and Deploy to Personal Staging
+
+on:
+  push:
+    branches:
+      - dev # Organization의 dev 브랜치에 push(merge)될 때 실행
+
+jobs:
+  build-and-sync:
+    runs-on: ubuntu-latest
+    steps:
+      # 1. 소스 코드 체크아웃
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # 2. build.sh 실행 권한 부여 및 실행
+      - name: Execute build script
+        run: |
+          chmod +x ./build.sh
+          ./build.sh
+
+      # 3. 개인 레포지토리로 빌드 결과물 푸시
+      - name: Pushes to personal repository
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          # 원본 빌드 결과물 폴더 (build.sh에서 최종적으로 파일들을 모아둔 폴더명)
+          source-directory: 'output'
+          # 목적지 개인 레포지토리 주소
+          destination-github-username: 'H-sooyeon'
+          destination-repository-name: 'team-ittda'
+          user-email: ${{ secrets.EMAIL }}
+          target-branch: 'staging'

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+mkdir output
+find . -maxdepth 1 ! -name '.' ! -name 'output' -exec cp -R {} output/ \;


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- #292 

## 작업 내용 + 스크린샷

- 클라이언트 운영 배포 전, 로컬 확인을 위한 vercel 배포 및 action 설정 추가
- dev 확인용 클라이언트 경로: https://ittda-preview.vercel.app/

## 실제 걸린 시간

3h

## 작업하며 고민했던 점

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

디스코드로 알려주신 백엔드 로컬 환경변수 적용해 클라이언트 배포했습니다.

<br />

참고 자료

[[Github Action] 깃허브 Organization 레포지토리 vercel 자동 배포](https://jjang-j.tistory.com/93#google_vignette)

## 시각 자료(이미지/영상, 있다면)(선택)
