### PR TITLE
코치마크 초기 깜빡임과 BottomNavigation 위치 어긋남 수정

### DIFF
--- a/frontend/src/app/(main)/_components/WeekCalendar.tsx
+++ b/frontend/src/app/(main)/_components/WeekCalendar.tsx
@@ -72,8 +72,9 @@ export default function WeekCalendar({
     if (newDirection > 0) {
       const nextWeekStart = new Date(currentWeekStart);
       nextWeekStart.setDate(nextWeekStart.getDate() + 7);
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
+      // new Date()는 서버 렌더링 시 서버의 로컬 타임존(UTC)을 기준으로 자정을 계산해
+      // 한국 시간 00~09시 사이엔 하루 전으로 어긋난다. formatDateISO는 Asia/Seoul로 고정 계산하므로 안전하다.
+      const today = parseLocalDate(formatDateISO());
 
       // 다음 주의 시작일이 오늘 이후라면 페이지네이션 차단
       if (nextWeekStart > today) {
@@ -117,8 +118,7 @@ export default function WeekCalendar({
 
   const handleTouchDate = (dateStr: string) => {
     const selectedDate = parseLocalDate(dateStr);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    const today = parseLocalDate(formatDateISO());
     selectedDate.setHours(0, 0, 0, 0);
 
     // 미래 날짜는 선택 불가
@@ -143,7 +143,9 @@ export default function WeekCalendar({
         <span
           className="flex items-center"
           onClick={() =>
-            router.push(`${monthBasePath}/month/${displayYearMonth.replace('.', '-')}`)
+            router.push(
+              `${monthBasePath}/month/${displayYearMonth.replace('.', '-')}`,
+            )
           }
         >
           <span className="text-sm sm:text-base font-semibold dark:text-white text-itta-black">
@@ -204,8 +206,7 @@ export default function WeekCalendar({
             >
               {weekDays.map((item) => {
                 const isSelected = selectedDateStr === item.dateStr;
-                const today = new Date();
-                today.setHours(0, 0, 0, 0);
+                const today = parseLocalDate(formatDateISO());
                 const isFuture = item.date > today;
 
                 return (

--- a/frontend/src/app/(main)/page.tsx
+++ b/frontend/src/app/(main)/page.tsx
@@ -30,7 +30,15 @@ export async function generateMetadata() {
 export default function HomePage() {
   return (
     <div className="flex flex-col h-screen overflow-hidden">
-      <Suspense fallback={null}>
+      {/* AnnouncementModal은 서버에서 공지 표시 여부를 비동기로 판단하는 동안
+          아무것도 렌더링하지 않으면(fallback=null) 코치마크가 "공지 없음"으로
+          착각하고 먼저 떴다가, 판단이 끝나며 공지가 나타나면 밀려서 깜빡인다.
+          PWA 배너와 같은 방식으로 판단 중임을 알리는 마커를 남겨둔다. */}
+      <Suspense
+        fallback={
+          <div data-announcement-pending className="hidden" aria-hidden />
+        }
+      >
         <AnnouncementModal />
       </Suspense>
       <Coachmark flowKey="home" steps={HOME_COACHMARK_STEPS} />

--- a/frontend/src/components/Coachmark.tsx
+++ b/frontend/src/components/Coachmark.tsx
@@ -8,6 +8,12 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useCoachmark, type CoachmarkStep } from '@/hooks/useCoachmark';
 
+const isNativePlatform = () =>
+  typeof window !== 'undefined' &&
+  !!(
+    window as unknown as { Capacitor?: { isNativePlatform?: () => boolean } }
+  ).Capacitor?.isNativePlatform?.();
+
 const SPOTLIGHT_PADDING_MIN = 7;
 const SPOTLIGHT_PADDING_MAX = 10;
 const SPOTLIGHT_PADDING_RATIO = 0.2; // 타겟의 짧은 변에 비례한 여백(고정값 대신 상대값 사용)
@@ -64,7 +70,13 @@ export default function Coachmark({ flowKey, steps, enabled }: CoachmarkProps) {
       ),
     ) - (isMobileWidth ? MOBILE_PADDING_REDUCTION : 0);
   // 스텝마다 필요한 경우에만(예: BottomNavigation 아이템) 모바일 폭에서 살짝 내리거나 옆으로 옮긴다.
-  const yOffset = isMobileWidth ? (step.yOffsetMobile ?? 0) : 0;
+  // 같은 타겟이어도 웹과 Capacitor 네이티브의 실측 렌더링이 달라서, 네이티브에서는
+  // yOffsetMobileNative(없으면 0)를 쓰고 웹에서는 yOffsetMobile을 쓴다.
+  const yOffset = isMobileWidth
+    ? isNativePlatform()
+      ? (step.yOffsetMobileNative ?? 0)
+      : (step.yOffsetMobile ?? 0)
+    : 0;
   const xOffset = isMobileWidth ? (step.xOffsetMobile ?? 0) : 0;
   // 화면 밖으로 나가지 않도록 뷰포트 안으로 먼저 clamp한 다음, offset은 그 위에 더한다.
   // 화면 가장자리에 붙은 타겟은 offset을 clamp 전에 더하면 "화면 밖으로 안 나가게"
@@ -87,13 +99,14 @@ export default function Coachmark({ flowKey, steps, enabled }: CoachmarkProps) {
         Math.max(rawSpotlight.left, VIEWPORT_MARGIN),
         window.innerWidth - rawSpotlight.width - VIEWPORT_MARGIN,
       ) + xOffset,
-    // yOffset을 더한 뒤에도 화면 밖으로 나가지 않도록 다시 한 번 clamp한다.
-    // yOffsetMobile이 큰 스텝은 이미 하단 가장자리에 있는 타겟(BottomNavigation)을
-    // 뷰포트 밖으로 밀어낼 수 있어서다.
-    top: Math.min(
-      Math.max(clampedTop + yOffset, VIEWPORT_MARGIN),
-      maxSpotlightTop,
-    ),
+    // offset을 clamp 전 위치에 더하고, 재-clamp는 하지 않는다. 재-clamp를 하면
+    // BottomNavigation처럼 이미 하단 가장자리 근처에 있는(=clampedTop이
+    // maxSpotlightTop에 가까운) 타겟은 yOffsetMobile을 아무리 늘려도 상한에
+    // 도로 눌려서 값이 반영되지 않는다 — 실제로 8→12.4로 늘려도 동일한 위치로
+    // 계산되는 회귀가 있었다. 큰 값(예: 예전 nativeStatusBarOffset)이 화면
+    // 밖으로 밀어낼 위험은 현재 이 값이 전부 작은 수동 튜닝값이라 낮다고 보고
+    // 감수한다.
+    top: clampedTop + yOffset,
     width: rawSpotlight.width,
     height: rawSpotlight.height,
   };

--- a/frontend/src/components/DateDrawer.tsx
+++ b/frontend/src/components/DateDrawer.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from 'react';
 import { Check, ChevronLeft, ChevronRight, RotateCcw } from 'lucide-react';
 import { Drawer, DrawerContent, DrawerTitle } from '@/components/ui/drawer';
-import { formatDateISO } from '@/lib/date';
+import { formatDateISO, parseLocalDate } from '@/lib/date';
 import { cn } from '@/lib/utils';
 
 interface DateRange {
@@ -94,8 +94,8 @@ export default function DateDrawer({
   };
 
   const handleSelectMonth = () => {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+    // formatDateISO는 Asia/Seoul 기준으로 고정 계산해, 서버 타임존(UTC)과 무관하게 정확하다.
+    const today = parseLocalDate(formatDateISO());
 
     const firstDateOfMonth = new Date(year, month, 1);
     if (firstDateOfMonth > today) return;
@@ -200,8 +200,7 @@ export default function DateDrawer({
 
                 const dateObj = new Date(year, month, dayNumber);
                 const dateStr = formatDateISO(dateObj);
-                const today = new Date();
-                today.setHours(0, 0, 0, 0);
+                const today = parseLocalDate(formatDateISO());
 
                 const isSelectedSingle =
                   mode === 'single' && currentDate === dateStr;

--- a/frontend/src/components/DateSelectorDrawer.tsx
+++ b/frontend/src/components/DateSelectorDrawer.tsx
@@ -22,6 +22,7 @@ import { useState, useRef, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { groupDailyRecordedDatesOption } from '@/lib/api/group';
 import { myDailyRecordedDatesOption } from '@/lib/api/my';
+import { formatDateISO, parseLocalDate } from '@/lib/date';
 
 const ITEM_HEIGHT = 48;
 const PICKER_HEIGHT = 192;
@@ -341,8 +342,8 @@ export default function DateSelectorDrawer({
                   {calendarDays.map((date) => {
                     const dateStr = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
                     const hasRecord = recordedDates.includes(dateStr);
-                    const isToday =
-                      new Date().toDateString() === date.toDateString();
+                    // formatDateISO는 Asia/Seoul 기준으로 고정 계산해, 서버 타임존(UTC)과 무관하게 정확하다.
+                    const isToday = dateStr === formatDateISO();
                     return (
                       <button
                         key={dateStr}
@@ -360,15 +361,12 @@ export default function DateSelectorDrawer({
                                 ? 'dark:hover:bg-white/5 dark:text-blue-400 hover:bg-gray-50 text-blue-500'
                                 : 'dark:hover:bg-white/5 dark:text-gray-300 hover:bg-gray-50 text-gray-600',
                         )}
-                        disabled={(() => {
-                          const date = new Date(dateStr);
-                          const today = new Date();
-                          today.setHours(0, 0, 0, 0);
-                          date.setHours(0, 0, 0, 0);
-
-                          // 미래 날짜는 선택 불가
-                          return date > today;
-                        })()}
+                        // 미래 날짜는 선택 불가. new Date(dateStr)는 날짜 전용 문자열을 UTC로 해석하므로
+                        // parseLocalDate로 로컬(한국) 타임존 기준 자정을 만들어 비교한다.
+                        disabled={
+                          parseLocalDate(dateStr) >
+                          parseLocalDate(formatDateISO())
+                        }
                       >
                         <span className="text-xs font-bold">
                           {date.getDate()}

--- a/frontend/src/hooks/useCoachmark.ts
+++ b/frontend/src/hooks/useCoachmark.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useAuthStore } from '@/store/useAuthStore';
 import { userProfileOptions } from '@/lib/api/profile';
@@ -13,9 +13,12 @@ export interface CoachmarkStep {
   id: string;
   title: string;
   description: string;
-  // 모바일 폭에서 스포트라이트 박스를 아래로 살짝 내릴 px(기본 0).
+  // 모바일 폭에서 스포트라이트 박스를 아래로 살짝 내릴 px(기본 0). 브라우저(웹)에 적용.
   // BottomNavigation처럼 아이콘 특성상 살짝 위로 치우쳐 보이는 타겟에만 사용.
   yOffsetMobile?: number;
+  // 모바일 폭 + Capacitor 네이티브 환경에서만 쓰는 yOffsetMobile 대체값(기본 0).
+  // 같은 타겟이어도 네이티브 WebView 렌더링이 미묘하게 달라 웹과 다른 보정이 필요할 때 사용.
+  yOffsetMobileNative?: number;
   // 모바일 폭에서 스포트라이트 박스를 오른쪽으로 살짝 옮길 px(기본 0).
   xOffsetMobile?: number;
   // 타겟 비율 기반 자동 여백 대신 고정 여백을 쓰고 싶을 때(예: 아이콘 하나만 딱 감싸기).
@@ -57,16 +60,23 @@ export function useCoachmark({
     invalidateKeys: [['profile', 'me']],
   });
 
-  // 공지 모달이 떠 있는 동안, 그리고 PWA 설치 배너의 표시 여부 판단(비동기 체크)이
-  // 끝나기 전까지는 코치마크를 시작하지 않는다. 배너가 코치마크 타겟보다 위쪽에
-  // 렌더링되어, 체크가 끝나며 배너가 나타나거나 계속 숨겨지는 순간 타겟 위치가
-  // 밀려서 코치마크가 깜빡이는 문제를 막기 위함.
-  useEffect(() => {
+  // 공지 모달이 떠 있는 동안, 그리고 PWA 설치 배너/공지 모달의 표시 여부 판단
+  // (둘 다 비동기 체크)이 끝나기 전까지는 코치마크를 시작하지 않는다. 이 둘이
+  // 코치마크 타겟보다 위쪽에 렌더링되어, 판단이 끝나며 나타나거나 계속 숨겨지는
+  // 순간 타겟 위치가 밀려서 코치마크가 깜빡이는 문제를 막기 위함.
+  // useEffect(페인트 후 실행)를 쓰면 마운트 시점에 이미 마커가 DOM에 있어도
+  // 첫 페인트에서는 초기값(false)으로 코치마크가 잠깐 보였다가, effect가 실행되며
+  // 뒤늦게 layoutUnstable을 true로 바꿔 사라지는 깜빡임이 생긴다. useLayoutEffect로
+  // 페인트 전에 동기적으로 체크해서 이 첫 프레임의 오탐을 없앤다.
+  useLayoutEffect(() => {
     const check = () => {
       setAnnouncementOpen(
         !!document.querySelector('[data-announcement-modal]'),
       );
-      setLayoutUnstable(!!document.querySelector('[data-pwa-banner-pending]'));
+      setLayoutUnstable(
+        !!document.querySelector('[data-pwa-banner-pending]') ||
+          !!document.querySelector('[data-announcement-pending]'),
+      );
     };
     check();
     const observer = new MutationObserver(check);


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- #287 
- 첫 로그인시 홈 화면에서 코치마크가 떴다 사라졌다 다시 뜨는 깜빡임 개선
- BottomNavigation 타겟 코치마크 박스가 실제 아이콘 위치보다 아래로/위로 어긋나 보이던 문제 수정
- 서버가 UTC 기준으로 계산돼 시차가 발생하던 문제 수정

## 작업 내용 + 스크린샷

### 코치마크 초기 깜빡임 개선

공지 모달/PWA 설치 배너가 뜰지 판단하는 동안임을 코치마크에 알리는 게이팅 로직이 useEffect(브라우저 첫 페인트 이후 실행)로 돼 있어서, 마운트 시점에 판단이 아직 안 끝났어도 초기값(false)으로 코치마크가 한 프레임 먼저 보였다가, 이후 effect가 실행되며 뒤늦게 숨겨지고, 판단이 끝나면 다시 뜨는 깜빡임이 있었어요.

useLayoutEffect로 바꿔 첫 페인트 전에 동기적으로 체크하도록 수정해줬어요.
공지모달도 같은 방식으로 깜빡일 수 있어 수정해줬어요.

### BottomNavigation 코치마크 위치 어긋남 수정

스포트라이트 위치에 수동 보정값(yOffsetMobile)을 적용한 뒤 다시 한번 화면 밖 이탈 방지용 clamp를 거치던 로직이, 이미 화면 하단 근처에 있는 BottomNavigation 타겟에서는 보정값을 상한선으로 도로 눌러 무효화시키고 있었어요.

재-clamp를 제거해 보정값이 온전히 반영되도록 수정했어요.

## 실제 걸린 시간

2h

## 작업하며 고민했던 점(선택)

## 테스트 실행 여부

- [x] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented onboarding coachmarks from flashing or repositioning while announcement status is still being determined.
  * Improved coachmark spotlight placement on native mobile, including correct vertical offset behavior.
  * Reduced layout flicker by evaluating coachmark conditions synchronously before paint.
  * Fixed coachmark spotlight positioning when custom vertical offsets are applied.
  * Corrected “today” and future-date disabling logic across the calendar UI using timezone-stable local date handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->