### PR TITLE
휴지통 게시글 및 참조 미디어 자동 삭제 오류 수정

### DIFF
--- a/backend/src/modules/media/media.service.spec.ts
+++ b/backend/src/modules/media/media.service.spec.ts
@@ -211,6 +211,29 @@ describe('MediaService', () => {
     expect(mediaAssetRepository.delete).not.toHaveBeenCalled();
   });
 
+  it('keeps assets referenced by post media, including trashed posts', async () => {
+    mediaAssetRepository.find.mockResolvedValue([
+      { id: 'asset-1', storageKey: 'media/user-1/asset-1' },
+    ]);
+    postMediaQueryBuilder.getRawMany.mockResolvedValue([
+      { mediaId: 'asset-1' },
+    ]);
+    mediaAssetRepository.update.mockResolvedValue({ affected: 1 });
+
+    await (
+      service as unknown as {
+        processPendingMediaDeletionCandidates: (
+          mediaIds: string[],
+        ) => Promise<void>;
+      }
+    ).processPendingMediaDeletionCandidates(['asset-1']);
+
+    expect(postMediaQueryBuilder.innerJoin).not.toHaveBeenCalled();
+    expect(postMediaQueryBuilder.andWhere).not.toHaveBeenCalled();
+    expect(s3Send).not.toHaveBeenCalled();
+    expect(mediaAssetRepository.delete).not.toHaveBeenCalled();
+  });
+
   it('keeps the row and records retry metadata when storage deletion fails', async () => {
     mediaAssetRepository.find.mockResolvedValue([
       { id: 'asset-1', storageKey: 'media/user-1/asset-1' },

--- a/backend/src/modules/media/media.service.spec.ts
+++ b/backend/src/modules/media/media.service.spec.ts
@@ -1,5 +1,5 @@
 import { ConfigService } from '@nestjs/config';
-import type { Repository, EntityManager } from 'typeorm';
+import { In, type Repository, type EntityManager } from 'typeorm';
 
 import { MediaService } from './media.service';
 import { MediaAsset, MediaAssetStatus } from './entity/media-asset.entity';
@@ -230,6 +230,14 @@ describe('MediaService', () => {
 
     expect(postMediaQueryBuilder.innerJoin).not.toHaveBeenCalled();
     expect(postMediaQueryBuilder.andWhere).not.toHaveBeenCalled();
+    expect(mediaAssetRepository.update).toHaveBeenCalledWith(
+      { id: In(['asset-1']) },
+      {
+        deleteRequestedAt: null,
+        deleteRetryCount: 0,
+        lastDeleteError: null,
+      },
+    );
     expect(s3Send).not.toHaveBeenCalled();
     expect(mediaAssetRepository.delete).not.toHaveBeenCalled();
   });

--- a/backend/src/modules/media/media.service.ts
+++ b/backend/src/modules/media/media.service.ts
@@ -985,17 +985,13 @@ export class MediaService {
     ] = await Promise.all([
       this.postMediaRepository
         .createQueryBuilder('pm')
-        .innerJoin(Post, 'p', 'p.id = pm.postId')
         .select('pm.mediaId', 'mediaId')
         .where('pm.mediaId IN (:...mediaIds)', { mediaIds })
-        .andWhere('p.deletedAt IS NULL')
         .getRawMany<{ mediaId: string }>(),
       this.postDraftMediaRepository
         .createQueryBuilder('pdm')
-        .innerJoin(PostDraft, 'pd', 'pd.id = pdm.draftId')
         .select('pdm.mediaId', 'mediaId')
         .where('pdm.mediaId IN (:...mediaIds)', { mediaIds })
-        .andWhere('pd.isActive = true')
         .getRawMany<{ mediaId: string }>(),
       this.userRepository.find({
         where: { profileImageId: In(mediaIds) },

--- a/backend/src/modules/trash/trash.service.ts
+++ b/backend/src/modules/trash/trash.service.ts
@@ -95,8 +95,8 @@ export class TrashService {
       .delete()
       .from(Post)
       .where('deletedAt IS NOT NULL') // soft-delete 된 것 중
-      .andWhere('deletedAt <= NOW() - INTERVAL 30 DAY') // 30일 이상 지난 것만
-      // INTERVAL 30 DAY는 postgresql 전용 데이터 타입 연산자
+      .andWhere("deletedAt <= NOW() - INTERVAL '30 days'") // 30일 이상 지난 것만
+      // PostgreSQL의 INTERVAL 리터럴은 기간 값을 작은따옴표로 감싸야 함
       .execute();
 
     this.logger.log(


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

- PostgreSQL 문법 오류로 휴지통 게시글 영구 삭제 스케줄러가 실패하는 문제를 수정했습니다.
- 휴지통 게시글과 비활성 초안에서 참조 중인 미디어가 삭제 대상으로 잘못 분류되는 문제를 수정했습니다.

## 작업 내용 + 스크린샷

### 휴지통 게시글 영구 삭제 쿼리 수정

PostgreSQL에서 지원하지 않는 아래 `INTERVAL` 문법을 수정했습니다.

```sql
-- 변경 전
NOW() - INTERVAL 30 DAY
NOW() - INTERVAL '30 days'
```

### 참조 중인 미디어 삭제 방지
기존 미디어 참조 확인 로직은 다음 연결을 참조 대상에서 제외하고 있었습니다.
- 소프트 삭제되어 휴지통에 보관 중인 게시글의 미디어
- 비활성 초안에 연결된 미디어
해당 미디어는 DB 외래키가 남아 있음에도 orphan으로 잘못 판단되어 S3 삭제가 먼저 실행되고, 이후 media_assets 행 삭제 과정에서 외래키 제약 조건 오류가 발생했습니다.

모든 `post_media` 및 `post_draft_media` 연결을 참조 대상으로 판단하도록 변경하여 다음 문제를 방지했습니다.
- 복구 가능한 휴지통 게시글의 미디어가 삭제되는 문제
- S3 파일은 삭제되지만 DB 행은 삭제되지 않는 불일치
- 15분 간격 재시도 작업에서 동일한 외래키 오류가 반복되는 문제
또한 휴지통 게시글에서 참조 중인 미디어가 삭제되지 않는지 확인하는 회귀 테스트를 추가했습니다.

## 실제 걸린 시간
약 1h

## 작업하며 고민했던 점(선택)
미디어가 단순히 활성 게시글에서 사용되고 있는지만 확인할지, 실제 외래키 참조가 존재하는 모든 경우를 보호할지 고민했습니다.
휴지통 게시글은 30일 동안 복구할 수 있으므로 연결된 미디어도 함께 보존되어야 합니다. 또한 `post_media`와 `post_draft_media`의 외래키가 ON DELETE NO ACTION으로 설정되어 있어, 연결 행이 남아 있는 동안에는 미디어 자산을 삭제할 수 없습니다.
따라서 게시글 삭제 상태나 초안 활성 상태와 관계없이 연결 테이블에 참조가 존재하면 미디어를 삭제하지 않도록 처리했습니다.

## 테스트 실행 여부

- [x] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [ ] 🤯 아니요, 하지만 테스트가 필요해요.

## 리뷰 참고사항(선택)
오류 로그에 포함된 기존 미디어 2건은 S3 객체 삭제가 성공한 후 DB 외래키 오류가 발생한 것으로 보입니다.
따라서 DB의 `media_assets` 행은 남아 있더라도 실제 S3 객체는 이미 삭제되었을 가능성이 있습니다. 해당 객체가 필요한 경우 S3 버전 관리 또는 백업을 확인하거나 파일을 다시 업로드해야 할 수 있습니다.
이번 변경 배포 후에는 참조 중인 미디어의 삭제 예약 정보가 초기화되며, 동일한 외래키 오류가 반복되는 것을 방지합니다.

## 시각 자료(이미지/영상, 있다면)(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Preserved media assets referenced by posts and drafts, including content moved to trash.
* Prevented referenced media from being incorrectly removed during media cleanup.
* Ensured deletion metadata is cleared when retained assets are restored.
* Fixed scheduled permanent deletion so items older than 30 days are processed reliably.
* Improved cleanup behavior without affecting media still in use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->