### PR TITLE
기록 임시 저장 기능 추가 및 버그 수정

### DIFF
--- a/frontend/public/privacy-policy.html
+++ b/frontend/public/privacy-policy.html
@@ -267,7 +267,7 @@
         <tbody>
           <tr>
             <td>쿠키 (Cookie)</td>
-            <td>로그인 상태 유지(JWT 토큰), 세션 관리</td>
+            <td>로그인 상태 유지 및 세션 관리</td>
           </tr>
           <tr>
             <td>접속 IP 주소</td>
@@ -331,10 +331,6 @@
             <td>이용자 삭제 요청 또는 회원 탈퇴 시까지</td>
           </tr>
           <tr>
-            <td>리프레시 토큰</td>
-            <td>발급일로부터 14일</td>
-          </tr>
-          <tr>
             <td>게스트 세션</td>
             <td>세션 만료 시까지 (수일 이내)</td>
           </tr>
@@ -368,11 +364,6 @@
           </tr>
         </thead>
         <tbody>
-          <tr>
-            <td>네이버 클라우드 플랫폼</td>
-            <td>사진 및 미디어 파일 저장·관리</td>
-            <td>위탁 계약 기간</td>
-          </tr>
           <tr>
             <td>Google</td>
             <td>OAuth 인증 서비스</td>
@@ -421,11 +412,11 @@
           </tr>
           <tr>
             <td>접근 제어</td>
-            <td>JWT 기반 인증 및 권한 관리</td>
+            <td>인증 기반 접근 제어 및 권한 관리</td>
           </tr>
           <tr>
-            <td>토큰 보안</td>
-            <td>HttpOnly 쿠키 저장, 토큰 갱신(Rotation) 적용</td>
+            <td>로그인 세션 보안</td>
+            <td>안전한 쿠키 저장 방식 적용 및 세션 관리</td>
           </tr>
           <tr>
             <td>접근 권한 최소화</td>
@@ -438,11 +429,11 @@
       <h2>8. 쿠키(Cookie) 정책</h2>
       <p>서비스는 로그인 상태 유지를 위해 쿠키를 사용합니다.</p>
       <ul>
-        <li><strong>사용 쿠키</strong>: JWT 액세스 토큰, 리프레시 토큰</li>
+        <li><strong>사용 목적</strong>: 로그인 상태 유지 및 세션 관리</li>
+        <li><strong>저장 방식</strong>: 보안이 강화된 쿠키 저장 방식 적용</li>
         <li>
-          <strong>저장 방식</strong>: HttpOnly 쿠키 (JavaScript로 접근 불가)
+          <strong>만료</strong>: 일정 기간 경과 또는 로그아웃 시 자동 만료
         </li>
-        <li><strong>만료</strong>: 액세스 토큰 15분, 리프레시 토큰 14일</li>
       </ul>
       <p>
         브라우저 설정에서 쿠키를 거부할 수 있으나, 이 경우 로그인이 필요한

--- a/frontend/src/app/(main)/_components/WeekCalendar.tsx
+++ b/frontend/src/app/(main)/_components/WeekCalendar.tsx
@@ -133,7 +133,7 @@ export default function WeekCalendar({
       new CustomEvent('itda:dateChange', { detail: dateStr }),
     );
     // URL 쿼리 파라미터로 날짜 설정
-    router.push(`${basePath}?date=${dateStr}`);
+    router.replace(`${basePath}?date=${dateStr}`);
     calculateYearMonth(dateStr);
   };
 

