### PR TITLE
게스트 로그인 시 잔존 NextAuth 세션 때문에 /login 재진입이 홈으로 튕기는 문제 수정(#287)

### DIFF
--- a/frontend/src/app/(login)/login/_components/LoginContent.tsx
+++ b/frontend/src/app/(login)/login/_components/LoginContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { signOut } from 'next-auth/react';
 import { useApiPost } from '@/hooks/useApi';
 import { GuestInfo } from '@/lib/types/profile';
 import { getRedirectUri } from '@/lib/utils/getRedirectUri';
@@ -215,6 +216,7 @@ export default function LoginContent({
 
   const handleLoginGuest = async () => {
     setIsLoading(true);
+   await signOut({ redirect: false });
     const existingSessionId = getCookie(guestCookieKey) || guestSessionId;
     if (existingSessionId) {
       try {


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- #287 
- 게스트 로그인 시 잔존 NextAuth 세션 때문에 /login 재진입이 홈으로 튕기는 문제 수정

## 작업 내용 + 스크린샷

로그아웃 없이 게스트로 전환하면 NextAuth 세션 쿠키가 계속 유효해서, `SessionGuard`가 `/login` 진입을 "이미 로그인됨"으로 오판해 홈으로 리다이렉트시키는 문제.
게스트 로그인 진입점(handleLoginGuest)에서 `signOut({ redirect: false }`)을 호출해 게스트 전환 시 잔존 세션을 명시적으로 정리하도록 수정.

## 실제 걸린 시간

## 작업하며 고민했던 점(선택)

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)
