### PR TITLE
게스트가 코치마크를 보게 되는 상황에 대한 문제 수정

### DIFF
--- a/backend/src/modules/map/dto/map-query.dto.ts
+++ b/backend/src/modules/map/dto/map-query.dto.ts
@@ -119,6 +119,9 @@ export class MapPostItemDto {
 
   @ApiPropertyOptional({ description: '장소명', nullable: true })
   placeName?: string | null;
+
+  @ApiPropertyOptional({ description: '내용 요약 (snippet)' })
+  snippet?: string;
 }
 
 export class PaginatedMapPostsResponseDto {

--- a/backend/src/modules/map/map.service.ts
+++ b/backend/src/modules/map/map.service.ts
@@ -146,6 +146,15 @@ export class MapService {
           placeDisplay = val.placeName || val.address || null;
         }
 
+        // Snippet extraction (first text block) — 검색 결과와 동일한 방식
+        const firstTextBlock = await this.postRepository.manager.findOne(
+          PostBlock,
+          {
+            where: { postId: post.id, type: PostBlockType.TEXT },
+            order: { layoutRow: 'ASC', layoutCol: 'ASC' },
+          },
+        );
+
         return {
           id: post.id,
           lat: (post.location as Point).coordinates[1],
@@ -156,6 +165,9 @@ export class MapService {
           tags: post.tags || [],
           emotion: post.emotion ?? [],
           placeName: placeDisplay,
+          snippet: firstTextBlock
+            ? (firstTextBlock.value as { text: string }).text.substring(0, 100)
+            : undefined,
         };
       }),
     );

--- a/backend/src/modules/map/map.service.ts
+++ b/backend/src/modules/map/map.service.ts
@@ -125,52 +125,67 @@ export class MapService {
       });
     }
 
