### PR TITLE
서비스워커 갱신 시 강제 새로고침이 로그인 직후 이동과 경합하는 문제 수정

### DIFF
--- a/frontend/src/app/(login)/login/_components/LoginContent.tsx
+++ b/frontend/src/app/(login)/login/_components/LoginContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { signOut } from 'next-auth/react';
 import { useApiPost } from '@/hooks/useApi';
 import { GuestInfo } from '@/lib/types/profile';
 import { getRedirectUri } from '@/lib/utils/getRedirectUri';
@@ -215,6 +216,7 @@ export default function LoginContent({
 
   const handleLoginGuest = async () => {
     setIsLoading(true);
+   await signOut({ redirect: false });
     const existingSessionId = getCookie(guestCookieKey) || guestSessionId;
     if (existingSessionId) {
       try {

--- a/frontend/src/components/ServiceWorkerUpdater.test.tsx
+++ b/frontend/src/components/ServiceWorkerUpdater.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
 import ServiceWorkerUpdater from './ServiceWorkerUpdater';
 
@@ -6,32 +6,21 @@ function mockRegistration() {
   return { update: vi.fn().mockResolvedValue(undefined) };
 }
 
-function setupServiceWorker(registrations: ReturnType<typeof mockRegistration>[]) {
-  const listeners: Record<string, (() => void)[]> = {};
+function setupServiceWorker(
+  registrations: ReturnType<typeof mockRegistration>[],
+) {
   const serviceWorker = {
     getRegistrations: vi.fn().mockResolvedValue(registrations),
-    addEventListener: vi.fn((event: string, handler: () => void) => {
-      (listeners[event] ??= []).push(handler);
-    }),
-    removeEventListener: vi.fn(),
   };
   Object.defineProperty(navigator, 'serviceWorker', {
     value: serviceWorker,
     configurable: true,
   });
-  return { serviceWorker, fire: (event: string) => listeners[event]?.forEach((h) => h()) };
+  return { serviceWorker };
 }
 
 describe('ServiceWorkerUpdater', () => {
-  const reloadMock = vi.fn();
-
-  beforeEach(() => {
-    reloadMock.mockClear();
-    vi.stubGlobal('location', { ...window.location, reload: reloadMock });
-  });
-
   afterEach(() => {
-    vi.unstubAllGlobals();
     Reflect.deleteProperty(navigator, 'serviceWorker');
     vi.useRealTimers();
   });
@@ -42,7 +31,9 @@ describe('ServiceWorkerUpdater', () => {
     const { serviceWorker } = setupServiceWorker([reg1, reg2]);
 
     render(<ServiceWorkerUpdater />);
-    await vi.waitFor(() => expect(serviceWorker.getRegistrations).toHaveBeenCalled());
+    await vi.waitFor(() =>
+      expect(serviceWorker.getRegistrations).toHaveBeenCalled(),
+    );
     await vi.waitFor(() => expect(reg1.update).toHaveBeenCalled());
     expect(reg2.update).toHaveBeenCalled();
   });
@@ -52,7 +43,9 @@ describe('ServiceWorkerUpdater', () => {
     const { serviceWorker } = setupServiceWorker([reg]);
 
     render(<ServiceWorkerUpdater />);
-    await vi.waitFor(() => expect(serviceWorker.getRegistrations).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(serviceWorker.getRegistrations).toHaveBeenCalledTimes(1),
+    );
 
     const visibilitySpy = vi
       .spyOn(document, 'visibilityState', 'get')
@@ -64,15 +57,5 @@ describe('ServiceWorkerUpdater', () => {
     );
 
     visibilitySpy.mockRestore();
-  });
-
-  it('controllerchange 발생 시 페이지를 한 번만 새로고침한다', async () => {
-    const { fire } = setupServiceWorker([mockRegistration()]);
-    render(<ServiceWorkerUpdater />);
-
-    fire('controllerchange');
-    fire('controllerchange');
-
-    expect(reloadMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/ServiceWorkerUpdater.tsx
+++ b/frontend/src/components/ServiceWorkerUpdater.tsx
@@ -11,7 +11,9 @@ const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1시간
 
 function checkForUpdates() {
   navigator.serviceWorker.getRegistrations().then((registrations) => {
-    registrations.forEach((registration) => registration.update().catch(() => {}));
+    registrations.forEach((registration) =>
+      registration.update().catch(() => {}),
+    );
   });
 }
 
@@ -28,27 +30,9 @@ export default function ServiceWorkerUpdater() {
 
     const intervalId = setInterval(checkForUpdates, CHECK_INTERVAL_MS);
 
-    // 새 서비스워커가 활성화되어 이 페이지의 제어권을 넘겨받으면(skipWaiting+clients.claim
-    // 덕분에 새로고침 없이도 발생함) 한 번만 새로고침해 최신 앱 셸을 확실히 반영한다.
-    // refreshing 플래그로 controllerchange가 중복 발생해도 재귀적으로 새로고침되지 않게 막는다.
-    let refreshing = false;
-    const handleControllerChange = () => {
-      if (refreshing) return;
-      refreshing = true;
-      window.location.reload();
-    };
-    navigator.serviceWorker.addEventListener(
-      'controllerchange',
-      handleControllerChange,
-    );
-
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       clearInterval(intervalId);
-      navigator.serviceWorker?.removeEventListener(
-        'controllerchange',
-        handleControllerChange,
-      );
     };
   }, []);
 


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- #287 

## 작업 내용 + 스크린샷

- 로그인 성공 후 window.location.href로 이동하는 순간, 서비스워커 갱신 확인이 끝나며 controllerchange가 발동해
`window.location.reload()`가 아직 커밋되지 않은 이동을 가로채 직전 URL을 다시 로드하는 경합이 있었음.
- firebase-messaging-sw.js 둘 다 fetch를 가로채 캐싱하지 않으므로 이 강제 새로고침은 실익 없이 위 레이스만 유발하고 있어 제거함.

## 실제 걸린 시간

## 작업하며 고민했던 점(선택)

## 테스트 실행 여부

- [x] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)

## 시각 자료(이미지/영상, 있다면)(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved guest login recovery by resetting any existing authentication state before restoring a guest session.
  - Service worker updates continue checking for new versions without automatically reloading the page when the active worker changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->