### PR TITLE
백엔드 Docker 이미지 기반 Railway 자동 배포 추가

### DIFF
--- a/.github/workflows/deploy-backend-railway-dev.yml
+++ b/.github/workflows/deploy-backend-railway-dev.yml
@@ -1,0 +1,75 @@
+name: Deploy Dev Backend to Railway
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - 'backend/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/deploy-backend-railway-dev.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-backend-railway-production
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: myh020118/ittda-backend
+
+jobs:
+  deploy:
+    name: Build, Push, and Deploy Dev Backend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Generate image tag
+        id: image
+        shell: bash
+        run: |
+          TAG="$(git rev-parse --short=12 HEAD)"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "url=docker.io/${IMAGE_NAME}:$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: myh020118
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./backend/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.image.outputs.tag }}
+            ${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Redeploy Railway service from latest image
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+        run: |
+          docker run --rm \
+            -e RAILWAY_TOKEN \
+            ghcr.io/railwayapp/cli:4.58.0 \
+            redeploy \
+            --service "$RAILWAY_SERVICE_ID" \
+            --from-source \
+            --yes

--- a/.github/workflows/deploy-backend-railway.yml
+++ b/.github/workflows/deploy-backend-railway.yml
@@ -1,0 +1,75 @@
+name: Deploy Backend to Railway
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/deploy-backend-railway.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-backend-railway-production
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: myh020118/ittda-backend
+
+jobs:
+  deploy:
+    name: Build, Push, and Deploy Backend
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Generate image tag
+        id: image
+        shell: bash
+        run: |
+          TAG="$(git rev-parse --short=12 HEAD)"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "url=docker.io/${IMAGE_NAME}:$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: myh020118
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./backend/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.image.outputs.tag }}
+            ${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Redeploy Railway service from latest image
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_SERVICE_ID: ${{ vars.RAILWAY_SERVICE_ID }}
+        run: |
+          docker run --rm \
+            -e RAILWAY_TOKEN \
+            ghcr.io/railwayapp/cli:latest \
+            redeploy \
+            --service "$RAILWAY_SERVICE_ID" \
+            --from-source \
+            --yes


### PR DESCRIPTION
## 요약 (연관 이슈 번호 포함)

Refs #253

- `dev` 및 `main`에 백엔드 변경사항이 반영되면 Docker 이미지를 빌드하고 Railway를 자동으로 재배포합니다.
- 커밋 SHA 태그와 `latest` 태그를 함께 Docker Hub에 푸시합니다.
- 운영 Railway 배포가 중복 실행되지 않도록 concurrency를 적용했습니다.

## 작업 내용 + 스크린샷

- `.github/workflows/deploy-backend-railway-dev.yml` 추가
  - `dev` 브랜치 대상
  - 현재 베타 운영 중인 Railway 서비스에 배포
- `.github/workflows/deploy-backend-railway.yml` 추가
  - `main` 브랜치 대상
- 12자리 커밋 SHA 태그와 `latest` 태그 생성
- `linux/amd64` 플랫폼으로 백엔드 Docker 이미지 빌드
- Docker Hub 이미지 푸시 후 Railway 서비스 재배포
- GitHub Actions 캐시를 활용한 Docker 빌드 캐싱
- 동일 운영 서비스의 배포가 겹치지 않도록 공통 concurrency 그룹 적용
- 필요할 때 수동으로 실행할 수 있도록 `workflow_dispatch` 추가

스크린샷은 첫 `dev` 머지 후 GitHub Actions 및 Railway 배포 결과를 확인하고 첨부할 예정입니다.

## 실제 걸린 시간

약 1시간

## 작업하며 고민했던 점(선택)

Railway의 이미지 소스를 `latest`로 유지하면서도 이전 버전으로 롤백할 수 있도록 커밋 SHA 태그를 함께 푸시하도록 구성했습니다.

현재는 `dev`와 `main` 모두 동일한 Railway 운영 서비스를 대상으로 하므로 같은 concurrency 그룹을 사용합니다. 이에 따라 배포가 동시에 시작되면 최신 배포만 진행됩니다.

추후 `dev` 배포를 Render로 이전할 때는 다음 작업이 필요합니다.

- `dev`와 `main`의 concurrency 그룹 분리
- `dev` 이미지 태그를 `latest`가 아닌 `dev` 등의 별도 태그로 분리
- Render와 Railway가 서로 독립적으로 배포되도록 워크플로 수정

## 테스트 실행 여부

- [ ] 👍 네, 테스트했어요.
- [ ] 🙅 아니요, 필요하지 않아요.
- [x] 🤯 아니요, 하지만 테스트가 필요해요.

GitHub Actions와 Railway를 연결하는 통합 작업이므로 로컬 테스트만으로 검증하기 어렵습니다. 이 PR이 `dev`에 머지되면 자동으로 시작되는 배포를 통해 다음 항목을 확인할 예정입니다.

- GitHub Actions 워크플로 성공 여부
- Docker Hub의 SHA 및 `latest` 태그 생성 여부
- Railway 재배포 성공 여부
- `/healthz` 응답 여부
- 기존 주요 API 정상 동작 여부

## 리뷰 참고사항(선택)

GitHub Actions에는 다음 값이 등록되어 있어야 합니다.

Repository secrets:

- `DOCKERHUB_TOKEN`
- `RAILWAY_TOKEN`

Repository variable:

- `RAILWAY_SERVICE_ID`

이 PR이 `dev`에 머지되면 백엔드 자동 배포가 실제로 실행됩니다.

Railway의 Auto Updates는 중복 배포를 방지하기 위해 비활성화하고, GitHub Actions에서 명시적으로 재배포하도록 구성했습니다.

## 시각 자료(이미지/영상, 있다면)(선택)

첫 자동 배포 완료 후 GitHub Actions 실행 결과와 Railway 배포 결과를 첨부할 예정입니다.