### PR TITLE
Firebase 서비스 계정 초기화 누락으로 중단된 FCM 발송 복구

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -66,4 +66,7 @@ ADMIN_KEY="random string for admin notice"
 # =================
 # Firebase Admin SDK (FCM 푸시 알림 발송)
 # =================
+# 배포 환경에서는 서비스 계정 JSON을 Base64로 인코딩한 값을 권장합니다.
+FIREBASE_SERVICE_ACCOUNT_BASE64=
+# 로컬 파일을 사용할 때의 대체 설정입니다.
 FIREBASE_SERVICE_ACCOUNT_PATH=./firebase-adminsdk.json

--- a/backend/src/modules/notification/notification.service.spec.ts
+++ b/backend/src/modules/notification/notification.service.spec.ts
@@ -1,9 +1,14 @@
 import type { Repository } from 'typeorm';
 import type { ConfigService } from '@nestjs/config';
-import type { App } from 'firebase-admin/app';
+import { cert, initializeApp, type App } from 'firebase-admin/app';
 import { getMessaging } from 'firebase-admin/messaging';
 import { NotificationService } from './notification.service';
 import { FcmToken } from './entity/fcm-token.entity';
+
+jest.mock('firebase-admin/app', () => ({
+  cert: jest.fn((serviceAccount: unknown) => serviceAccount),
+  initializeApp: jest.fn(() => ({})),
+}));
 
 jest.mock('firebase-admin/messaging', () => ({
   getMessaging: jest.fn(),
@@ -34,6 +39,7 @@ describe('NotificationService', () => {
   let service: NotificationService;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     fcmTokenRepo = {
       upsert: jest.fn(),
       delete: jest.fn(),
@@ -49,6 +55,34 @@ describe('NotificationService', () => {
     );
     // onModuleInit()은 실제 서비스 계정 파일이 필요해 거치지 않고, 초기화된 것처럼 app을 직접 주입한다.
     (service as unknown as { app: App }).app = {} as App;
+  });
+
+  describe('onModuleInit', () => {
+    it('Base64 서비스 계정으로 Firebase를 초기화한다', () => {
+      const serviceAccount = {
+        projectId: 'project-1',
+        clientEmail: 'firebase@example.com',
+        privateKey: 'private-key',
+      };
+      const configService = {
+        get: jest.fn((key: string) =>
+          key === 'FIREBASE_SERVICE_ACCOUNT_BASE64'
+            ? Buffer.from(JSON.stringify(serviceAccount)).toString('base64')
+            : undefined,
+        ),
+      };
+      service = new NotificationService(
+        configService as unknown as ConfigService,
+        fcmTokenRepo as unknown as Repository<FcmToken>,
+      );
+
+      service.onModuleInit();
+
+      expect(cert).toHaveBeenCalledWith(serviceAccount);
+      expect(initializeApp).toHaveBeenCalledWith({
+        credential: serviceAccount,
+      });
+    });
   });
 
   describe('registerToken', () => {

--- a/backend/src/modules/notification/notification.service.ts
+++ b/backend/src/modules/notification/notification.service.ts
@@ -24,21 +24,28 @@ export class NotificationService implements OnModuleInit {
   ) {}
 
   onModuleInit() {
+    const encodedServiceAccount = this.configService.get<string>(
+      'FIREBASE_SERVICE_ACCOUNT_BASE64',
+    );
     const serviceAccountPath = this.configService.get<string>(
       'FIREBASE_SERVICE_ACCOUNT_PATH',
     );
-    if (!serviceAccountPath) {
+    if (!encodedServiceAccount && !serviceAccountPath) {
       this.logger.warn(
-        'FIREBASE_SERVICE_ACCOUNT_PATH가 설정되지 않아 FCM을 비활성화합니다.',
+        'Firebase 서비스 계정이 설정되지 않아 FCM을 비활성화합니다.',
       );
       return;
     }
 
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const serviceAccount = require(
-        resolve(serviceAccountPath),
-      ) as ServiceAccount;
+      const serviceAccount = encodedServiceAccount
+        ? (JSON.parse(
+            Buffer.from(encodedServiceAccount, 'base64').toString('utf8'),
+          ) as ServiceAccount)
+        : // 로컬 파일 방식은 기존 개발 환경과의 호환성을 위해 유지한다.
+          // eslint-disable-next-line @typescript-eslint/no-require-imports
+          (require(resolve(serviceAccountPath as string)) as ServiceAccount);
+
       this.app = initializeApp({ credential: cert(serviceAccount) });
       this.logger.log('Firebase Admin SDK 초기화 완료');
     } catch (e) {
@@ -67,7 +74,11 @@ export class NotificationService implements OnModuleInit {
     body: string,
     data?: Record<string, string>,
   ): Promise<void> {
-    if (!this.app || userIds.length === 0) return;
+    if (!this.app) {
+      this.logger.warn('Firebase가 초기화되지 않아 FCM 발송을 건너뜁니다.');
+      return;
+    }
+    if (userIds.length === 0) return;
 
     const tokens = await this.fcmTokenRepo.find({
       where: userIds.map((userId) => ({ userId })),
@@ -120,6 +131,10 @@ export class NotificationService implements OnModuleInit {
       }
 
       const failedCount = response.responses.filter((r) => !r.success).length;
+      const successCount = response.responses.length - failedCount;
+      this.logger.log(
+        `FCM 발송 완료: 성공 ${successCount}건, 실패 ${failedCount}건`,
+      );
       if (failedCount > 0) {
         this.logger.warn(`FCM 발송 실패: ${failedCount}/${messages.length}`);
       }


### PR DESCRIPTION
## 변경 내용

- `FIREBASE_SERVICE_ACCOUNT_BASE64`를 이용한 Firebase Admin SDK 초기화를 지원합니다.
- 기존 `FIREBASE_SERVICE_ACCOUNT_PATH` 방식도 로컬 개발 호환성을 위해 유지합니다.
- Firebase가 초기화되지 않은 경우 FCM 발송을 건너뛴다는 경고 로그를 남깁니다.
- FCM 발송 성공 및 실패 건수를 서버 로그에서 확인할 수 있도록 개선했습니다.
- Base64 서비스 계정 초기화에 대한 회귀 테스트를 추가했습니다.
- 환경변수 예시 파일에 두 가지 Firebase 인증정보 설정 방식을 문서화했습니다.

## 문제 원인

브라우저의 알림 권한, 서비스 워커, Push 구독 및 FCM 식별자 등록은 모두 정상적으로 동작하고 있었습니다.

하지만 로컬 환경에는 Firebase 서비스 계정이 `FIREBASE_SERVICE_ACCOUNT_BASE64`로 설정된 반면, 서버는 `FIREBASE_SERVICE_ACCOUNT_PATH`만 확인하고 있었습니다. 이로 인해 Firebase Admin SDK가 초기화되지 않았으며, 등록된 토큰이 있어도 실제 FCM 발송은 조용히 건너뛰고 있었습니다.

## 검증

- 다른 그룹원이 새 기록을 작성했을 때 브라우저 푸시 알림 수신 확인
- 백엔드 전체 린트 통과
- 알림 서비스 테스트 9개 통과
- 백엔드 빌드 통과
- Git diff 검사 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Firebase credentials using Base64-encoded service-account JSON.
  * Continued support for loading credentials from a local file path.
  * Added delivery results showing successful and failed notification counts.

* **Bug Fixes**
  * Improved handling when Firebase is not configured or when no notification recipients are provided.
  * Added clearer warnings when notification delivery is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->