### PR TITLE
게시글 작성 시 일부 감정이 유효하지 않다고 처리되는 문제 수정

### DIFF
--- a/backend/src/enums/post-mood.enum.ts
+++ b/backend/src/enums/post-mood.enum.ts
@@ -10,10 +10,12 @@ export const PostMood = {
   BUSY: '바쁨',
   BORED: '심심',
   WORRIED: '걱정',
+  ANXIOUS: '불안',
   SECRET: '비밀',
   SURPRISED: '놀람',
   ANGRY: '화남',
   SAD: '슬픔',
+  DEPRESSED: '우울',
   SICK: '아픔',
   ANNOYED: '짜증',
 } as const;

--- a/backend/src/modules/post/dto/post-block.dto.spec.ts
+++ b/backend/src/modules/post/dto/post-block.dto.spec.ts
@@ -1,0 +1,32 @@
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+
+import { PostBlockType } from '@/enums/post-block-type.enum';
+
+import { PostBlockDto } from './post-block.dto';
+
+const createMoodBlock = (mood: string) =>
+  plainToInstance(PostBlockDto, {
+    type: PostBlockType.MOOD,
+    value: { mood },
+    layout: { row: 1, col: 1, span: 1 },
+  });
+
+describe('PostBlockDto mood validation', () => {
+  it('accepts moods that exist in the frontend picker', () => {
+    const anxiousBlock = createMoodBlock('불안');
+    const depressedBlock = createMoodBlock('우울');
+
+    expect(validateSync(anxiousBlock)).toHaveLength(0);
+    expect(validateSync(depressedBlock)).toHaveLength(0);
+  });
+
+  it('rejects moods outside the allowed set', () => {
+    const invalidBlock = createMoodBlock('설렘');
+    const [error] = validateSync(invalidBlock);
+
+    expect(error?.constraints?.MoodValueConstraint).toContain(
+      'mood must be one of:',
+    );
+  });
+});

--- a/backend/src/modules/post/post.controller.ts
+++ b/backend/src/modules/post/post.controller.ts
@@ -35,6 +35,7 @@ import {
   ApiWrappedCreatedResponse,
   ApiWrappedOkResponse,
 } from '@/common/swagger/api-wrapped-response.decorator';
+import { PostMood } from '@/enums/post-mood.enum';
 import { JwtAuthGuard } from '../auth/jwt/jwt.guard';
 
 import type { MyJwtPayload } from '../auth/auth.type';
@@ -94,7 +95,7 @@ export class PostController {
   @ApiBody({
     type: CreatePostDto,
     description:
-      'MOOD 블록의 value.mood는 [행복, 좋음, 만족, 재미, 감동, 보통, 공허, 피곤, 바쁨, 심심, 걱정, 비밀, 놀람, 화남, 슬픔, 아픔, 짜증] 중 하나여야 합니다.<br/>' +
+      `MOOD 블록의 value.mood는 [${Object.values(PostMood).join(', ')}] 중 하나여야 합니다.<br/>` +
       'LOCATION 블록은 lat/lng/address가 필요하며 placeName은 선택입니다.<br/>' +
       'RATING 블록의 value.rating은 소수점 한 자리까지 허용됩니다.<br/>' +
       'MEDIA 블록의 value에는 title, type, externalId가 필수이며 year/imageUrl/originalTitle은 선택입니다.',

--- a/backend/test/post.e2e-spec.ts
+++ b/backend/test/post.e2e-spec.ts
@@ -612,12 +612,12 @@ describe('PostController (e2e)', () => {
         },
         {
           type: 'MOOD',
-          value: { mood: '보통' },
+          value: { mood: '불안' },
           layout: { row: 4, col: 1, span: 1 },
         },
         {
           type: 'MOOD',
-          value: { mood: '좋음' },
+          value: { mood: '우울' },
           layout: { row: 4, col: 2, span: 1 },
         },
       ],


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- close #299
- 게시글 작성 시 프론트에서 선택 가능한 일부 감정이 백엔드 검증에서 유효하지 않은 값으로 처리되던 문제를 수정했습니다.
- 감정 선택지와 서버 허용값이 다시 어긋나지 않도록 문서와 테스트도 함께 보강했습니다.

## 작업 내용 + 스크린샷

- 백엔드 `PostMood`에 프론트 감정 선택지와 맞지 않던 감정 값을 추가했습니다.
- 게시글 생성 API 문서의 허용 감정 목록을 enum 기반으로 노출하도록 수정했습니다.
- 감정 검증 DTO 테스트를 추가했습니다.
- 게시글 작성 관련 e2e 테스트의 감정 케이스를 최신 허용값 기준으로 갱신했습니다.

## 실제 걸린 시간
약 30분

## 작업하며 고민했던 점(선택)

- 제보는 특정 감정 기준이었지만, 개별 값만 임시로 추가하기보다 프론트 감정 선택지와 백엔드 검증 기준의 불일치 자체를 줄이는 방향으로 수정했습니다.
- 같은 문제가 반복되지 않도록 enum 기반 문서화와 회귀 테스트를 같이 넣었습니다.

## 테스트 실행 여부

- [x] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

실행한 테스트:
- `./node_modules/.bin/eslint src/enums/post-mood.enum.ts src/modules/post/post.controller.ts src/modules/post/dto/post-block.dto.spec.ts`
- `./backend/node_modules/.bin/jest backend/src/modules/post/dto/post-block.dto.spec.ts --runInBand --config backend/package.json`


## 리뷰 참고사항(선택)

- 전체 e2e는 로컬 `JWT_SECRET` 및 테스트 DB 환경이 준비되지 않으면 실패할 수 있어, 이번 PR에서는 감정 검증 범위에 맞는 단위 테스트와 린트 위주로 확인했습니다.
- 감정 선택지는 프론트 상수와 백엔드 enum이 함께 유지되어야 하므로, 이후 감정 목록 변경 시 두 영역을 같이 확인해주시면 됩니다.


## 시각 자료(이미지/영상, 있다면)(선택)

- 없음