--- a/frontend/src/app/(main)/profile/edit/_components/ProfileEditClient.tsx
+++ b/frontend/src/app/(main)/profile/edit/_components/ProfileEditClient.tsx
@@ -28,7 +28,7 @@ export default function ProfileEditClient() {
       let finalMediaId = profile?.user.profileImageId;
 
       if (data.image) {
-        finalMediaId = (await uploadMultipleMedia([data.image]))[0];
+        finalMediaId = (await uploadMultipleMedia([data.image])).successIds[0];
       }
 
       const response = await updateUserProfile({

--- a/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
+++ b/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
@@ -65,7 +65,6 @@ import {
   cleanupStaleDraftPhotos,
   fileToDataUrl,
 } from '@/lib/utils/draftPhotoStorage';
-import { refreshGroupData } from '@/lib/actions/revalidate';
 import AssetImage from '@/components/AssetImage';
 import Image from 'next/image';
 import LocationDrawer from '@/components/map/LocationDrawer';
@@ -728,11 +727,6 @@ export default function PostEditor({
     setIsSaving(true);
 
     try {
-      if (groupId) {
-        await refreshGroupData(groupId);
-        queryClient.invalidateQueries({ queryKey: ['group', groupId] });
-      }
-
       // 개인용 게시글 이미지 -> id 변환 로직
       const finalizedBlocks = await Promise.all(
         filteredBlocks.map(async (block) => {

--- a/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
+++ b/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
@@ -224,8 +224,8 @@ export default function PostEditor({
   const [title, setTitle] = useState(initialPost?.title ?? '');
   const [blocks, setBlocks] = useState<RecordBlock[]>([]);
 
-  // 개인 신규 기록에서만 localStorage 자동저장 활성화
-  const isPersonalNew = mode === 'add' && !groupId && !draftId;
+  // 신규 기록(개인/그룹 개인 모두)에서 localStorage 자동저장 활성화
+  const isPersonalNew = mode === 'add' && !draftId;
   const [draftSavedAt, setDraftSavedAt] = useState<Date | null>(null);
   const [isEditorReady, setIsEditorReady] = useState(false);
   // 초기화 직후 상태 참조 — 사용자 변경 여부 판별용 (reference 비교)
@@ -380,6 +380,8 @@ export default function PostEditor({
   // 자동저장: 마지막 변경 3초 후 localStorage(텍스트) + IndexedDB(사진) 저장
   useEffect(() => {
     if (!isPersonalNew || !initializedStateRef.current) return;
+    // 저장 진행 중에는 타이머를 취소해 race condition 방지
+    if (isSaving || isPublishing) return;
     if (
       title === initializedStateRef.current.title &&
       blocks === initializedStateRef.current.blocks
@@ -412,7 +414,15 @@ export default function PostEditor({
     }, 3_000);
 
     return () => clearTimeout(timer);
-  }, [title, blocks, isPersonalNew, saveDraft, pendingFilesRef]);
+  }, [
+    title,
+    blocks,
+    isPersonalNew,
+    isSaving,
+    isPublishing,
+    saveDraft,
+    pendingFilesRef,
+  ]);
 
   // 에디터 준비 완료 시 stale 정리 + 임시 기록 복원 토스트 표시
   useEffect(() => {

--- a/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
+++ b/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
@@ -57,6 +57,14 @@ import AuthLoadingScreen from '@/components/AuthLoadingScreen';
 import { useRecordEditorPhotos } from '../../_hooks/useRecordEditorPhotos';
 import { useMediaUpload } from '@/hooks/useMediaUpload';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useLocalDraft, PERSONAL_DRAFT_KEY } from '@/hooks/useLocalDraft';
+import {
+  saveDraftPhotos,
+  loadDraftPhotos,
+  clearDraftPhotos,
+  cleanupStaleDraftPhotos,
+  fileToDataUrl,
+} from '@/lib/utils/draftPhotoStorage';
 import { refreshGroupData } from '@/lib/actions/revalidate';
 import AssetImage from '@/components/AssetImage';
 import Image from 'next/image';
@@ -216,6 +224,23 @@ export default function PostEditor({
   const [title, setTitle] = useState(initialPost?.title ?? '');
   const [blocks, setBlocks] = useState<RecordBlock[]>([]);
 
+  // 개인 신규 기록에서만 localStorage 자동저장 활성화
+  const isPersonalNew = mode === 'add' && !groupId && !draftId;
+  const [draftSavedAt, setDraftSavedAt] = useState<Date | null>(null);
+  const [isEditorReady, setIsEditorReady] = useState(false);
+  // 초기화 직후 상태 참조 — 사용자 변경 여부 판별용 (reference 비교)
+  const initializedStateRef = useRef<{
+    title: string;
+    blocks: RecordBlock[];
+  } | null>(null);
+  const { saveDraft, loadDraft, clearDraft } =
+    useLocalDraft(PERSONAL_DRAFT_KEY);
+
+  const clearDraftAndPhotos = useCallback(() => {
+    clearDraft();
+    clearDraftPhotos(PERSONAL_DRAFT_KEY).catch(() => {});
+  }, [clearDraft]);
+
   const { socket, sessionId: mySessionId } = useSocketStore();
   const [locks, setLocks] = useState<Record<string, string>>({});
 
@@ -261,6 +286,7 @@ export default function PostEditor({
       setIsSaving(false);
       resetNavigatingToRecord();
     },
+    onSuccess: isPersonalNew ? clearDraftAndPhotos : undefined,
   });
 
   // 네비게이션이 실패하거나 느린 경우 로딩 화면이 무한히 뜨는 것을 방지하는 안전망
@@ -341,11 +367,123 @@ export default function PostEditor({
   usePostEditorInitializer({
     initialPost: resolvedInitialPost,
     initialDate,
-    onInitialized: ({ title, blocks }) => {
-      setTitle(title);
-      setBlocks(blocks);
+    onInitialized: ({ title: initTitle, blocks: initBlocks }) => {
+      setTitle(initTitle);
+      setBlocks(initBlocks);
+      if (isPersonalNew) {
+        initializedStateRef.current = { title: initTitle, blocks: initBlocks };
+        setIsEditorReady(true);
+      }
     },
   });
+
+  // 자동저장: 마지막 변경 3초 후 localStorage(텍스트) + IndexedDB(사진) 저장
+  useEffect(() => {
+    if (!isPersonalNew || !initializedStateRef.current) return;
+    if (
+      title === initializedStateRef.current.title &&
+      blocks === initializedStateRef.current.blocks
+    )
+      return;
+
+    const timer = setTimeout(() => {
+      saveDraft(title, blocks);
+
+      // 미업로드 사진(tempUrls)을 File 객체와 매핑하여 IndexedDB에 저장
+      const photoData: Array<{
+        blockId: string;
+        originalUrl: string;
+        file: File;
+      }> = [];
+      for (const block of blocks) {
+        if (block.type !== 'photos') continue;
+        for (const url of (block.value as { tempUrls?: string[] }).tempUrls ??
+          []) {
+          const file = pendingFilesRef.current.get(url);
+          if (file)
+            photoData.push({ blockId: block.id, originalUrl: url, file });
+        }
+      }
+      if (photoData.length > 0) {
+        saveDraftPhotos(PERSONAL_DRAFT_KEY, photoData).catch(() => {});
+      }
+
+      setDraftSavedAt(new Date());
+    }, 3_000);
+
+    return () => clearTimeout(timer);
+  }, [title, blocks, isPersonalNew, saveDraft, pendingFilesRef]);
+
+  // 에디터 준비 완료 시 stale 정리 + 임시 기록 복원 토스트 표시
+  useEffect(() => {
+    if (!isEditorReady) return;
+
+    // 만료된 사진 데이터 정리 (7일 초과)
+    cleanupStaleDraftPhotos().catch(() => {});
+
+    const draft = loadDraft();
+    if (!draft) return;
+
+    const savedDate = new Date(draft.savedAt);
+    const minutes = Math.floor((Date.now() - savedDate.getTime()) / 60_000);
+    const timeLabel = minutes < 1 ? '방금' : `${minutes}분 전`;
+
+    toast(`${timeLabel} 작성하던 기록이 있어요`, {
+      description: draft.title ? `"${draft.title}"` : '제목 없음',
+      action: {
+        label: '이어서 작성',
+        onClick: async () => {
+          // IndexedDB에서 사진 복원
+          const photos = await loadDraftPhotos(PERSONAL_DRAFT_KEY).catch(
+            () => null,
+          );
+
+          let restoredBlocks = draft.blocks;
+
+          if (photos && photos.length > 0) {
+            // File → data URL 변환 (display용)
+            const urlMap = new Map<string, string>();
+            await Promise.all(
+              photos.map(async ({ originalUrl, file }) => {
+                const dataUrl = await fileToDataUrl(file).catch(() => null);
+                if (dataUrl) {
+                  urlMap.set(originalUrl, dataUrl);
+                  pendingFilesRef.current.set(dataUrl, file as File);
+                }
+              }),
+            );
+
+            // 블록의 빈 tempUrls를 복원된 URL로 채움
+            restoredBlocks = draft.blocks.map((block) => {
+              if (block.type !== 'photos') return block;
+              const blockPhotos = photos
+                .filter((p) => p.blockId === block.id)
+                .map((p) => urlMap.get(p.originalUrl))
+                .filter(Boolean) as string[];
+              return {
+                ...block,
+                value: { ...block.value, tempUrls: blockPhotos },
+              };
+            });
+          }
+
+          setTitle(draft.title);
+          setBlocks(restoredBlocks);
+          initializedStateRef.current = {
+            title: draft.title,
+            blocks: restoredBlocks,
+          };
+        },
+      },
+      cancel: {
+        label: '새로 시작',
+        onClick: clearDraftAndPhotos,
+      },
+      duration: Infinity,
+    });
+    // isEditorReady가 true로 바뀌는 순간 한 번만 실행
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isEditorReady]);
 
   // draftId가 있지만 initialPost가 없는 경우 처리
   // (발행 직후 또는 잘못된 draft ID)
@@ -921,7 +1059,12 @@ export default function PostEditor({
   return (
     <div className="w-full flex flex-col h-full bg-white dark:bg-[#121212]">
       {(isPublishing || isSaving) && <AuthLoadingScreen type="publish" />}
-      <RecordEditorHeader mode={mode} onSave={handleSave} members={members} />
+      <RecordEditorHeader
+        mode={mode}
+        onSave={handleSave}
+        members={members}
+        draftSavedAt={isPersonalNew ? draftSavedAt : null}
+      />
       <div className="mx-3 sm:mx-6 mt-2 sm:mt-3 flex flex-row gap-1.5 sm:gap-2">
         {group?.group.name ? (
           <div className="px-2 sm:px-3 w-fit items-center rounded-full py-0.5 sm:py-1 text-[11px] sm:text-[13px] font-bold bg-emerald-50 text-emerald-600 border border-emerald-100 dark:bg-emerald-500/10 dark:text-emerald-400 dark:border-emerald-500/20">

--- a/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
+++ b/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
@@ -57,7 +57,7 @@ import AuthLoadingScreen from '@/components/AuthLoadingScreen';
 import { useRecordEditorPhotos } from '../../_hooks/useRecordEditorPhotos';
 import { useMediaUpload } from '@/hooks/useMediaUpload';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useLocalDraft, PERSONAL_DRAFT_KEY } from '@/hooks/useLocalDraft';
+import { useLocalDraft, getDraftKey } from '@/hooks/useLocalDraft';
 import {
   saveDraftPhotos,
   loadDraftPhotos,
@@ -232,13 +232,14 @@ export default function PostEditor({
     title: string;
     blocks: RecordBlock[];
   } | null>(null);
-  const { saveDraft, loadDraft, clearDraft } =
-    useLocalDraft(PERSONAL_DRAFT_KEY);
+  // 개인 글과 그룹별 글의 임시저장을 분리하기 위한 키
+  const draftStorageKey = getDraftKey(groupId);
+  const { saveDraft, loadDraft, clearDraft } = useLocalDraft(draftStorageKey);
 
   const clearDraftAndPhotos = useCallback(() => {
     clearDraft();
-    clearDraftPhotos(PERSONAL_DRAFT_KEY).catch(() => {});
-  }, [clearDraft]);
+    clearDraftPhotos(draftStorageKey).catch(() => {});
+  }, [clearDraft, draftStorageKey]);
 
   const { socket, sessionId: mySessionId } = useSocketStore();
   const [locks, setLocks] = useState<Record<string, string>>({});
@@ -409,7 +410,7 @@ export default function PostEditor({
         }
       }
       if (photoData.length > 0) {
-        saveDraftPhotos(PERSONAL_DRAFT_KEY, photoData).catch(() => {});
+        saveDraftPhotos(draftStorageKey, photoData).catch(() => {});
       }
 
       setDraftSavedAt(new Date());
@@ -423,6 +424,7 @@ export default function PostEditor({
     isSaving,
     isPublishing,
     saveDraft,
+    draftStorageKey,
     pendingFilesRef,
   ]);
 
@@ -446,7 +448,7 @@ export default function PostEditor({
         label: '이어서 작성',
         onClick: async () => {
           // IndexedDB에서 사진 복원
-          const photos = await loadDraftPhotos(PERSONAL_DRAFT_KEY).catch(
+          const photos = await loadDraftPhotos(draftStorageKey).catch(
             () => null,
           );
 

--- a/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
+++ b/frontend/src/app/(post)/_components/editor/RecordEditor.tsx
@@ -338,6 +338,8 @@ export default function PostEditor({
   const {
     pendingMetadata,
     pendingFilesRef,
+    isProcessingPhotos,
+    pendingPreviewUrls,
     handlePhotoUpload,
     handleApplyMetadata,
     handleSkipMetadata,
@@ -352,6 +354,7 @@ export default function PostEditor({
     uploadMultipleMedia,
     applyPatch,
     releaseLock,
+    removeBlock,
   });
 
   const { gridRef, isDraggingId, handleGridDragOver, handleDragEnd } =
@@ -746,9 +749,9 @@ export default function PostEditor({
             });
 
             if (filesToUpload.length > 0) {
-              const newMediaIds = await uploadMultipleMedia(filesToUpload);
+              const { successIds } = await uploadMultipleMedia(filesToUpload);
               const updatedValue = {
-                mediaIds: [...(block.value.mediaIds || []), ...newMediaIds],
+                mediaIds: [...(block.value.mediaIds || []), ...successIds],
                 tempUrls: [], // 업로드 완료 후 비움
               };
 
@@ -985,11 +988,17 @@ export default function PostEditor({
 
               let nextValue;
               if (mediaIds.length > 0) {
-                // draft 모드: mediaIds와 tempUrls가 인덱스 대응 — 같이 제거
+                // tempUrls는 mediaIds 뒤쪽(tail)에 추가된 새 사진의 미리보기와 대응됨
+                // (기록 수정 등 기존 mediaIds에는 대응하는 tempUrl이 없을 수 있음)
+                const tempUrlOffset = mediaIds.length - tempUrls.length;
+                const tempIdx = idx - tempUrlOffset;
                 nextValue = {
                   ...photoValue,
                   mediaIds: mediaIds.filter((_, i) => i !== idx),
-                  tempUrls: tempUrls.filter((_, i) => i !== idx),
+                  tempUrls:
+                    tempIdx >= 0
+                      ? tempUrls.filter((_, i) => i !== tempIdx)
+                      : tempUrls,
                 };
               } else {
                 // 일반 모드: tempUrls만
@@ -1013,6 +1022,8 @@ export default function PostEditor({
               handleCloseDrawer(id);
             }}
             draftId={draftId}
+            isUploading={isProcessingPhotos}
+            pendingPreviewUrls={pendingPreviewUrls}
           />
         );
       case 'emotion':

--- a/frontend/src/app/(post)/_components/editor/RecordEditorHeader.tsx
+++ b/frontend/src/app/(post)/_components/editor/RecordEditorHeader.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Back from '@/components/Back';
+import { Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import { PresenceMember } from '@/hooks/useDraftPresence';
 
 import {
@@ -17,14 +19,35 @@ interface RecordEditorHeaderProps {
   onSave: () => void;
   onBack?: () => void;
   members?: PresenceMember[];
+  draftSavedAt?: Date | null;
 }
+
+type DraftBadgeState = 'visible' | 'fading' | null;
 
 export default function RecordEditorHeader({
   mode,
   onSave,
   members,
+  draftSavedAt,
 }: RecordEditorHeaderProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [draftBadge, setDraftBadge] = useState<DraftBadgeState>(null);
+
+  useEffect(() => {
+    if (!draftSavedAt) return;
+
+    requestAnimationFrame(() => {
+      setDraftBadge('visible');
+    });
+
+    const fadeTimer = setTimeout(() => setDraftBadge('fading'), 2500);
+    const removeTimer = setTimeout(() => setDraftBadge(null), 3000);
+
+    return () => {
+      clearTimeout(fadeTimer);
+      clearTimeout(removeTimer);
+    };
+  }, [draftSavedAt]);
   const memberList = members ?? [];
   const hasMembers = memberList.length > 0;
   const titleText = mode === 'edit' ? '기록 수정' : '기록 작성';
@@ -140,6 +163,17 @@ export default function RecordEditorHeader({
           </div>
         )}
 
+        {draftBadge && (
+          <span
+            className={cn(
+              'flex items-center gap-1 text-[11px] text-gray-400 dark:text-gray-500 whitespace-nowrap shrink-0 transition-opacity duration-500',
+              draftBadge === 'visible' ? 'opacity-100' : 'opacity-0',
+            )}
+          >
+            <Check className="w-3 h-3" />
+            저장됨
+          </span>
+        )}
         <button
           onClick={onSave}
           className="px-3.5 sm:px-5 py-1.5 sm:py-2 rounded-lg sm:rounded-xl text-xs sm:text-sm font-semibold active:scale-95 transition-all shadow-sm bg-itta-black text-white shrink-0 dark:bg-white dark:text-black"

--- a/frontend/src/app/(post)/_components/editor/metadata/MetadataSelectionDrawer.tsx
+++ b/frontend/src/app/(post)/_components/editor/metadata/MetadataSelectionDrawer.tsx
@@ -113,6 +113,7 @@ export default function MetadataSelectionDrawer({
                         alt={`사진 ${idx + 1}`}
                         className="w-full h-full object-cover rounded-2xl"
                         unoptimized
+                        style={{ imageOrientation: 'from-image' }}
                       />
                       {selectedIndex === idx && (
                         <div className="absolute inset-0 bg-[#10B981]/20 flex items-center justify-center">

--- a/frontend/src/app/(post)/_components/editor/photo/PhotoDrawer.tsx
+++ b/frontend/src/app/(post)/_components/editor/photo/PhotoDrawer.tsx
@@ -47,7 +47,8 @@ export default function PhotoDrawer({
   );
 
   // 총 사진 수: mediaIds 기준 (로딩 중에도 개수 유지)
-  const totalCount = mediaIds.length > 0 ? mediaIds.length : (photos.tempUrls?.length || 0);
+  const totalCount =
+    mediaIds.length > 0 ? mediaIds.length : photos.tempUrls?.length || 0;
 
   // 각 슬롯의 URL(null이면 로딩 스켈레톤): tempUrl 우선, 없으면 resolved URL
   const photoSlots =
@@ -116,6 +117,7 @@ export default function PhotoDrawer({
                         alt={`첨부사진 ${idx + 1}`}
                         className="w-full h-full object-cover rounded-2xl"
                         unoptimized={true}
+                        style={{ imageOrientation: 'from-image' }}
                       />
                     ) : (
                       // URL 아직 로딩 중 — 스켈레톤

--- a/frontend/src/app/(post)/_components/editor/photo/PhotoDrawer.tsx
+++ b/frontend/src/app/(post)/_components/editor/photo/PhotoDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Trash2, X, Plus, Info, CheckCircle2 } from 'lucide-react';
+import { Trash2, X, Plus, Info, CheckCircle2, Loader2 } from 'lucide-react';
 import {
   Drawer,
   DrawerClose,
@@ -27,6 +27,8 @@ interface PhotoDrawerProps {
     };
   };
   draftId?: string;
+  isUploading?: boolean;
+  pendingPreviewUrls?: string[];
 }
 
 export default function PhotoDrawer({
@@ -38,31 +40,55 @@ export default function PhotoDrawer({
   onEditMetadata,
   appliedMetadata = {},
   draftId,
+  isUploading = false,
+  pendingPreviewUrls = [],
 }: PhotoDrawerProps) {
   const mediaIds = photos.mediaIds || [];
+  const tempUrls = photos.tempUrls || [];
   const { data: resolvedData } = useMediaResolveMulti(mediaIds, draftId);
 
   const urlMap = new Map(
     resolvedData?.items.map((item) => [item.mediaId, item.url]),
   );
 
-  // 총 사진 수: mediaIds 기준 (로딩 중에도 개수 유지)
+  // 총 사진 수: mediaIds 기준 (로딩 중에도 개수 유지) + 업로드 중인 미리보기
   const totalCount =
-    mediaIds.length > 0 ? mediaIds.length : photos.tempUrls?.length || 0;
+    (mediaIds.length > 0 ? mediaIds.length : tempUrls.length) +
+    pendingPreviewUrls.length;
+
+  // tempUrls는 mediaIds 뒤쪽(tail)에 추가된 새 사진의 미리보기와 대응된다.
+  // (기록 수정 등 기존 mediaIds에는 대응하는 tempUrl이 없을 수 있음)
+  const tempUrlOffset = mediaIds.length - tempUrls.length;
 
   // 각 슬롯의 URL(null이면 로딩 스켈레톤): tempUrl 우선, 없으면 resolved URL
-  const photoSlots =
-    mediaIds.length > 0
+  // 업로드 중인 미리보기는 맨 뒤에 추가 (서버 반영 전 자기 자신에게만 표시)
+  const photoSlots = [
+    ...(mediaIds.length > 0
       ? mediaIds.map((id, i) => ({
           key: id,
-          url: photos.tempUrls?.[i] || urlMap.get(id) || null,
+          url:
+            (i >= tempUrlOffset ? tempUrls[i - tempUrlOffset] : undefined) ||
+            urlMap.get(id) ||
+            null,
+          isPending: false,
         }))
-      : (photos.tempUrls || []).map((url, i) => ({
+      : tempUrls.map((url, i) => ({
           key: `temp-${i}`,
           url,
-        }));
+          isPending: false,
+        }))),
+    ...pendingPreviewUrls.map((url, i) => ({
+      key: `pending-${i}`,
+      url,
+      isPending: true,
+    })),
+  ];
   return (
-    <Drawer open={true} onOpenChange={(open) => !open && onClose()}>
+    <Drawer
+      open={true}
+      onOpenChange={(open) => !open && !isUploading && onClose()}
+      dismissible={!isUploading}
+    >
       <DrawerContent className="h-[80vh] flex flex-col outline-none">
         <div className="w-full px-6 pt-4 pb-10 flex flex-col h-full overflow-hidden">
           <DrawerHeader className="px-0 items-start text-left flex flex-row justify-between">
@@ -89,13 +115,20 @@ export default function PhotoDrawer({
             <div className="grid grid-cols-3 md:grid-cols-4 gap-3 py-2">
               <button
                 onClick={onUploadClick}
-                className="aspect-square rounded-2xl border-2 border-dashed border-gray-200 dark:border-white/10 flex flex-col items-center justify-center gap-1 text-[#10B981] bg-[#10B981]/5 active:scale-95 transition-all"
+                disabled={isUploading}
+                className="aspect-square rounded-2xl border-2 border-dashed border-gray-200 dark:border-white/10 flex flex-col items-center justify-center gap-1 text-[#10B981] bg-[#10B981]/5 active:scale-95 transition-all disabled:opacity-50 disabled:active:scale-100"
               >
-                <Plus size={24} />
-                <span className="text-[10px] font-bold">사진 추가</span>
+                {isUploading ? (
+                  <Loader2 size={24} className="animate-spin" />
+                ) : (
+                  <Plus size={24} />
+                )}
+                <span className="text-[10px] font-bold">
+                  {isUploading ? '업로드 중' : '사진 추가'}
+                </span>
               </button>
 
-              {photoSlots.map(({ key, url }, idx) => {
+              {photoSlots.map(({ key, url, isPending }, idx) => {
                 const appliedFields = url ? appliedMetadata[url] : undefined;
                 const isMetadataApplied =
                   appliedFields &&
@@ -123,6 +156,12 @@ export default function PhotoDrawer({
                       // URL 아직 로딩 중 — 스켈레톤
                       <div className="w-full h-full animate-pulse bg-gray-200 dark:bg-white/20 rounded-2xl" />
                     )}
+                    {isPending && (
+                      // 업로드 진행 중 — 자기 자신에게만 보이는 미리보기
+                      <div className="absolute inset-0 flex items-center justify-center bg-black/30 rounded-2xl">
+                        <Loader2 size={20} className="animate-spin text-white" />
+                      </div>
+                    )}
                     {isMetadataApplied && (
                       <div className="absolute bottom-1.5 left-1.5 flex items-center gap-1 px-2 py-1 bg-[#10B981] rounded-full">
                         <CheckCircle2 size={12} className="text-white" />
@@ -131,12 +170,15 @@ export default function PhotoDrawer({
                         </span>
                       </div>
                     )}
-                    <button
-                      onClick={() => onRemovePhoto(idx)}
-                      className="absolute top-1.5 right-1.5 p-1.5 bg-black/50 backdrop-blur-md rounded-full text-white active:scale-90 transition-transform"
-                    >
-                      <X size={12} />
-                    </button>
+                    {!isPending && (
+                      <button
+                        onClick={() => onRemovePhoto(idx)}
+                        disabled={isUploading}
+                        className="absolute top-1.5 right-1.5 p-1.5 bg-black/50 backdrop-blur-md rounded-full text-white active:scale-90 transition-transform disabled:opacity-50 disabled:active:scale-100"
+                      >
+                        <X size={12} />
+                      </button>
+                    )}
                   </div>
                 );
               })}
@@ -150,15 +192,23 @@ export default function PhotoDrawer({
                   onRemoveAll();
                   onClose();
                 }}
-                className="w-full py-3 flex items-center justify-center gap-2 text-rose-500 font-bold text-xs hover:bg-rose-50 dark:hover:bg-rose-500/5 rounded-xl transition-colors"
+                disabled={isUploading}
+                className="w-full py-3 flex items-center justify-center gap-2 text-rose-500 font-bold text-xs hover:bg-rose-50 dark:hover:bg-rose-500/5 rounded-xl transition-colors disabled:opacity-50"
               >
                 <Trash2 size={14} />
                 전체 삭제하기
               </button>
             )}
-            <DrawerClose className="w-full py-4 rounded-xl font-bold text-sm bg-itta-black text-white dark:bg-white dark:text-black shadow-xl active:scale-95 transition-all">
-              완료
-            </DrawerClose>
+            {isUploading ? (
+              <div className="w-full py-4 rounded-xl font-bold text-sm bg-gray-200 dark:bg-white/10 text-gray-400 dark:text-gray-500 flex items-center justify-center gap-2 cursor-not-allowed">
+                <Loader2 size={16} className="animate-spin" />
+                이미지 업로드 중...
+              </div>
+            ) : (
+              <DrawerClose className="w-full py-4 rounded-xl font-bold text-sm bg-itta-black text-white dark:bg-white dark:text-black shadow-xl active:scale-95 transition-all">
+                완료
+              </DrawerClose>
+            )}
           </div>
         </div>
       </DrawerContent>

--- a/frontend/src/app/(post)/_components/editor/photo/PhotoField.tsx
+++ b/frontend/src/app/(post)/_components/editor/photo/PhotoField.tsx
@@ -22,14 +22,18 @@ export const PhotoField = ({ photos, onClick, onRemove, draftId }: Props) => {
   const MAX_VISIBLE = 3;
 
   const mediaIds = photos.mediaIds || [];
-  const { data: resolvedData, isLoading } = useMediaResolveMulti(mediaIds, draftId);
+  const { data: resolvedData, isLoading } = useMediaResolveMulti(
+    mediaIds,
+    draftId,
+  );
 
   const urlMap = new Map(
     resolvedData?.items.map((item) => [item.mediaId, item.url]),
   );
 
   // mediaId 개수 기준으로 총 사진 수 계산 (로딩 중에도 개수 유지)
-  const totalCount = mediaIds.length > 0 ? mediaIds.length : (photos.tempUrls?.length || 0);
+  const totalCount =
+    mediaIds.length > 0 ? mediaIds.length : photos.tempUrls?.length || 0;
   const hasMore = totalCount > MAX_VISIBLE;
 
   // URL 결정: tempUrl 우선, 없으면 resolved URL, 둘 다 없으면 null(스켈레톤)
@@ -76,6 +80,7 @@ export const PhotoField = ({ photos, onClick, onRemove, draftId }: Props) => {
                 className="w-full h-full object-cover"
                 alt={`첨부 사진 ${idx + 1}`}
                 unoptimized={true}
+                style={{ imageOrientation: 'from-image' }}
               />
             ) : (
               // URL 아직 로딩 중 — 스켈레톤

--- a/frontend/src/app/(post)/_components/editor/photo/PhotoField.tsx
+++ b/frontend/src/app/(post)/_components/editor/photo/PhotoField.tsx
@@ -22,6 +22,7 @@ export const PhotoField = ({ photos, onClick, onRemove, draftId }: Props) => {
   const MAX_VISIBLE = 3;
 
   const mediaIds = photos.mediaIds || [];
+  const tempUrls = photos.tempUrls || [];
   const { data: resolvedData, isLoading } = useMediaResolveMulti(
     mediaIds,
     draftId,
@@ -32,18 +33,24 @@ export const PhotoField = ({ photos, onClick, onRemove, draftId }: Props) => {
   );
 
   // mediaId 개수 기준으로 총 사진 수 계산 (로딩 중에도 개수 유지)
-  const totalCount =
-    mediaIds.length > 0 ? mediaIds.length : photos.tempUrls?.length || 0;
+  const totalCount = mediaIds.length > 0 ? mediaIds.length : tempUrls.length;
   const hasMore = totalCount > MAX_VISIBLE;
+
+  // tempUrls는 mediaIds 뒤쪽(tail)에 추가된 새 사진의 미리보기와 대응된다.
+  // (기록 수정 등 기존 mediaIds에는 대응하는 tempUrl이 없을 수 있음)
+  const tempUrlOffset = mediaIds.length - tempUrls.length;
 
   // URL 결정: tempUrl 우선, 없으면 resolved URL, 둘 다 없으면 null(스켈레톤)
   const photoSlots =
     mediaIds.length > 0
       ? mediaIds.slice(0, MAX_VISIBLE).map((id, i) => ({
           key: id,
-          url: photos.tempUrls?.[i] || urlMap.get(id) || null,
+          url:
+            (i >= tempUrlOffset ? tempUrls[i - tempUrlOffset] : undefined) ||
+            urlMap.get(id) ||
+            null,
         }))
-      : (photos.tempUrls || []).slice(0, MAX_VISIBLE).map((url, i) => ({
+      : tempUrls.slice(0, MAX_VISIBLE).map((url, i) => ({
           key: `temp-${i}`,
           url,
         }));

--- a/frontend/src/app/(post)/_hooks/useRecordEditorPhotos.ts
+++ b/frontend/src/app/(post)/_hooks/useRecordEditorPhotos.ts
@@ -11,11 +11,15 @@ import {
   ExifMetadata,
 } from '@/lib/utils/exifExtractor';
 
-import { normalizeLayout } from '../_utils/recordLayoutHelper';
+import {
+  isRecordBlockEmpty,
+  normalizeLayout,
+} from '../_utils/recordLayoutHelper';
 import { MULTI_INSTANCE_LIMITS } from '@/lib/constants/record';
 import * as Sentry from '@sentry/nextjs';
 import { logger } from '@/lib/utils/logger';
 import { PatchApplyPayload } from '@/lib/types/recordCollaboration';
+import { UploadMultipleResult } from '@/hooks/useMediaUpload';
 
 interface ImageWithMetadata {
   imageUrl: string;
@@ -46,9 +50,10 @@ interface RecordEditorPhotos {
   >;
   handleDone: (val: BlockValue, shouldClose?: boolean) => void;
   draftId?: string;
-  uploadMultipleMedia?: (files: File[]) => Promise<string[]>;
+  uploadMultipleMedia?: (files: File[]) => Promise<UploadMultipleResult>;
   applyPatch?: (patch: PatchApplyPayload | PatchApplyPayload[]) => void;
   releaseLock?: (lockKey: string) => void;
+  removeBlock?: (id: string) => void;
 }
 const PHOTO_LIMIT = MULTI_INSTANCE_LIMITS['photos'] || 5;
 export function useRecordEditorPhotos({
@@ -61,6 +66,7 @@ export function useRecordEditorPhotos({
   uploadMultipleMedia,
   applyPatch,
   releaseLock,
+  removeBlock,
 }: RecordEditorPhotos) {
   // draft 모드에서 생성한 blob URL 목록 — 언마운트 시 revoke
   const blobUrlsRef = useRef<string[]>([]);
@@ -85,6 +91,15 @@ export function useRecordEditorPhotos({
       };
     };
   } | null>(null);
+
+  // 사진 업로드 ~ EXIF 추출 ~ 블록/메타데이터 반영까지 전체 처리 중 여부.
+  // 이 동안 PhotoDrawer를 닫지 못하게 막아야 activeDrawer가 바뀌어
+  // 업로드 결과가 다른 블록에 잘못 반영되거나 유실되는 문제를 방지할 수 있다.
+  const [isProcessingPhotos, setIsProcessingPhotos] = useState(false);
+
+  // 서버 업로드가 끝나기 전, 본인 화면에 먼저 보여줄 미리보기 URL (blob/data URL).
+  // 블록에 반영(3단계) 또는 처리 종료 시 비워진다.
+  const [pendingPreviewUrls, setPendingPreviewUrls] = useState<string[]>([]);
 
   /**
    * 사진 업로드
@@ -127,160 +142,213 @@ export function useRecordEditorPhotos({
     let uploadedIds: string[] = [];
     let newImages: string[] = [];
 
-    // 1단계: 이미지 업로드 + 미리보기 URL 생성 (핵심 단계 — 실패 시 toast)
-    // draft 모드: blob URL 사용 (HEIC 등 WebView에서 data URL 렌더링 불가 문제 방지)
-    // 일반 모드: data URL 사용 (저장 시 pendingFilesRef로 File 매칭 필요)
-    let dataUrls: string[] = []; // EXIF 추출용 data URL (draft 포함)
+    setIsProcessingPhotos(true);
     try {
-      if (isDraft) {
-        // Android content:// URI 소진 문제 방지:
-        // getImageDimensions·XHR·exifr 등 여러 작업이 동일 File을 읽으면
-        // 이후 <img>가 blob URL에서 읽으려 할 때 content URI가 이미 닫혀 이미지가 깨짐.
-        // arrayBuffer()로 한 번에 메모리로 읽어 in-memory 복사본을 만든 뒤
-        // 모든 후속 작업(표시·업로드·EXIF)에 복사본을 사용.
-        const buffers = await Promise.all(
-          filesToRead.map((f) => f.arrayBuffer()),
-        );
-        filesToRead = filesToRead.map(
-          (file, i) =>
-            new File([buffers[i]], file.name, {
-              type: file.type || 'image/jpeg',
-            }),
-        );
-        newImages = buffers.map((buffer, i) => {
-          const blob = new Blob([buffer], {
-            type: filesToRead[i].type || 'image/jpeg',
-          });
-          const url = URL.createObjectURL(blob);
-          blobUrlsRef.current.push(url);
-          return url;
-        });
-        dataUrls = newImages;
-      }
-
-      if (isDraft && uploadMultipleMedia) {
-        uploadedIds = await uploadMultipleMedia(filesToRead);
-      }
-
-      if (!isDraft) {
-        newImages = await Promise.all(
-          filesToRead.map(
-            (file) =>
-              new Promise<string>((res, rej) => {
-                const reader = new FileReader();
-                reader.onload = (ev) => {
-                  const url = ev.target?.result as string;
-                  pendingFilesRef.current.set(url, file);
-                  res(url);
-                };
-                reader.onerror = rej;
-                reader.readAsDataURL(file);
+      // 1단계: 이미지 업로드 + 미리보기 URL 생성 (핵심 단계 — 실패 시 toast)
+      // draft 모드: blob URL 사용 (HEIC 등 WebView에서 data URL 렌더링 불가 문제 방지)
+      // 일반 모드: data URL 사용 (저장 시 pendingFilesRef로 File 매칭 필요)
+      let dataUrls: string[] = []; // EXIF 추출용 data URL (draft 포함)
+      try {
+        if (isDraft) {
+          // Android content:// URI 소진 문제 방지:
+          // getImageDimensions·XHR·exifr 등 여러 작업이 동일 File을 읽으면
+          // 이후 <img>가 blob URL에서 읽으려 할 때 content URI가 이미 닫혀 이미지가 깨짐.
+          // arrayBuffer()로 한 번에 메모리로 읽어 in-memory 복사본을 만든 뒤
+          // 모든 후속 작업(표시·업로드·EXIF)에 복사본을 사용.
+          const buffers = await Promise.all(
+            filesToRead.map((f) => f.arrayBuffer()),
+          );
+          filesToRead = filesToRead.map(
+            (file, i) =>
+              new File([buffers[i]], file.name, {
+                type: file.type || 'image/jpeg',
               }),
-          ),
-        );
-        dataUrls = newImages;
-      }
-    } catch (err) {
-      Sentry.captureException(err, {
-        level: 'error',
-        tags: { context: 'post-editor', operation: 'image-upload' },
-        extra: { isDraft },
-      });
-      logger.error('이미지 업로드에 실패', err);
-      toast.error('이미지 업로드에 실패했습니다.');
-      e.target.value = '';
-      return;
-    }
-
-    // 2단계: EXIF 메타데이터 추출 (실패해도 이미지 추가는 계속 진행)
-    let allImagesWithMetadata: {
-      imageUrl: string;
-      metadata: ExifMetadata;
-    }[] = [];
-    try {
-      const existingImagesWithMetadata = await Promise.all(
-        (currentPhotoValue.tempUrls || []).map(async (url) => ({
-          imageUrl: url,
-          metadata: await extractExifFromDataUrl(url),
-        })),
-      );
-
-      const newImagesWithMetadata = (
-        await Promise.all(
-          isDraft
-            ? // draft 모드: File 객체로 직접 EXIF 추출 (blob URL은 exifr 파싱 불가)
-              filesToRead.map(async (file, i) => ({
-                imageUrl: newImages[i],
-                metadata: await extractExifMetadata(file),
-              }))
-            : // 일반 모드: data URL로 EXIF 추출
-              dataUrls.map(async (url, i) => ({
-                imageUrl: newImages[i],
-                metadata: await extractExifFromDataUrl(url),
-              })),
-        )
-      ).filter((img) => img.metadata.hasMetadata);
-
-      allImagesWithMetadata = [
-        ...existingImagesWithMetadata.filter((img) => img.metadata.hasMetadata),
-        ...newImagesWithMetadata,
-      ];
-    } catch {
-      // EXIF 추출 실패는 무시 — 이미지 추가는 정상 진행
-    }
-
-    // 3단계: 메타데이터 있으면 drawer, 없으면 바로 추가
-    if (allImagesWithMetadata.length > 0) {
-      setPendingMetadata((prev) => ({
-        images: allImagesWithMetadata,
-        newImageUrls: newImages,
-        uploadedIds: uploadedIds.length > 0 ? uploadedIds : undefined,
-        appliedMetadata: prev?.appliedMetadata || {},
-      }));
-    } else {
-      if (draftId) {
-        // draft 모드: handleApplyMetadata와 동일하게 setBlocks + applyPatch + 드로어 직접 닫기
-        // handleDone → handleCloseDrawer 경로는 다른 collaborator의 patch와 버전 충돌 가능성 있음
-        const photosBlockId = activeDrawer?.id;
-        const nextValue: PhotoValue = {
-          mediaIds: [...(existingPhotos?.value.mediaIds || []), ...uploadedIds],
-          // tempUrls: 로컬 미리보기용 fallback — WebSocket 전송 시에는 제거됨 (useRecordCollaboration.applyPatch)
-          tempUrls: [...(existingPhotos?.value.tempUrls || []), ...newImages],
-        };
-
-        setBlocks((prev) =>
-          prev.map((b) =>
-            b.id === photosBlockId && b.type === 'photos'
-              ? ({ ...b, value: nextValue } as RecordBlock)
-              : b,
-          ),
-        );
-
-        if (photosBlockId && applyPatch) {
-          applyPatch({
-            type: 'BLOCK_SET_VALUE',
-            blockId: photosBlockId,
-            value: nextValue,
+          );
+          newImages = buffers.map((buffer, i) => {
+            const blob = new Blob([buffer], {
+              type: filesToRead[i].type || 'image/jpeg',
+            });
+            const url = URL.createObjectURL(blob);
+            blobUrlsRef.current.push(url);
+            return url;
           });
+          dataUrls = newImages;
+          // 업로드 완료 전 자기 자신에게 먼저 미리보기 표시
+          setPendingPreviewUrls(newImages);
         }
 
-        if (photosBlockId && releaseLock) {
-          releaseLock(`block:${photosBlockId}`);
+        if (isDraft && uploadMultipleMedia) {
+          const uploadResult = await uploadMultipleMedia(filesToRead);
+          uploadedIds = uploadResult.successIds;
+
+          if (uploadResult.failedIndices.length > 0) {
+            const failedSet = new Set(uploadResult.failedIndices);
+
+            // 업로드 실패한 이미지는 blob URL을 해제하고
+            // 결과/미리보기/EXIF 추출 대상에서 제외한다.
+            newImages.forEach((url, i) => {
+              if (failedSet.has(i)) {
+                URL.revokeObjectURL(url);
+                blobUrlsRef.current = blobUrlsRef.current.filter(
+                  (u) => u !== url,
+                );
+              }
+            });
+            filesToRead = filesToRead.filter((_, i) => !failedSet.has(i));
+            newImages = newImages.filter((_, i) => !failedSet.has(i));
+            dataUrls = dataUrls.filter((_, i) => !failedSet.has(i));
+            setPendingPreviewUrls(newImages);
+
+            toast.warning(
+              `${uploadResult.failedIndices.length}장의 이미지 업로드에 실패해 제외되었습니다.`,
+            );
+          }
         }
 
-        // handleApplyMetadata와 동일하게 드로어를 직접 닫아 handleCloseDrawer 경유를 막음
-        // handleCloseDrawer가 닫힐 때 PATCH_APPLY를 재전송하면 버전 충돌로 PATCH_REJECTED_STALE 발생
-        setActiveDrawer(null);
-      } else {
-        const updatedPhotoValue: PhotoValue = {
-          ...currentPhotoValue,
-          tempUrls: [...(currentPhotoValue.tempUrls || []), ...newImages],
-        };
-        handleDone(updatedPhotoValue, false);
+        if (!isDraft) {
+          newImages = await Promise.all(
+            filesToRead.map(
+              (file) =>
+                new Promise<string>((res, rej) => {
+                  const reader = new FileReader();
+                  reader.onload = (ev) => {
+                    const url = ev.target?.result as string;
+                    pendingFilesRef.current.set(url, file);
+                    res(url);
+                  };
+                  reader.onerror = rej;
+                  reader.readAsDataURL(file);
+                }),
+            ),
+          );
+          dataUrls = newImages;
+          setPendingPreviewUrls(newImages);
+        }
+      } catch (err) {
+        // 업로드 실패로 사용되지 않게 된 blob URL 정리 (draft 모드)
+        newImages.forEach((url) => {
+          if (url.startsWith('blob:')) URL.revokeObjectURL(url);
+        });
+        blobUrlsRef.current = blobUrlsRef.current.filter(
+          (u) => !newImages.includes(u),
+        );
+
+        Sentry.captureException(err, {
+          level: 'error',
+          tags: { context: 'post-editor', operation: 'image-upload' },
+          extra: { isDraft },
+        });
+        logger.error('이미지 업로드에 실패', err);
+        toast.error('이미지 업로드에 실패했습니다.');
+
+        // 새로 생성된 빈 사진 블록이라면(기존 이미지 없음) 블록 자체를 제거
+        const photosBlockId = activeDrawer?.id;
+        if (
+          photosBlockId &&
+          removeBlock &&
+          isRecordBlockEmpty(currentPhotoValue)
+        ) {
+          removeBlock(photosBlockId);
+          setActiveDrawer(null);
+        }
+
+        e.target.value = '';
+        return;
       }
-    }
 
-    e.target.value = '';
+      // 2단계: EXIF 메타데이터 추출 (실패해도 이미지 추가는 계속 진행)
+      let allImagesWithMetadata: {
+        imageUrl: string;
+        metadata: ExifMetadata;
+      }[] = [];
+      try {
+        const existingImagesWithMetadata = await Promise.all(
+          (currentPhotoValue.tempUrls || []).map(async (url) => ({
+            imageUrl: url,
+            metadata: await extractExifFromDataUrl(url),
+          })),
+        );
+
+        const newImagesWithMetadata = (
+          await Promise.all(
+            isDraft
+              ? // draft 모드: File 객체로 직접 EXIF 추출 (blob URL은 exifr 파싱 불가)
+                filesToRead.map(async (file, i) => ({
+                  imageUrl: newImages[i],
+                  metadata: await extractExifMetadata(file),
+                }))
+              : // 일반 모드: data URL로 EXIF 추출
+                dataUrls.map(async (url, i) => ({
+                  imageUrl: newImages[i],
+                  metadata: await extractExifFromDataUrl(url),
+                })),
+          )
+        ).filter((img) => img.metadata.hasMetadata);
+
+        allImagesWithMetadata = [
+          ...existingImagesWithMetadata.filter((img) => img.metadata.hasMetadata),
+          ...newImagesWithMetadata,
+        ];
+      } catch {
+        // EXIF 추출 실패는 무시 — 이미지 추가는 정상 진행
+      }
+
+      // 3단계: 메타데이터 있으면 drawer, 없으면 바로 추가
+      if (allImagesWithMetadata.length > 0) {
+        setPendingMetadata((prev) => ({
+          images: allImagesWithMetadata,
+          newImageUrls: newImages,
+          uploadedIds: uploadedIds.length > 0 ? uploadedIds : undefined,
+          appliedMetadata: prev?.appliedMetadata || {},
+        }));
+      } else {
+        if (draftId) {
+          // draft 모드: handleApplyMetadata와 동일하게 setBlocks + applyPatch + 드로어 직접 닫기
+          // handleDone → handleCloseDrawer 경로는 다른 collaborator의 patch와 버전 충돌 가능성 있음
+          const photosBlockId = activeDrawer?.id;
+          const nextValue: PhotoValue = {
+            mediaIds: [...(existingPhotos?.value.mediaIds || []), ...uploadedIds],
+            // tempUrls: 로컬 미리보기용 fallback — WebSocket 전송 시에는 제거됨 (useRecordCollaboration.applyPatch)
+            tempUrls: [...(existingPhotos?.value.tempUrls || []), ...newImages],
+          };
+
+          setBlocks((prev) =>
+            prev.map((b) =>
+              b.id === photosBlockId && b.type === 'photos'
+                ? ({ ...b, value: nextValue } as RecordBlock)
+                : b,
+            ),
+          );
+
+          if (photosBlockId && applyPatch) {
+            applyPatch({
+              type: 'BLOCK_SET_VALUE',
+              blockId: photosBlockId,
+              value: nextValue,
+            });
+          }
+
+          if (photosBlockId && releaseLock) {
+            releaseLock(`block:${photosBlockId}`);
+          }
+
+          // handleApplyMetadata와 동일하게 드로어를 직접 닫아 handleCloseDrawer 경유를 막음
+          // handleCloseDrawer가 닫힐 때 PATCH_APPLY를 재전송하면 버전 충돌로 PATCH_REJECTED_STALE 발생
+          setActiveDrawer(null);
+        } else {
+          const updatedPhotoValue: PhotoValue = {
+            ...currentPhotoValue,
+            tempUrls: [...(currentPhotoValue.tempUrls || []), ...newImages],
+          };
+          handleDone(updatedPhotoValue, false);
+        }
+      }
+
+      e.target.value = '';
+    } finally {
+      setIsProcessingPhotos(false);
+      setPendingPreviewUrls([]);
+    }
   };
 
   /**
@@ -637,6 +705,8 @@ export function useRecordEditorPhotos({
   return {
     pendingMetadata,
     pendingFilesRef,
+    isProcessingPhotos,
+    pendingPreviewUrls,
     handlePhotoUpload,
     handleApplyMetadata,
     handleSkipMetadata,

--- a/frontend/src/app/(post)/_utils/convertMonthRecords.ts
+++ b/frontend/src/app/(post)/_utils/convertMonthRecords.ts
@@ -1,4 +1,3 @@
-import { randomBaseImage } from '@/lib/image';
 import { DailyRecordList, MonthlyRecordList } from '@/lib/types/recordResponse';
 
 const dayNames = ['일', '월', '화', '수', '목', '금', '토'] as const;
@@ -32,6 +31,6 @@ export const convertDayRecords = (dailyRecords: DailyRecordList[]) =>
       dayName: dayNames[dayIndex],
       title: record.latestPostTitle,
       count: record.postCount,
-      coverUrl: record.coverAssetId || randomBaseImage(record.date),
+      coverUrl: record.coverAssetId || null,
     };
   });

--- a/frontend/src/app/(post)/group/[groupId]/edit/profile/_components/GroupProfileEditClient.tsx
+++ b/frontend/src/app/(post)/group/[groupId]/edit/profile/_components/GroupProfileEditClient.tsx
@@ -40,7 +40,7 @@ export default function GroupProfileEditClient({
       let finalMediaId = groupData.me?.profileImage?.assetId ?? undefined;
 
       if (data.image) {
-        finalMediaId = (await uploadMultipleMedia([data.image]))[0];
+        finalMediaId = (await uploadMultipleMedia([data.image])).successIds[0];
       }
 
       await updateProfile({

--- a/frontend/src/app/(post)/group/_components/AddRecordDrawer.tsx
+++ b/frontend/src/app/(post)/group/_components/AddRecordDrawer.tsx
@@ -45,8 +45,8 @@ export function AddRecordDrawer({
     }
 
     if (refetchedData?.redirectUrl) {
-      router.push(refetchedData.redirectUrl);
       onOpenChange(false);
+      router.replace(refetchedData.redirectUrl);
     } else {
       // 리다이렉트 URL 누락은 백엔드 응답 문제일 가능성
       const error = new Error(
@@ -70,8 +70,8 @@ export function AddRecordDrawer({
   };
 
   const handleIndividualRecord = () => {
-    router.push(`/add?groupId=${groupId}`);
     onOpenChange(false);
+    router.replace(`/add?groupId=${groupId}`);
   };
 
   return (

--- a/frontend/src/app/(post)/group/_components/GroupHeader.tsx
+++ b/frontend/src/app/(post)/group/_components/GroupHeader.tsx
@@ -2,6 +2,7 @@ import GroupHeaderActions from './GroupHeaderActions';
 import { getCachedGroupCurrentMembers } from '@/lib/api/group';
 import { GroupMembersResponse } from '@/lib/types/groupResponse';
 import { createMockGroupMembers } from '@/lib/mocks/mock';
+import RetryFallback from '@/components/RetryFallback';
 
 export default async function GroupHeader({
   className,
@@ -10,17 +11,25 @@ export default async function GroupHeader({
   className?: string;
   groupId: string;
 }) {
-  let groupInfo: GroupMembersResponse;
+  let groupInfo: GroupMembersResponse | null = null;
 
   if (process.env.NEXT_PUBLIC_MOCK === 'true') {
     groupInfo = createMockGroupMembers();
   } else {
-    groupInfo = await getCachedGroupCurrentMembers(groupId);
+    try {
+      groupInfo = await getCachedGroupCurrentMembers(groupId);
+    } catch {
+      // 멤버 정보 로드 실패 시 헤더 영역만 축소 렌더링
+    }
   }
 
   return (
     <header className="sticky top-0 pt-3 z-50 -mx-4 sm:-mx-6 px-4 sm:px-6 pb-2 transition-all duration-300 dark:bg-[#121212] bg-white">
-      <GroupHeaderActions groupInfo={groupInfo} className={className} />
+      {groupInfo ? (
+        <GroupHeaderActions groupInfo={groupInfo} className={className} />
+      ) : (
+        <RetryFallback fallback="/shared" className="mb-3" />
+      )}
     </header>
   );
 }

--- a/frontend/src/app/(post)/record/_components/RecordDetailHeaderActions.tsx
+++ b/frontend/src/app/(post)/record/_components/RecordDetailHeaderActions.tsx
@@ -83,7 +83,6 @@ export default function RecordDetailHeaderActions({
     textBlock && 'text' in textBlock.value ? textBlock.value.text : '';
   const image = record.blocks.find((block) => block.type === 'IMAGE')
     ?.value as ImageValue;
-  // 마운트 시점에 window 주소 가져오기
   useEffect(() => {
     requestAnimationFrame(() => {
       setCurrentUrl(`${window.location.origin}/record/${record.id}`);

--- a/frontend/src/app/api/media-image/[id]/route.ts
+++ b/frontend/src/app/api/media-image/[id]/route.ts
@@ -53,8 +53,9 @@ export async function GET(
 
   const originalBuffer = Buffer.from(await imageRes.arrayBuffer());
 
-  // WebP로 변환
+  // WebP로 변환 (.rotate()로 EXIF 회전 적용 후 스트립)
   const webpBuffer = await sharp(originalBuffer)
+    .rotate()
     .webp({ quality: 85 })
     .toBuffer();
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,7 +4,6 @@ import './globals.css';
 import MswLoader from '@/components/MswLoader';
 import Providers from './providers';
 import BottomNavigation from '@/components/BottomNavigation';
-import Script from 'next/script';
 import ConditionalHeader from '@/components/ConditionalHeader';
 import { ThemeProvider } from 'next-themes';
 import ThemeColorSetter from '@/components/ThemeColorSetter';
@@ -28,6 +27,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   minimumScale: 1,
   viewportFit: 'cover',
+  interactiveWidget: 'resizes-visual',
 };
 
 export const metadata: Metadata = {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -15,6 +15,7 @@ import StatusBarCover from '@/components/StatusBarCover';
 import NativeStatusBarSync from '@/components/NativeStatusBarSync';
 import NetworkGuard from '@/components/NetworkGuard';
 import AndroidBackHandler from '@/components/AndroidBackHandler';
+import ServiceGuard from '@/components/ServiceGuard';
 import { GoogleAnalytics } from '@next/third-parties/google';
 
 const notoSans = Noto_Sans_KR({
@@ -259,6 +260,7 @@ export default function RootLayout({
               <ThemeColorSetter />
               <NativeStatusBarSync />
               <NetworkGuard />
+              <ServiceGuard />
               <AndroidBackHandler />
               <div
                 data-app-root

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -29,7 +29,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
           },
         }),
         mutationCache: new MutationCache({
-          onError: (error, variables, context, mutation) => {
+          onError: (error, _variables, _context, mutation) => {
             if (mutation.meta?.silent) return;
             if ((error as ApiError)?.code === 'TIMEOUT') {
               toast.error('요청 시간이 초과되었습니다.', {

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -21,6 +21,13 @@ export default function Providers({ children }: { children: React.ReactNode }) {
             if ((error as ApiError)?.code === 'TIMEOUT') {
               toast.error('요청 시간이 초과되었습니다.', {
                 description: '네트워크 연결을 확인하고 다시 시도해 주세요.',
+                duration: 8000,
+                action: {
+                  label: '다시 시도',
+                  onClick: () => {
+                    (query as unknown as { fetch: () => void }).fetch();
+                  },
+                },
               });
               return;
             }
@@ -29,11 +36,22 @@ export default function Providers({ children }: { children: React.ReactNode }) {
           },
         }),
         mutationCache: new MutationCache({
-          onError: (error, _variables, _context, mutation) => {
+          onError: (error, variables, _context, mutation) => {
             if (mutation.meta?.silent) return;
             if ((error as ApiError)?.code === 'TIMEOUT') {
               toast.error('요청 시간이 초과되었습니다.', {
                 description: '네트워크 연결을 확인하고 다시 시도해 주세요.',
+                duration: 8000,
+                action: {
+                  label: '다시 시도',
+                  onClick: () => {
+                    (
+                      mutation as unknown as {
+                        execute: (v: unknown) => void;
+                      }
+                    ).execute(variables);
+                  },
+                },
               });
               return;
             }

--- a/frontend/src/components/AndroidBackHandler.tsx
+++ b/frontend/src/components/AndroidBackHandler.tsx
@@ -25,9 +25,25 @@ export function pushBackHandler(handler: BackHandler): () => void {
 
 export default function AndroidBackHandler() {
   useEffect(() => {
-    const platform = (
-      window as unknown as { Capacitor?: { getPlatform?: () => string } }
-    ).Capacitor?.getPlatform?.();
+    const w = window as unknown as {
+      Capacitor?: {
+        getPlatform?: () => string;
+        isNativePlatform?: () => boolean;
+      };
+    };
+    const platform = w.Capacitor?.getPlatform?.();
+
+    // Web/PWA: 브라우저 뒤로가기(popstate)로 drawer 닫기
+    if (!w.Capacitor?.isNativePlatform?.()) {
+      const handlePopState = () => {
+        if (backHandlerStack.length > 0) {
+          backHandlerStack[backHandlerStack.length - 1]();
+        }
+      };
+      window.addEventListener('popstate', handlePopState);
+      return () => window.removeEventListener('popstate', handlePopState);
+    }
+
     if (platform !== 'android') return;
 
     let backPressedOnce = false;

--- a/frontend/src/components/Back.tsx
+++ b/frontend/src/components/Back.tsx
@@ -15,12 +15,46 @@ export default function Back({ size, className, onClick, fallback }: BackProps) 
   const router = useRouter();
 
   const handleBack = () => {
-    if (typeof window !== 'undefined' && window.history.length <= 1 && fallback) {
-      router.replace(fallback);
-    } else {
-      router.back();
+    const navigate = () => {
+      if (
+        typeof window !== 'undefined' &&
+        window.history.length <= 1 &&
+        fallback
+      ) {
+        router.replace(fallback);
+      } else {
+        router.back();
+      }
+      onClick?.();
+    };
+
+    if (typeof window === 'undefined') {
+      navigate();
+      return;
     }
-    onClick?.();
+
+    // Drawer를 열고 닫으면 현재 페이지와 동일한 URL의 placeholder history entry가
+    // 남는다(components/ui/drawer.tsx). 이를 먼저 소비하지 않으면 첫 클릭이
+    // 이 entry만 제거하고 화면은 그대로여서 "한 번 더 눌러야 뒤로 가는" 것처럼 보인다.
+    const consumeDrawerPlaceholders = () => {
+      const state = window.history.state as
+        | { __drawerId?: string; __drawerClosed?: boolean }
+        | null;
+
+      if (state?.__drawerId || state?.__drawerClosed) {
+        const handlePop = () => {
+          window.removeEventListener('popstate', handlePop);
+          consumeDrawerPlaceholders();
+        };
+        window.addEventListener('popstate', handlePop);
+        window.history.go(-1);
+        return;
+      }
+
+      navigate();
+    };
+
+    consumeDrawerPlaceholders();
   };
 
   return (

--- a/frontend/src/components/ProfileInfo.tsx
+++ b/frontend/src/components/ProfileInfo.tsx
@@ -83,6 +83,7 @@ export default function ProfileInfo({
                   src={imagePreviewUrl}
                   alt={`${nickname} 프로필`}
                   className="w-full h-full object-cover"
+                  style={{ imageOrientation: 'from-image' }}
                 />
               ) : (
                 <AssetImage

--- a/frontend/src/components/RetryFallback.tsx
+++ b/frontend/src/components/RetryFallback.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Back from '@/components/Back';
+import { RefreshCw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+interface RetryFallbackProps {
+  /** Back 버튼의 fallback 경로. 미전달 시 Back 버튼 미노출. */
+  fallback?: string;
+  className?: string;
+}
+
+export default function RetryFallback({
+  fallback,
+  className,
+}: RetryFallbackProps) {
+  const router = useRouter();
+
+  return (
+    <div className={`flex items-center gap-2 ${className ?? ''}`}>
+      {fallback !== undefined && <Back fallback={fallback} />}
+      <button
+        onClick={() => router.refresh()}
+        className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-semibold text-gray-400 dark:text-gray-500 bg-gray-50 dark:bg-white/5 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors"
+      >
+        <RefreshCw className="w-3.5 h-3.5" />
+        재시도
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/ServiceGuard.tsx
+++ b/frontend/src/components/ServiceGuard.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { ServerCrash } from 'lucide-react';
+
+/**
+ * 서버 장애 시 전체 화면 오버레이를 띄우는 컴포넌트.
+ *
+ * 활성화 방법: Vercel 대시보드 → Environment Variables에서
+ * NEXT_PUBLIC_MAINTENANCE_MODE=true 추가 후 재배포(~1분).
+ * 서버 연결 없이 클라이언트 빌드 타임에 결정되므로 서버 다운 시에도 동작.
+ */
+export default function ServiceGuard() {
+  if (process.env.NEXT_PUBLIC_MAINTENANCE_MODE !== 'true') return null;
+
+  return (
+    <div className="fixed inset-0 z-[99999] flex flex-col items-center justify-center bg-white dark:bg-[#121212] px-8">
+      <div className="flex flex-col items-center gap-4 text-center">
+        <div className="w-16 h-16 rounded-full bg-gray-100 dark:bg-white/10 flex items-center justify-center">
+          <ServerCrash className="w-8 h-8 text-gray-400 dark:text-gray-500" />
+        </div>
+        <div className="space-y-1.5">
+          <p className="text-base font-bold text-gray-900 dark:text-white">
+            서비스 점검 중입니다
+          </p>
+          <p className="text-sm text-gray-400 leading-relaxed">
+            더 나은 서비스를 위해 점검 중입니다.
+            <br />
+            불편을 드려 죄송합니다.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SocialShareDrawer.tsx
+++ b/frontend/src/components/SocialShareDrawer.tsx
@@ -187,26 +187,24 @@ export default function SocialShareDrawer({
           {/* 소셜 버튼 목록 */}
           <div className="overflow-x-auto scrollbar-hide pb-4 scroll-smooth touch-pan-x overscroll-x-contain">
             <ul className="flex justify-start gap-4 sm:gap-6 min-w-max">
-              {!isNative && (
-                <li className="flex flex-col items-center shrink-0">
-                  <button
-                    onClick={handleKakaoShare}
-                    className="flex flex-col items-center"
-                    aria-label="카카오톡으로 공유하기"
-                  >
-                    <div className="w-10 h-10 sm:w-15 sm:h-15 relative">
-                      <Image
-                        src="/kakao_logo.png"
-                        alt="카카오톡 로고"
-                        width={60}
-                        height={60}
-                        className="w-full h-full object-cover rounded-full"
-                      />
-                    </div>
-                    <SocialName name="Kakao" />
-                  </button>
-                </li>
-              )}
+              <li className="flex flex-col items-center shrink-0">
+                <button
+                  onClick={handleKakaoShare}
+                  className="flex flex-col items-center"
+                  aria-label="카카오톡으로 공유하기"
+                >
+                  <div className="w-10 h-10 sm:w-15 sm:h-15 relative">
+                    <Image
+                      src="/kakao_logo.png"
+                      alt="카카오톡 로고"
+                      width={60}
+                      height={60}
+                      className="w-full h-full object-cover rounded-full"
+                    />
+                  </div>
+                  <SocialName name="Kakao" />
+                </button>
+              </li>
               <li className="flex flex-col items-center shrink-0">
                 <FacebookShareButton
                   url={path}

--- a/frontend/src/components/StatusBarCover.tsx
+++ b/frontend/src/components/StatusBarCover.tsx
@@ -20,7 +20,7 @@ export default function StatusBarCover() {
       )}
       style={{
         height: 'env(safe-area-inset-top)',
-        zIndex: 49,
+        zIndex: 51,
       }}
     />
   );

--- a/frontend/src/components/ui/PostCard.tsx
+++ b/frontend/src/components/ui/PostCard.tsx
@@ -80,7 +80,14 @@ export function PostCard({
               priorityLoad={priorityLoad}
             />
           ) : (
-            <div className={cn('flex items-center justify-center', className)}>
+            <div
+              className="absolute inset-0 bg-gray-100 dark:bg-[#252525] flex items-center justify-center"
+              style={{
+                backgroundImage:
+                  'radial-gradient(circle, rgba(0,0,0,0.07) 1px, transparent 1px)',
+                backgroundSize: '18px 18px',
+              }}
+            >
               <ImageIcon className="w-6 h-6 text-gray-400" />
             </div>
           )}

--- a/frontend/src/components/ui/RecordCard.tsx
+++ b/frontend/src/components/ui/RecordCard.tsx
@@ -4,7 +4,6 @@ import { Clock, MapPin } from 'lucide-react';
 import { PostCard } from './PostCard';
 import { useRouter } from 'next/navigation';
 import { GroupCover } from '@/lib/types/group';
-import { randomBaseImage } from '@/lib/image';
 import { memo } from 'react';
 
 /**
@@ -40,11 +39,10 @@ export const RecordCard = memo(function RecordCard({
   height,
   priorityLoad,
 }: RecordCardProps) {
-  const baseImage = randomBaseImage(id);
   return (
     <PostCard
       height={height}
-      imageUrl={cover?.assetId || baseImage}
+      imageUrl={cover?.assetId || null}
       imageAlt={name}
       onClick={onClick}
       priorityLoad={priorityLoad}

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -139,7 +139,11 @@ function DrawerContent({
         // setTimeout(300ms) 대신 RAF를 써야 육안으로 보이는 깜빡임이 없음.
         rafId = requestAnimationFrame(() => {
           const elNow = contentRef.current;
-          if (elNow) elNow.style.height = '';
+          if (!elNow) return;
+          elNow.style.height = '';
+          // vaul이 handler를 skip한 경우(포커스가 input이 아닐 때)
+          // style.bottom이 keyboard 높이로 남아 drawer가 화면 밖으로 튀어나가므로 초기화.
+          elNow.style.bottom = '';
         });
       }
     };

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -75,11 +75,35 @@ function DrawerContent({
   children,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+  const [keyboardHeight, setKeyboardHeight] = React.useState(0);
+
+  React.useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const handler = () => {
+      const kh = window.innerHeight - vv.height - vv.offsetTop;
+      setKeyboardHeight(Math.max(0, kh));
+    };
+
+    vv.addEventListener('resize', handler);
+    vv.addEventListener('scroll', handler);
+    return () => {
+      vv.removeEventListener('resize', handler);
+      vv.removeEventListener('scroll', handler);
+    };
+  }, []);
+
   return (
     <DrawerPortal data-slot="drawer-portal">
       <DrawerOverlay />
       <DrawerPrimitive.Content
         data-slot="drawer-content"
+        style={
+          keyboardHeight > 0
+            ? { maxHeight: `calc(100dvh - ${keyboardHeight}px - 24px)` }
+            : undefined
+        }
         className={cn(
           'dark:bg-[#1E1E1E] bg-white max-w-4xl mx-auto',
           'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -17,13 +17,45 @@ function Drawer({
   });
 
   React.useEffect(() => {
-    if (open === undefined || !open) return;
+    if (open !== true) return;
 
     // drawer 열릴 때 Android 백버튼 핸들러 등록 → 닫힐 때 자동 해제
     const remove = pushBackHandler(() => {
       onOpenChangeRef.current?.(false);
     });
     return remove;
+  }, [open]);
+
+  // Web/PWA: drawer 열릴 때 history entry push → 뒤로가기로 닫기 지원
+  React.useEffect(() => {
+    const isNative = (
+      window as unknown as { Capacitor?: { isNativePlatform?: () => boolean } }
+    ).Capacitor?.isNativePlatform?.();
+    if (isNative || open !== true) return;
+
+    const drawerId = Math.random().toString(36).slice(2);
+
+    // 직전 닫기에서 남긴 placeholder entry가 있으면 재사용해 pushState 누적 방지
+    if (
+      (history.state as { __drawerClosed?: boolean } | null)?.__drawerClosed
+    ) {
+      history.replaceState({ __drawerId: drawerId }, '');
+    } else {
+      history.pushState({ __drawerId: drawerId }, '');
+    }
+
+    return () => {
+      // 뒤로가기로 닫힌 경우: popstate가 이미 history를 소비했으므로 skip
+      // 일반 닫기(X 버튼, backdrop 등): history.go(-1) 대신 replaceState 사용
+      // → 동기 실행이므로 빠른 재오픈 시 async go(-1)가 새 entry를 소비하는
+      //   경쟁 조건(2·4번째 열기 버그)을 방지
+      if (
+        (history.state as { __drawerId?: string } | null)?.__drawerId ===
+        drawerId
+      ) {
+        history.replaceState({ __drawerClosed: true }, '');
+      }
+    };
   }, [open]);
 
   return (
@@ -75,22 +107,53 @@ function DrawerContent({
   children,
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Content>) {
-  const [keyboardHeight, setKeyboardHeight] = React.useState(0);
+  const contentRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     const vv = window.visualViewport;
     if (!vv) return;
 
-    const handler = () => {
-      const kh = window.innerHeight - vv.height - vv.offsetTop;
-      setKeyboardHeight(Math.max(0, kh));
+    // interactiveWidget 미지원 환경에서는 window.innerHeight도 키보드와 함께 줄어들어
+    // kh = innerHeight - vv.height ≈ 0 이 되므로, 직접 관측한 최대값을 기준으로 삼음.
+    let baseHeight = vv.height;
+    let rafId = 0;
+
+    const onResize = () => {
+      // effect 시작 시 캡처하면 drawer가 닫힌 상태일 때 null을 고정해버리므로
+      // 매 이벤트마다 ref를 직접 조회해 drawer가 열린 뒤에도 동작하게 함.
+      const el = contentRef.current;
+      if (!el) return;
+
+      cancelAnimationFrame(rafId);
+      if (vv.height > baseHeight) baseHeight = vv.height;
+
+      const kh = baseHeight - vv.height;
+
+      if (kh > 60) {
+        const next = `${Math.round(vv.height) - 24}px`;
+        if (el.style.maxHeight !== next) el.style.maxHeight = next;
+      } else if (el.style.maxHeight !== '') {
+        el.style.maxHeight = '';
+        // vaul도 같은 vv.resize에서 동기적으로 style.height를 잘못 설정하므로
+        // RAF로 vaul의 핸들러가 끝난 뒤(한 프레임, ~16ms) height를 초기화함.
+        // setTimeout(300ms) 대신 RAF를 써야 육안으로 보이는 깜빡임이 없음.
+        rafId = requestAnimationFrame(() => {
+          const elNow = contentRef.current;
+          if (elNow) elNow.style.height = '';
+        });
+      }
     };
 
-    vv.addEventListener('resize', handler);
-    vv.addEventListener('scroll', handler);
+    vv.addEventListener('resize', onResize);
+
     return () => {
-      vv.removeEventListener('resize', handler);
-      vv.removeEventListener('scroll', handler);
+      vv.removeEventListener('resize', onResize);
+      cancelAnimationFrame(rafId);
+      const el = contentRef.current;
+      if (el) {
+        el.style.maxHeight = '';
+        el.style.height = '';
+      }
     };
   }, []);
 
@@ -98,12 +161,8 @@ function DrawerContent({
     <DrawerPortal data-slot="drawer-portal">
       <DrawerOverlay />
       <DrawerPrimitive.Content
+        ref={contentRef}
         data-slot="drawer-content"
-        style={
-          keyboardHeight > 0
-            ? { maxHeight: `calc(100dvh - ${keyboardHeight}px - 24px)` }
-            : undefined
-        }
         className={cn(
           'dark:bg-[#1E1E1E] bg-white max-w-4xl mx-auto',
           'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
@@ -115,7 +174,7 @@ function DrawerContent({
         )}
         {...props}
       >
-        <div className="bg-muted mx-auto mt-4 hidden h-2 w-[100px] shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
+        <div className="bg-muted mx-auto mt-4 hidden h-2 w-25 shrink-0 rounded-full group-data-[vaul-drawer-direction=bottom]/drawer-content:block" />
         {children}
         <div
           aria-hidden

--- a/frontend/src/hooks/useCreateRecord.ts
+++ b/frontend/src/hooks/useCreateRecord.ts
@@ -157,17 +157,20 @@ export const useCreateRecord = (
         return;
       }
 
-      // 개인 기록은 소프트 네비게이션 유지
-      router.replace(recordUrl);
-
-      // 백그라운드에서 캐시 무효화
-      Promise.all([
+      // 서버 액션(invalidateQuery 내 revalidatePath)을 router.replace 이전에 완료
+      // startTransition 중인 navigation과 revalidatePath 응답이 겹치면
+      // history 교체가 깨지는 race condition이 발생함 (그룹 경로와 동일한 패턴)
+      await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['me'] }),
         queryClient.invalidateQueries({ queryKey: ['summary'] }),
         queryClient.invalidateQueries({ queryKey: ['pattern'] }),
         queryClient.refetchQueries({ queryKey: ['search', 'tags'] }),
+        invalidateQuery(),
       ]);
-      invalidateQuery();
+
+      // 개인 기록은 소프트 네비게이션 유지
+      router.replace(recordUrl);
+
       setTimeout(() => {
         toast.success('기록이 성공적으로 저장되었습니다.');
       }, 1000);

--- a/frontend/src/hooks/useCreateRecord.ts
+++ b/frontend/src/hooks/useCreateRecord.ts
@@ -7,14 +7,6 @@ import { CreateRecordRequest } from '@/lib/types/record';
 import { toast } from 'sonner';
 import { useQueryClient } from '@tanstack/react-query';
 import { ApiResponse } from '@/lib/types/response';
-import {
-  refreshGroupData,
-  refreshHomeData,
-  refreshRecordAndHomeData,
-  refreshRecordData,
-  refreshRecordGroupAndSharedData,
-  refreshSharedData,
-} from '@/lib/actions/revalidate';
 import { ApiError } from '@/lib/utils/errorHandler';
 import { handlePublishError } from '@/lib/utils/error/publishHandler';
 
@@ -52,39 +44,41 @@ export const useCreateRecord = (
   useEffect(() => {
     if (!pendingNavUrl || isNavigatingRef.current) return;
     isNavigatingRef.current = true;
-    router.replace(pendingNavUrl);
 
-    requestAnimationFrame(() => {
-      setPendingNavUrl(null);
-      isNavigatingRef.current = false;
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const url = pendingNavUrl;
+
+    // vaul Drawer가 open 시 history.pushState({__drawerId}, ''), close 시
+    // replaceState({__drawerClosed: true}) 를 호출해 history 항목이 남는다.
+    // router.replace 전에 이 항목들을 모두 제거해야 /add 가 history에 남지 않는다.
+    const clearDrawerHistoryAndNavigate = () => {
+      const state = history.state as Record<string, unknown> | null;
+      if (state?.__drawerId || state?.__drawerClosed) {
+        const handlePop = () => {
+          window.removeEventListener('popstate', handlePop);
+          clearDrawerHistoryAndNavigate();
+        };
+        window.addEventListener('popstate', handlePop);
+        history.go(-1);
+      } else {
+        setPendingNavUrl(null);
+        isNavigatingRef.current = false;
+        router.replace(url);
+      }
+    };
+
+    clearDrawerHistoryAndNavigate();
   }, [pendingNavUrl]);
 
-  const invalidateQuery = async (groupId?: string) => {
-    await refreshRecordAndHomeData();
-
-    const invalidations = [
+  const invalidateQuery = async () => {
+    // revalidatePath 서버 액션 제외: 네비게이션 도중 응답이 도착하면
+    // Next.js App Router가 진행 중인 네비게이션을 취소해 /add로 되돌아가는 버그 발생.
+    await Promise.all([
       queryClient.invalidateQueries({ queryKey: ['my', 'records'] }),
       queryClient.invalidateQueries({ queryKey: ['records'] }),
       queryClient.invalidateQueries({ queryKey: ['profile'] }),
       queryClient.invalidateQueries({ queryKey: ['summary'] }),
       queryClient.invalidateQueries({ queryKey: ['map', 'records'] }),
-    ];
-
-    if (groupId) {
-      invalidations.push(
-        queryClient.invalidateQueries({
-          queryKey: ['group', groupId, 'records'],
-        }),
-        queryClient.invalidateQueries({
-          queryKey: ['shared'],
-        }),
-        refreshRecordGroupAndSharedData(groupId),
-      );
-    }
-
-    await Promise.all(invalidations);
+    ]);
   };
 
   // 일반 게시글 생성
@@ -146,13 +140,8 @@ export const useCreateRecord = (
         : `/record/${res.data.id}`;
 
       if (groupId) {
-        // Router Cache 무효화: router.replace 이전에 완료해야
-        // 서버 액션 응답이 클라이언트에 도달해 Router Cache가 실제로 비워짐.
-        // 이전 코드처럼 fire-and-forget으로 두면 revalidatePath가 늦게 실행돼
-        // 사용자가 그룹 페이지로 돌아올 때 여전히 캐시된 old payload가 사용됨.
-        await refreshGroupData(groupId);
-
-        // 나머지 무효화는 네비게이션 이후 백그라운드에서 처리
+        // revalidatePath 서버 액션 전부 제외: 네비게이션 도중 응답이 도착하면
+        // Next.js App Router가 진행 중인 네비게이션을 취소해 /add로 되돌아가는 버그 발생.
         Promise.all([
           queryClient.invalidateQueries({ queryKey: ['me'] }),
           queryClient.invalidateQueries({ queryKey: ['summary'] }),
@@ -163,9 +152,6 @@ export const useCreateRecord = (
           }),
           queryClient.invalidateQueries({ queryKey: ['shared'] }),
           queryClient.invalidateQueries({ queryKey: ['map', 'records'] }),
-          refreshSharedData(),
-          refreshRecordData(),
-          refreshHomeData(),
         ]);
 
         // React lifecycle 안에서 replace해야 history entry가 제대로 교체됨

--- a/frontend/src/hooks/useCreateRecord.ts
+++ b/frontend/src/hooks/useCreateRecord.ts
@@ -39,6 +39,7 @@ export const useCreateRecord = (
   postId?: string,
   options?: {
     onError?: (error: Error) => void;
+    onSuccess?: () => void;
   },
 ) => {
   const router = useRouter();
@@ -124,6 +125,7 @@ export const useCreateRecord = (
 
   async function handleSuccess(res: ApiResponse<RecordDetail>) {
     if (res.success && res.data?.id) {
+      options?.onSuccess?.();
       const recordUrl = groupId
         ? `/record/${res.data.id}?scope=group&groupId=${groupId}`
         : `/record/${res.data.id}`;

--- a/frontend/src/hooks/useCreateRecord.ts
+++ b/frontend/src/hooks/useCreateRecord.ts
@@ -1,5 +1,6 @@
 import { useAuthStore } from '@/store/useAuthStore';
 import { useApiPatch, useApiPost } from './useApi';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { RecordDetail } from '@/lib/types/recordResponse';
 import { CreateRecordRequest } from '@/lib/types/record';
@@ -45,6 +46,20 @@ export const useCreateRecord = (
   const router = useRouter();
   const queryClient = useQueryClient();
   const { userId } = useAuthStore();
+  const [pendingNavUrl, setPendingNavUrl] = useState<string | null>(null);
+  const isNavigatingRef = useRef(false);
+
+  useEffect(() => {
+    if (!pendingNavUrl || isNavigatingRef.current) return;
+    isNavigatingRef.current = true;
+    router.replace(pendingNavUrl);
+
+    requestAnimationFrame(() => {
+      setPendingNavUrl(null);
+      isNavigatingRef.current = false;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingNavUrl]);
 
   const invalidateQuery = async (groupId?: string) => {
     await refreshRecordAndHomeData();
@@ -153,23 +168,23 @@ export const useCreateRecord = (
           refreshHomeData(),
         ]);
 
-        router.replace(recordUrl);
+        // React lifecycle 안에서 replace해야 history entry가 제대로 교체됨
+        setPendingNavUrl(recordUrl);
         return;
       }
 
-      // 서버 액션(invalidateQuery 내 revalidatePath)을 router.replace 이전에 완료
-      // startTransition 중인 navigation과 revalidatePath 응답이 겹치면
-      // history 교체가 깨지는 race condition이 발생함 (그룹 경로와 동일한 패턴)
-      await Promise.all([
+      // 개인 기록은 소프트 네비게이션 유지
+      // 백그라운드에서 캐시 무효화
+      Promise.all([
         queryClient.invalidateQueries({ queryKey: ['me'] }),
         queryClient.invalidateQueries({ queryKey: ['summary'] }),
         queryClient.invalidateQueries({ queryKey: ['pattern'] }),
         queryClient.refetchQueries({ queryKey: ['search', 'tags'] }),
-        invalidateQuery(),
       ]);
+      invalidateQuery();
 
-      // 개인 기록은 소프트 네비게이션 유지
-      router.replace(recordUrl);
+      // React lifecycle 안에서 replace해야 history entry가 제대로 교체됨
+      setPendingNavUrl(recordUrl);
 
       setTimeout(() => {
         toast.success('기록이 성공적으로 저장되었습니다.');

--- a/frontend/src/hooks/useLocalDraft.ts
+++ b/frontend/src/hooks/useLocalDraft.ts
@@ -3,6 +3,12 @@ import { RecordBlock } from '@/lib/types/record';
 
 export const PERSONAL_DRAFT_KEY = 'personal-record-draft';
 
+// 개인 글은 공통 키, 그룹 내 개인 글은 그룹별로 별도 키를 사용해 서로 다른 글의
+// 임시저장이 섞여 노출되지 않도록 한다.
+export function getDraftKey(groupId?: string): string {
+  return groupId ? `group-${groupId}-record-draft` : PERSONAL_DRAFT_KEY;
+}
+
 export interface DraftData {
   title: string;
   blocks: RecordBlock[];

--- a/frontend/src/hooks/useLocalDraft.ts
+++ b/frontend/src/hooks/useLocalDraft.ts
@@ -1,0 +1,60 @@
+import { useCallback } from 'react';
+import { RecordBlock } from '@/lib/types/record';
+
+export const PERSONAL_DRAFT_KEY = 'personal-record-draft';
+
+export interface DraftData {
+  title: string;
+  blocks: RecordBlock[];
+  savedAt: string; // ISO string
+}
+
+function serializeBlocks(blocks: RecordBlock[]): RecordBlock[] {
+  return blocks.map((block) => {
+    if (block.type === 'photos') {
+      return {
+        ...block,
+        value: { ...block.value, tempUrls: [] },
+      } as RecordBlock;
+    }
+    return block;
+  });
+}
+
+export function useLocalDraft(key: string = PERSONAL_DRAFT_KEY) {
+  const saveDraft = useCallback(
+    (title: string, blocks: RecordBlock[]) => {
+      try {
+        const data: DraftData = {
+          title,
+          blocks: serializeBlocks(blocks),
+          savedAt: new Date().toISOString(),
+        };
+        localStorage.setItem(key, JSON.stringify(data));
+      } catch {
+        // localStorage unavailable or quota exceeded
+      }
+    },
+    [key],
+  );
+
+  const loadDraft = useCallback((): DraftData | null => {
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) return null;
+      return JSON.parse(raw) as DraftData;
+    } catch {
+      return null;
+    }
+  }, [key]);
+
+  const clearDraft = useCallback(() => {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // ignore
+    }
+  }, [key]);
+
+  return { saveDraft, loadDraft, clearDraft };
+}

--- a/frontend/src/hooks/useMediaUpload.ts
+++ b/frontend/src/hooks/useMediaUpload.ts
@@ -30,15 +30,24 @@ export interface UploadedMedia {
   uploadUrl: string; // presigned PUT URL (업로드 직후 임시 표시용)
 }
 
+export interface UploadMultipleResult {
+  successIds: string[];
+  // files 배열 기준, 업로드 또는 완료 확정에 실패한 인덱스 (오름차순)
+  failedIndices: number[];
+}
+
 export const useMediaUpload = () => {
   const [isUploading, setIsUploading] = useState(false);
 
   /**
-   * 여러 파일 업로드 후 mediaId 배열 반환
-   * draft 모드에서는 uploadUrl도 함께 반환하여 PATCH_COMMITTED 전 임시 미리보기에 활용
+   * 여러 파일 업로드 후 성공한 mediaId와 실패한 파일의 인덱스를 반환
+   * 일부만 실패한 경우 성공한 파일만 successIds에 담고 failedIndices로 실패 위치를 알려준다.
+   * 전부 실패하면 에러를 throw한다.
    */
-  const uploadMultipleMedia = async (files: File[]): Promise<string[]> => {
-    if (files.length === 0) return [];
+  const uploadMultipleMedia = async (
+    files: File[],
+  ): Promise<UploadMultipleResult> => {
+    if (files.length === 0) return { successIds: [], failedIndices: [] };
     setIsUploading(true);
 
     try {
@@ -60,7 +69,7 @@ export const useMediaUpload = () => {
         })),
       );
 
-      await Promise.all(
+      const uploadResults = await Promise.allSettled(
         presignItems.map((item, index) =>
           uploadFileToStorage(
             item.uploadUrl,
@@ -70,10 +79,49 @@ export const useMediaUpload = () => {
         ),
       );
 
-      const mediaIds = presignItems.map((item) => item.mediaId);
-      const successIds = await postMediaComplete(mediaIds);
+      const succeededIndices: number[] = [];
+      const failedIndices: number[] = [];
+      uploadResults.forEach((result, index) => {
+        if (result.status === 'fulfilled') {
+          succeededIndices.push(index);
+        } else {
+          failedIndices.push(index);
+          Sentry.captureException(result.reason, {
+            tags: { context: 'media', operation: 'upload-single' },
+            extra: {
+              fileName: files[index].name,
+              fileType: files[index].type,
+            },
+          });
+          logger.error('이미지 업로드 실패', result.reason);
+        }
+      });
 
-      return successIds;
+      if (succeededIndices.length === 0) {
+        throw new Error('모든 이미지 업로드에 실패했습니다.');
+      }
+
+      const succeededMediaIds = succeededIndices.map(
+        (index) => presignItems[index].mediaId,
+      );
+      const completedIds = await postMediaComplete(succeededMediaIds);
+
+      if (completedIds.length === 0) {
+        throw new Error('모든 이미지 업로드에 실패했습니다.');
+      }
+
+      const completedSet = new Set(completedIds);
+      const successIds: string[] = [];
+      succeededIndices.forEach((index) => {
+        const mediaId = presignItems[index].mediaId;
+        if (completedSet.has(mediaId)) {
+          successIds.push(mediaId);
+        } else {
+          failedIndices.push(index);
+        }
+      });
+
+      return { successIds, failedIndices: failedIndices.sort((a, b) => a - b) };
     } catch (error) {
       if ((error as ApiError)?.code === 'TIMEOUT') {
         toast.error('이미지 업로드 시간이 초과되었습니다.', {

--- a/frontend/src/lib/api/api.ts
+++ b/frontend/src/lib/api/api.ts
@@ -294,10 +294,10 @@ export async function fetchApi<T>(
   } = options;
 
   const currentBaseUrl = getApiBaseUrl();
-  // 서버 환경에서는 /api -> /v1로 변환 (rewrites 규칙 반영)
+  // 서버 환경에서는 /api 접두사 제거 (base URL에 이미 /v1 포함)
   const finalEndpoint =
     typeof window === 'undefined'
-      ? endpoint.replace(/^\/api/, '/v1')
+      ? endpoint.replace(/^\/api/, '')
       : endpoint;
 
   let fullUrl = `${currentBaseUrl}${finalEndpoint}`;

--- a/frontend/src/lib/types/record.ts
+++ b/frontend/src/lib/types/record.ts
@@ -52,7 +52,7 @@ export interface DayRecord {
   dayName: string;
   title: string;
   count: number;
-  coverUrl: string;
+  coverUrl: string | null;
 }
 
 export interface Tag {

--- a/frontend/src/lib/utils/draftPhotoStorage.ts
+++ b/frontend/src/lib/utils/draftPhotoStorage.ts
@@ -1,0 +1,109 @@
+const DB_NAME = 'itta-draft-db';
+const DB_VERSION = 1;
+const STORE_NAME = 'draft-photos';
+const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface DraftPhotoEntry {
+  draftKey: string;
+  photos: Array<{ blockId: string; originalUrl: string; file: File }>;
+  savedAt: number;
+}
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE_NAME, { keyPath: 'draftKey' });
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function saveDraftPhotos(
+  draftKey: string,
+  photos: Array<{ blockId: string; originalUrl: string; file: File }>,
+): Promise<void> {
+  try {
+    const db = await openDB();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).put({ draftKey, photos, savedAt: Date.now() });
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } catch {
+    // QuotaExceededError 등 — 사진 저장 실패는 무시 (텍스트 draft는 이미 저장됨)
+  }
+}
+
+export async function loadDraftPhotos(
+  draftKey: string,
+): Promise<DraftPhotoEntry['photos'] | null> {
+  try {
+    const db = await openDB();
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const req = tx.objectStore(STORE_NAME).get(draftKey);
+      req.onsuccess = () =>
+        resolve((req.result as DraftPhotoEntry)?.photos ?? null);
+      req.onerror = () => reject(req.error);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function clearDraftPhotos(draftKey: string): Promise<void> {
+  try {
+    const db = await openDB();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      tx.objectStore(STORE_NAME).delete(draftKey);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } catch {
+    // ignore
+  }
+}
+
+// 에디터 진입 시 TTL 초과 항목 자동 삭제
+export async function cleanupStaleDraftPhotos(): Promise<void> {
+  try {
+    const db = await openDB();
+    const entries = await new Promise<DraftPhotoEntry[]>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const req = tx.objectStore(STORE_NAME).getAll();
+      req.onsuccess = () => resolve(req.result as DraftPhotoEntry[]);
+      req.onerror = () => reject(req.error);
+    });
+
+    const staleKeys = entries
+      .filter((e) => Date.now() - e.savedAt > TTL_MS)
+      .map((e) => e.draftKey);
+
+    if (staleKeys.length === 0) return;
+
+    const db2 = await openDB();
+    await new Promise<void>((resolve, reject) => {
+      const tx = db2.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      staleKeys.forEach((k) => store.delete(k));
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  } catch {
+    // ignore
+  }
+}
+
+// File을 base64 data URL로 변환
+export function fileToDataUrl(file: File | Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => resolve(e.target?.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}

--- a/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
+++ b/mobile-app/android/app/src/main/java/com/ittda/app/MainActivity.java
@@ -1,13 +1,20 @@
 package com.ittda.app;
 
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
 import android.content.res.Configuration;
 import android.graphics.Color;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.JavascriptInterface;
+import android.webkit.WebChromeClient;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
 
 import androidx.core.view.ViewCompat;
@@ -17,6 +24,7 @@ import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.core.splashscreen.SplashScreen;
 
 import com.getcapacitor.BridgeActivity;
+import com.getcapacitor.BridgeWebChromeClient;
 
 public class MainActivity extends BridgeActivity {
 
@@ -66,6 +74,70 @@ public class MainActivity extends BridgeActivity {
 
         // WebView 로드 전에 브릿지 등록 (onStart보다 이른 시점 → 타이밍 문제 해소)
         getBridge().getWebView().addJavascriptInterface(new StatusBarBridge(), "AndroidBridge");
+
+        setupKakaoShare();
+    }
+
+    private void setupKakaoShare() {
+        WebView webView = getBridge().getWebView();
+        // window.open() 팝업 허용 (기본값 false → Kakao SDK가 null을 받아 조용히 실패하는 원인)
+        webView.getSettings().setSupportMultipleWindows(true);
+
+        webView.setWebChromeClient(new BridgeWebChromeClient(getBridge()) {
+            @Override
+            public boolean onCreateWindow(WebView view, boolean isDialog,
+                                          boolean isUserGesture, android.os.Message resultMsg) {
+                WebView popup = new WebView(MainActivity.this);
+                popup.getSettings().setJavaScriptEnabled(true);
+
+                popup.setWebChromeClient(new WebChromeClient() {
+                    @Override
+                    public void onCloseWindow(WebView window) {
+                        window.destroy();
+                    }
+                });
+
+                popup.setWebViewClient(new WebViewClient() {
+                    @Override
+                    public boolean shouldOverrideUrlLoading(WebView v, WebResourceRequest req) {
+                        String url = req.getUrl().toString();
+
+                        // KakaoTalk 앱 실행 deep link: Intent.parseUri로 정확히 처리
+                        if (url.startsWith("intent://") || url.startsWith("kakaolink://")
+                                || url.startsWith("kakaotalk://")) {
+                            try {
+                                Intent intent = url.startsWith("intent://")
+                                        ? Intent.parseUri(url, Intent.URI_INTENT_SCHEME)
+                                        : new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                                startActivity(intent);
+                            } catch (ActivityNotFoundException e) {
+                                // KakaoTalk 미설치 — 무시
+                            } catch (Exception ignored) {}
+                            popup.destroy();
+                            return true;
+                        }
+
+                        // 카카오 도메인(sharer.kakao.com 등)은 팝업 WebView에서 정상 로드
+                        if (url.contains("kakao.com")) {
+                            return false;
+                        }
+
+                        // Facebook·Twitter 등 비카카오 URL → 시스템 브라우저로 열고 팝업 정리
+                        try {
+                            startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                        } catch (Exception ignored) {}
+                        popup.destroy();
+                        return true;
+                    }
+                });
+
+                WebView.WebViewTransport transport = (WebView.WebViewTransport) resultMsg.obj;
+                transport.setWebView(popup);
+                resultMsg.sendToTarget();
+                return true;
+            }
+        });
     }
 
     // 상태바 높이 (px): insets 콜백에서 설정, JS bridge에서 읽음


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- #287 
- UI 피드백 및 버그 수정
  - 기록 작성 후 상세 페이지에서 뒤로가기 시 `/add`로 이동하는 버그 수정
  - 그룹 홈 멤버 정보 API 실패시 에러 페이지 대신 재시도 버튼 노출
  - 가상 키보드 노출 시 drawer가 화면 바깥으로 밀려나는 버그 수정
  - 모바일 카메라로 직접 촬영한 사진이 90도 회전되어 저장되는 버그 수정
  - 서버 점검 페이지 추가 (vercel 환경변수 값 변경으로 점검 페이지 노출 가능)
  - ...

## 작업 내용 + 스크린샷

### 기록 작성 후 상세 페이지에서 뒤로가기 시 `/add`로 이동하는 버그 수정

**원인1**: 상세 페이지 이동 `router.replace` 실행 전 `revalidatePath` 서버 액션 응답이 도착하면 Next.js app router가 진행 중인 네비게이션을 취소하는 문제

-> 기록 저장 성공시 fire-and-forget으로 실행하던 서버 액션 캐시 초기화 로직 제거(클라이언트 캐시 무효화 로직으로 충분)

> **fire-and-forget**: 함수를 호출해놓고 결과를 기다리지 않는 패턴이에요. (await 없이 호출)
> 비동기 작업을 백그라운드에서 실행시키고, 완료를 신경쓰지 않는 방식이에요.
> 서버 액션이 언제 완료될지 모르는 채로 라우터 이동이 실행되고, 서버 액션 응답이 네비게이션 도중에 도착해서 충돌이 발생한거에요.

**원인2**: 에디터에서 drawer(날짜, 태그, 감정 등)를 열고 닫으면 vaul이 
`history.pushState` -> `history.replaceState`로 history 항목을 남기고 상세 페이지로 이동해 `/add` 항목이 stack에 남아있던 문제

-> 저장 후 네비게이션 전에 `history.state`가 drawer 상태(__drawerId / __drawerClosed)인 동안 `history.go(-1)`로 정리

<br />

### 그룹 홈 멤버 정보 API 실패시 에러 페이지 대신 재시도 버튼 노출

그룹 홈의 서버 레이아웃단에서 API 실패시 에러를 잡아내는 로직이 없어서 전역 에러 핸들링으로 넘어가게 되어있었어요.
그래서 API 실패시 부분 에러 컴포넌트가 아닌 전체 페이지가 다운되는 문제가 있었어요.
이를 `try-catch`로 잡아 재시도 버튼을 두도록 했어요.

<br />

### 가상 키보드 노출 시 drawer가 화면 바깥으로 밀려나는 버그 수정

capacitor 환경으로 모바일을 거의 확인해서인지 웹상에서 문제가 발생함을 인지하지 못했어요.

PWA/모바일 웹 환경에서 `input`이 포함된 drawer를 열 때 가상 키보드에 의해 drawer가 뷰포트 바깥까지 확장되는 문제가 있었어요.
또한 drawer 내부(input 제외) 클릭 시 키보드가 닫히면서 똑같이 drawer가 화면 밖으로 나가는 문제가 있었어요.

원인:
가상 키보드가 올라오면서 그만큼 영역을 차지하게 되어 뷰포트 높이가 줄어들게 돼요.
vaul 라이브러리도 이 이벤트를 받아서 drawer의 `style.height`를 재계산하는데, 이 계산이 잘못되거나 키보드가 내려간 후에도 그 값이 남아서 drawer가 뷰포트 바깥까지 밀려나던 문제에요.

> vaul: drawer UI 라이브러리에요.

이를 resize 이벤트로 키보드 높이를 감지해 drawer에 `maxHeight` 값이 동적으로 바뀌도록 해주었어요.
내부 클릭 문제는 vaul이 핸들러를 skip 하는 경우에 `style.bottom` 값이 키보드 높이로 남아서 화면밖으로 튀어나가는 문제였고, `requestAnimation`으로 빈 값으로 초기화하도록 해주었어요.

<br />

### 모바일 카메라로 직접 촬영한 사진이 90도 회전되어 저장되는 버그 수정

원인: 모바일 카메라로 찍은 사진은 물리적으로 데이터를 회전시키지 않고, EXIF 메타데이터에 `Orientation: 6 (90도 회전해서 표시)` 같은 태그만 붙여서 저장해요.
하지만 저희는 그 태그를 무시하고 있었어요.

이미지 최적화를 위해 webp 포맷으로 바꾸고 있는데, 이 포맷은 EXIF orientation을 지원하지 않거나 일부 무시해요.
그리고 `<Image>` 컴포넌트로 이미지를 출력하고 있는데, `imageOrientation: 'from-image'` 라는 스타일 속성을 적어주지 않아 브라우저가 EXIF를 무시하고 원본 픽셀 방향 그대로 렌더링하던 문제에요.

이를 webp 변환 과정에서 물리적으로 90도 돌아간 채로 저장되도록 `.rotate()` 메서드를 호출해줬어요.
그러면 sharp가 EXIF를 읽어서 픽셀을 실제로 회전시킨 뒤 태그를 제거, 이후 webp로 변환해요.
그리고 위에서 언급한 스타일 속성을 추가해줘서 브라우저가 EXIF orientation을 읽어서 자동으로 회전시킬 수 있도록 해줬어요.

> object-cover css가 걸려있는 환경에서는 동작이 억제되는 경우가 있다고 하네요. (그래서 수정해줬어요.)

<br />

그 외로

- 주간 달력 날짜 클릭 시 history stack에 쌓이던걸 현재 경로를 대체하는 것으로 변경
  - 뒤로가기 시 이전 날짜로 되돌아가 의도한 동작대로 페이지가 이동하지 않아 불편하다 느꼈어요.
- 기록 작성 중 자동저장 기능 추가 (draft는 서버와 동기화 되므로 제외)
- 서버 점검 페이지 추가 (vercel 환경변수 값 변경으로 점검 페이지 노출 가능)
- 기록 카드 기본 이미지는 없애고 아래 시각 자료처럼 수정해줬어요.

작업해줬습니다.

## 실제 걸린 시간

2day

## 작업하며 고민했던 점

기록 임시 저장 기능은 브라우저에서 제공하는 로컬스토리지와 IndexedDB를 사용해줬어요.

로컬 스토리지에는 텍스트 위주를, IndexedDB는 이미지를 저장하는데 사용했어요.
로컬 스토리지는 객체형식을 저장할 수 없기 때문에, 이미지를 저장하기엔 제약이 있었어요.
결국 이미지도 문자열 데이터로 사용이 되지만, 로컬스토리지 용량(약 5MB)이 이미지를 감당하기엔 무리가 있다고 생각했어요.

그래서 File/Blob 객체를 저장할 수 있는 IndexedDB를 사용해줬어요.

자동 저장은 마지막 입력을 기준으롤 3초간 이벤트가 없을 때 저장돼요.
여기서 마지막 입력은 블록 추가/수정 모두 포함이에요.
저장 되었다는 안내는 유저에게 불편함을 주지 않도록 작게 표현해줬어요. -> 저장 버튼 왼쪽에 텍스트로 사진처럼 노출되었다 사라져요.

<img width="40%" alt="image" src="https://github.com/user-attachments/assets/ec72d615-023b-437f-a5c8-5a1668ad0a76" />


## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/dc4f7ac6-a2e4-45b1-b6f0-ce4a3ed6bbe6" />