-    const resultItems: MapPostItemDto[] = await Promise.all(
-      items.map(async (post) => {
-        const previewMediaIds = previewMediaMap.get(post.id) ?? [];
-
-        // Find location block for placeName/address
-        const locationBlock = await this.postRepository.manager.findOne(
-          PostBlock,
-          {
-            where: { postId: post.id, type: PostBlockType.LOCATION },
-          },
-        );
-
-        let placeDisplay: string | null = null;
-        if (locationBlock) {
-          const val = locationBlock.value as {
-            address?: string;
-            placeName?: string;
-          };
-          placeDisplay = val.placeName || val.address || null;
+    // Snippet extraction (first text block per post) — 검색 결과와 동일한 방식.
+    // post당 findOne을 따로 부르면 최대 limit개의 추가 쿼리가 나가므로,
+    // 이미지 블록과 동일하게 postIds 전체를 한 번에 조회해 맵으로 구성한다.
+    const firstTextBlockByPostId = new Map<string, PostBlock>();
+    if (postIds.length > 0) {
+      const textBlocks = await this.postBlockRepository.find({
+        where: { postId: In(postIds), type: PostBlockType.TEXT },
+        order: { postId: 'ASC', layoutRow: 'ASC', layoutCol: 'ASC' },
+      });
+      for (const block of textBlocks) {
+        if (!firstTextBlockByPostId.has(block.postId)) {
+          firstTextBlockByPostId.set(block.postId, block);
         }
+      }
+    }
 
-        // Snippet extraction (first text block) — 검색 결과와 동일한 방식
-        const firstTextBlock = await this.postRepository.manager.findOne(
-          PostBlock,
-          {
-            where: { postId: post.id, type: PostBlockType.TEXT },
-            order: { layoutRow: 'ASC', layoutCol: 'ASC' },
-          },
-        );
+    // Location block for placeName/address — 위와 같은 이유로 배치 조회한다.
+    const locationBlockByPostId = new Map<string, PostBlock>();
+    if (postIds.length > 0) {
+      const locationBlocks = await this.postBlockRepository.find({
+        where: { postId: In(postIds), type: PostBlockType.LOCATION },
+        order: { postId: 'ASC', layoutRow: 'ASC', layoutCol: 'ASC' },
+      });
+      for (const block of locationBlocks) {
+        if (!locationBlockByPostId.has(block.postId)) {
+          locationBlockByPostId.set(block.postId, block);
+        }
+      }
+    }
 
-        return {
-          id: post.id,
-          lat: (post.location as Point).coordinates[1],
-          lng: (post.location as Point).coordinates[0],
-          title: post.title,
-          previewMediaIds,
-          createdAt: post.eventAt || post.createdAt,
-          tags: post.tags || [],
-          emotion: post.emotion ?? [],
-          placeName: placeDisplay,
-          snippet: firstTextBlock
-            ? (firstTextBlock.value as { text: string }).text.substring(0, 100)
-            : undefined,
+    const resultItems: MapPostItemDto[] = items.map((post) => {
+      const previewMediaIds = previewMediaMap.get(post.id) ?? [];
+
+      const locationBlock = locationBlockByPostId.get(post.id);
+
+      let placeDisplay: string | null = null;
+      if (locationBlock) {
+        const val = locationBlock.value as {
+          address?: string;
+          placeName?: string;
         };
-      }),
-    );
+        placeDisplay = val.placeName || val.address || null;
+      }
+
+      const firstTextBlock = firstTextBlockByPostId.get(post.id);
+
+      return {
+        id: post.id,
+        lat: (post.location as Point).coordinates[1],
+        lng: (post.location as Point).coordinates[0],
+        title: post.title,
+        previewMediaIds,
+        createdAt: post.eventAt || post.createdAt,
+        tags: post.tags || [],
+        emotion: post.emotion ?? [],
+        placeName: placeDisplay,
+        snippet: firstTextBlock
+          ? (firstTextBlock.value as { text: string }).text.substring(0, 100)
+          : undefined,
+      };
+    });
 
     let nextCursor: string | null = null;
     if (hasNextPage) {

--- a/frontend/src/app/(map)/_components/MapRecordItem.tsx
+++ b/frontend/src/app/(map)/_components/MapRecordItem.tsx
@@ -60,6 +60,12 @@ export function MapRecordItem({
             </span>
           </div>
 
+          {post.snippet && (
+            <p className="text-[11px] text-gray-600 dark:text-gray-300 mt-1.5 line-clamp-2 leading-relaxed">
+              {post.snippet}
+            </p>
+          )}
+
           {post.tags.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-2">
               {post.tags.slice(0, 4).map((tag: string) => (

--- a/frontend/src/hooks/useCoachmark.test.tsx
+++ b/frontend/src/hooks/useCoachmark.test.tsx
@@ -24,10 +24,15 @@ const STEPS: CoachmarkStep[] = [
 ];
 
 function setup({
-  userId = null as string | null,
+  userType = null as 'social' | 'guest' | null,
+  // 로그아웃 없이 게스트로 전환된 경우 등, userType과 무관하게 스토어에
+  // 남아있을 수 있는 값을 시뮬레이션하기 위해 userId는 별도로 받는다.
+  userId = (userType === 'social' ? 'user-1' : null) as string | null,
   seenCoachmarks = [] as string[],
 } = {}) {
-  mockUseAuthStore.mockImplementation((selector) => selector({ userId }));
+  mockUseAuthStore.mockImplementation((selector) =>
+    selector({ userId, userType }),
+  );
   getMock.mockResolvedValue({
     success: true,
     data: {
@@ -68,7 +73,24 @@ afterEach(() => {
 
 describe('useCoachmark', () => {
   it('게스트(userId 없음)는 타겟이 있어도 활성화되지 않는다', async () => {
-    setup({ userId: null });
+    setup({ userType: null });
+    addTarget('step-1');
+
+    const { result } = renderHook(
+      () => useCoachmark({ flowKey: 'home', steps: STEPS }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(getMock).not.toHaveBeenCalled());
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.rect).toBeNull();
+  });
+
+  // 회귀 테스트: logout() 없이 게스트로 전환되면 스토어에 예전 소셜 로그인의
+  // userId가 남아있을 수 있다. userId만으로 판단하면 이 경우 게스트인데도
+  // 로그인 사용자로 착각해 코치마크가 뜬다 — userType으로 판단해야 한다.
+  it('userType이 게스트면 userId가 남아있어도(로그아웃 없이 전환된 경우) 활성화되지 않는다', async () => {
+    setup({ userType: 'guest', userId: 'stale-user-id' });
     addTarget('step-1');
 
     const { result } = renderHook(
@@ -82,7 +104,7 @@ describe('useCoachmark', () => {
   });
 
   it('flowKey가 seenCoachmarks에 이미 있으면 활성화되지 않는다', async () => {
-    setup({ userId: 'user-1', seenCoachmarks: ['home'] });
+    setup({ userType: 'social', seenCoachmarks: ['home'] });
     addTarget('step-1');
 
     const { result } = renderHook(
@@ -95,7 +117,7 @@ describe('useCoachmark', () => {
   });
 
   it('로그인 유저이고 안 본 flowKey면 타겟을 찾아 활성화된다', async () => {
-    setup({ userId: 'user-1', seenCoachmarks: [] });
+    setup({ userType: 'social', seenCoachmarks: [] });
     addTarget('step-1');
 
     const { result } = renderHook(
@@ -109,7 +131,7 @@ describe('useCoachmark', () => {
   });
 
   it('공지 모달(data-announcement-modal)이 떠 있으면 활성화되지 않고, 닫히면 활성화된다', async () => {
-    setup({ userId: 'user-1' });
+    setup({ userType: 'social' });
     addTarget('step-1');
     const modal = document.createElement('div');
     modal.setAttribute('data-announcement-modal', '');
@@ -131,7 +153,7 @@ describe('useCoachmark', () => {
   });
 
   it('PWA 배너 표시 여부 체크가 진행 중이면(data-pwa-banner-pending) 활성화되지 않고, 끝나면 활성화된다', async () => {
-    setup({ userId: 'user-1' });
+    setup({ userType: 'social' });
     addTarget('step-1');
     const pendingMarker = document.createElement('div');
     pendingMarker.setAttribute('data-pwa-banner-pending', '');
@@ -153,7 +175,7 @@ describe('useCoachmark', () => {
   });
 
   it('nextStep은 마지막 스텝이 아니면 다음 스텝으로 넘어간다', async () => {
-    setup({ userId: 'user-1' });
+    setup({ userType: 'social' });
     addTarget('step-1');
     addTarget('step-2');
 
@@ -176,7 +198,7 @@ describe('useCoachmark', () => {
   });
 
   it('마지막 스텝에서 nextStep을 부르면 완료 처리되고, 로그인 유저는 seenCoachmarks에 flowKey를 합쳐서 저장한다', async () => {
-    setup({ userId: 'user-1', seenCoachmarks: ['shared'] });
+    setup({ userType: 'social', seenCoachmarks: ['shared'] });
     addTarget('step-1');
     addTarget('step-2');
 
@@ -203,7 +225,7 @@ describe('useCoachmark', () => {
   });
 
   it('skip을 호출하면 완료 처리되고 저장된다', async () => {
-    setup({ userId: 'user-1' });
+    setup({ userType: 'social' });
     addTarget('step-1');
 
     const { result } = renderHook(
@@ -224,7 +246,7 @@ describe('useCoachmark', () => {
   });
 
   it('게스트가 finish를 호출하면(스킵/마지막 확인) 설정 API를 호출하지 않는다', async () => {
-    setup({ userId: null });
+    setup({ userType: null });
 
     const { result } = renderHook(
       () => useCoachmark({ flowKey: 'home', steps: STEPS }),
@@ -240,7 +262,7 @@ describe('useCoachmark', () => {
 
   it('타겟을 계속 못 찾으면 타임아웃 후 자동으로 다음 스텝으로 넘어간다', async () => {
     vi.useFakeTimers();
-    setup({ userId: 'user-1' });
+    setup({ userType: 'social' });
     // step-1의 타겟은 DOM에 없음(예: 롤 제약으로 렌더되지 않는 버튼)
     addTarget('step-2');
 

--- a/frontend/src/hooks/useCoachmark.ts
+++ b/frontend/src/hooks/useCoachmark.ts
@@ -36,7 +36,8 @@ export function useCoachmark({
   steps,
   enabled = true,
 }: UseCoachmarkOptions) {
-  const userId = useAuthStore((state) => state.userId);
+  const userType = useAuthStore((state) => state.userType);
+  const isSocialUser = userType === 'social';
   const [stepIndex, setStepIndex] = useState(0);
   const [dismissed, setDismissed] = useState(false);
   const [announcementOpen, setAnnouncementOpen] = useState(false);
@@ -45,7 +46,7 @@ export function useCoachmark({
 
   const { data: profile, isLoading } = useQuery({
     ...userProfileOptions(),
-    enabled: !!userId && enabled,
+    enabled: isSocialUser && enabled,
   });
 
   const seenCoachmarks = Array.isArray(profile?.user?.settings?.seenCoachmarks)
@@ -86,7 +87,7 @@ export function useCoachmark({
 
   const isActive =
     enabled &&
-    !!userId &&
+    isSocialUser &&
     !isLoading &&
     !hasSeen &&
     !announcementOpen &&
@@ -136,7 +137,7 @@ export function useCoachmark({
 
   const finish = () => {
     setDismissed(true);
-    if (userId) {
+    if (isSocialUser) {
       const next = Array.from(new Set([...seenCoachmarks, flowKey]));
       updateSettings({ settings: { seenCoachmarks: next } });
     }

--- a/frontend/src/hooks/useCreateRecord.test.ts
+++ b/frontend/src/hooks/useCreateRecord.test.ts
@@ -107,9 +107,7 @@ describe('useCreateRecord.execute', () => {
     const updateMutation = makeMutation();
     useApiPatchMock.mockReturnValue(updateMutation);
 
-    const { result } = renderHook(() =>
-      useCreateRecord(undefined, 'post-1'),
-    );
+    const { result } = renderHook(() => useCreateRecord(undefined, 'post-1'));
     result.current.execute({ payload: { title: '수정된 제목' } as never });
 
     expect(updateMutation.mutate).toHaveBeenCalledWith({
@@ -163,9 +161,14 @@ describe('useCreateRecord - 저장 성공/실패 콜백', () => {
     expect(invalidateQueriesMock).toHaveBeenCalledWith({
       queryKey: ['my', 'records'],
     });
+    // 회귀 테스트: 새로 추가한 사진이 커버 사진 후보 목록에 반영되려면
+    // 이 쿼리도 함께 무효화돼야 한다(예전엔 빠져있었음).
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: ['cover'],
+    });
   });
 
-  it('그룹 기록 저장 성공 시 그룹 스코프 URL로 이동한다', async () => {
+  it('그룹 기록 저장 성공 시 그룹 스코프 URL로 이동하고 커버 후보 목록도 무효화한다', async () => {
     mockApiPost(makeMutation(), makeMutation());
     useApiPatchMock.mockReturnValue(makeMutation());
 
@@ -184,6 +187,9 @@ describe('useCreateRecord - 저장 성공/실패 콜백', () => {
         '/record/record-2?scope=group&groupId=group-1',
       ),
     );
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({
+      queryKey: ['cover'],
+    });
   });
 
   it('createMutation 실패 시 에러 토스트를 띄우고 onError를 호출한다', () => {

--- a/frontend/src/hooks/useCreateRecord.ts
+++ b/frontend/src/hooks/useCreateRecord.ts
@@ -78,6 +78,8 @@ export const useCreateRecord = (
       queryClient.invalidateQueries({ queryKey: ['profile'] }),
       queryClient.invalidateQueries({ queryKey: ['summary'] }),
       queryClient.invalidateQueries({ queryKey: ['map', 'records'] }),
+      // 새로 추가한 사진이 커버 사진 후보 목록(GalleryDrawer)에 바로 반영되도록.
+      queryClient.invalidateQueries({ queryKey: ['cover'] }),
     ]);
   };
 
@@ -140,8 +142,6 @@ export const useCreateRecord = (
         : `/record/${res.data.id}`;
 
       if (groupId) {
-        // revalidatePath 서버 액션 전부 제외: 네비게이션 도중 응답이 도착하면
-        // Next.js App Router가 진행 중인 네비게이션을 취소해 /add로 되돌아가는 버그 발생.
         Promise.all([
           queryClient.invalidateQueries({ queryKey: ['me'] }),
           queryClient.invalidateQueries({ queryKey: ['summary'] }),
@@ -152,6 +152,8 @@ export const useCreateRecord = (
           }),
           queryClient.invalidateQueries({ queryKey: ['shared'] }),
           queryClient.invalidateQueries({ queryKey: ['map', 'records'] }),
+          // 새로 추가한 사진이 커버 사진 후보 목록(GalleryDrawer)에 바로 반영되도록.
+          queryClient.invalidateQueries({ queryKey: ['cover'] }),
         ]);
 
         // React lifecycle 안에서 replace해야 history entry가 제대로 교체됨

--- a/frontend/src/lib/types/record.ts
+++ b/frontend/src/lib/types/record.ts
@@ -243,4 +243,5 @@ export interface MapPostItem {
   createdAt: string;
   tags: string[];
   placeName: string | null;
+  snippet?: string;
 }

--- a/frontend/src/store/useAuthStore.test.ts
+++ b/frontend/src/store/useAuthStore.test.ts
@@ -55,6 +55,25 @@ describe('useAuthStore', () => {
     );
   });
 
+  it('소셜 로그인 상태에서 setGuestInfo를 호출하면 userId가 초기화된다', () => {
+    useAuthStore.setState({
+      userType: 'social',
+      userId: 'stale-user-id',
+      isLoggedIn: true,
+    });
+
+    useAuthStore.getState().setGuestInfo({
+      guest: true,
+      guestSessionId: 'session-1',
+      guestAccessToken: 'token-1',
+      expiresAt: '2099-01-01T00:00:00.000Z',
+    });
+
+    const state = useAuthStore.getState();
+    expect(state.userType).toBe('guest');
+    expect(state.userId).toBeNull();
+  });
+
   it('게스트 상태에서 setLogin을 호출하면 소셜 계정으로 전환되고 게스트 정보가 지워진다', async () => {
     useAuthStore.getState().setGuestInfo({
       guest: true,
@@ -64,15 +83,13 @@ describe('useAuthStore', () => {
     });
     cookiesRemoveMock.mockClear();
 
-    useAuthStore
-      .getState()
-      .setLogin({
-        id: 'user-1',
-        email: 'a@test.com',
-        nickname: '홍길동',
-        profileImageId: null,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      });
+    useAuthStore.getState().setLogin({
+      id: 'user-1',
+      email: 'a@test.com',
+      nickname: '홍길동',
+      profileImageId: null,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    });
     await nextFrame();
 
     const state = useAuthStore.getState();
@@ -85,15 +102,13 @@ describe('useAuthStore', () => {
   });
 
   it('게스트 정보가 없는 상태에서 setLogin을 호출해도 소셜 로그인 상태가 된다', async () => {
-    useAuthStore
-      .getState()
-      .setLogin({
-        id: 'user-2',
-        email: 'b@test.com',
-        nickname: '이몽룡',
-        profileImageId: null,
-        createdAt: '2024-01-01T00:00:00.000Z',
-      });
+    useAuthStore.getState().setLogin({
+      id: 'user-2',
+      email: 'b@test.com',
+      nickname: '이몽룡',
+      profileImageId: null,
+      createdAt: '2024-01-01T00:00:00.000Z',
+    });
     await nextFrame();
 
     const state = useAuthStore.getState();

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -90,6 +90,7 @@ export const useAuthStore = create<State & Action>()(
           guestSessionId: guest.guestSessionId,
           guestSessionExpiresAt: guest.guestSessionId,
           userType: 'guest',
+          userId: null,
           isLoggedIn: true,
         });
         setGuestCookie(guestCookieKey, guest.guestSessionId);


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- #287 

## 작업 내용 + 스크린샷

- logout 없이 소셜 로그인에서 게스트로 전환되면 `useAuthStore`에 이전
로그인의 `userId`가 남아있어 게스트도 코치마크를 보게 되던 문제 수정
- 새로 추가한 사진이 커버 사진 선택 화면에 반영되지 않던 문제 -> 기록 추가 후 캐시 무효화
- 지도 기록 리스트를 검색 페이지 결과 리스트와 동일한 내용으로 출력되도록 수정

## 실제 걸린 시간

1h

## 작업하며 고민했던 점(선택)

## 테스트 실행 여부

- [x] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Map posts now display a short text preview when available.
- **Bug Fixes**
  - Coachmarks are now limited to social login users, preventing activation for guests.
  - Switching from social login to guest mode now clears the previous user identity.
  - Record updates now refresh related cover content so changes appear promptly.
- **Tests**
  - Added coverage for guest authentication transitions, coachmark eligibility, and record cache refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->